### PR TITLE
fix(stats): 修复深色模式下图表样式显示问题

### DIFF
--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -157,10 +157,10 @@ export function StatsDashboard() {
           <CardContent className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={ts.map((t) => ({ ...t, label: formatBucket(t.bucket_start, bucket) }))}>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="label" fontSize={11} />
-                <YAxis fontSize={11} allowDecimals={false} />
-                <RTooltip />
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="label" fontSize={11} tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <YAxis fontSize={11} allowDecimals={false} tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <RTooltip contentStyle={{ backgroundColor: "hsl(var(--popover))", border: "1px solid hsl(var(--border))", borderRadius: "6px" }} labelStyle={{ color: "hsl(var(--popover-foreground))" }} />
                 <Line type="monotone" dataKey="sessions" stroke={chartColors[0]} strokeWidth={2} dot={false} />
               </LineChart>
             </ResponsiveContainer>
@@ -174,10 +174,10 @@ export function StatsDashboard() {
           <CardContent className="h-64">
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={ts.map((t) => ({ ...t, label: formatBucket(t.bucket_start, bucket) }))}>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis dataKey="label" fontSize={11} />
-                <YAxis fontSize={11} tickFormatter={(v) => humanTokens(Number(v))} />
-                <RTooltip formatter={(v: number) => humanTokens(v)} />
+                <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+                <XAxis dataKey="label" fontSize={11} tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <YAxis fontSize={11} tickFormatter={(v) => humanTokens(Number(v))} tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <RTooltip formatter={(v: number) => humanTokens(v)} contentStyle={{ backgroundColor: "hsl(var(--popover))", border: "1px solid hsl(var(--border))", borderRadius: "6px" }} labelStyle={{ color: "hsl(var(--popover-foreground))" }} />
                 <Area type="monotone" dataKey="tokens" stroke={chartColors[1]} fill={chartColors[1]} fillOpacity={0.25} />
               </AreaChart>
             </ResponsiveContainer>
@@ -258,15 +258,19 @@ function ProjectTopCard({
       <CardContent className="h-64">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={sorted} layout="vertical" margin={{ left: 12, right: 12 }}>
-            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" horizontal={false} />
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" horizontal={false} />
             <XAxis
               type="number"
               fontSize={11}
               tickFormatter={kind === "tokens" ? (v) => humanTokens(Number(v)) : undefined}
+              tick={{ fill: "hsl(var(--muted-foreground))" }}
             />
-            <YAxis type="category" dataKey="label" fontSize={11} width={130} />
+            <YAxis type="category" dataKey="label" fontSize={11} width={130} tick={{ fill: "hsl(var(--muted-foreground))" }} />
             <RTooltip
               formatter={(v: number) => (kind === "tokens" ? humanTokens(v) : v)}
+              cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.6 }}
+              contentStyle={{ backgroundColor: "hsl(var(--popover))", border: "1px solid hsl(var(--border))", borderRadius: "6px" }}
+              labelStyle={{ color: "hsl(var(--popover-foreground))" }}
             />
             <Bar
               dataKey={kind}
@@ -315,6 +319,7 @@ function ModelDistCard({ data }: { data: ModelStat[] }) {
                     innerRadius={38}
                     outerRadius={70}
                     paddingAngle={2}
+                    stroke="none"
                   >
                     {data.map((_, i) => (
                       <Cell key={i} fill={chartColors[i % chartColors.length]} />
@@ -322,6 +327,8 @@ function ModelDistCard({ data }: { data: ModelStat[] }) {
                   </Pie>
                   <RTooltip
                     formatter={(v: number, name: string) => [`${v} 条`, name]}
+                    contentStyle={{ backgroundColor: "hsl(var(--popover))", border: "1px solid hsl(var(--border))", borderRadius: "6px" }}
+                    itemStyle={{ color: "hsl(var(--popover-foreground))" }}
                   />
                 </PieChart>
               </ResponsiveContainer>


### PR DESCRIPTION
This PR fixes #5 

- 为所有图表的坐标轴文字添加明确的颜色配置
- 修复 CartesianGrid 网格线颜色，使用主题变量
- 为所有 Tooltip 添加深色模式适配样式
- 使用 CSS 主题变量确保浅色/深色模式自动切换

影响范围：
- LineChart 
- AreaChart 
- BarChart 
- PieChart 

效果展示：
<img width="605" height="330" alt="Image_2026-06-08_17-31-38_o0hkcput ji5" src="https://github.com/user-attachments/assets/8b45aff1-4a41-4c23-900f-c997743a2cfb" />
<img width="483" height="250" alt="Image_2026-06-08_17-31-50_w5yyr3uj uro" src="https://github.com/user-attachments/assets/a8fef6dc-6d76-433b-a79e-4879ac06fa4c" />
<img width="254" height="163" alt="Image_2026-06-08_17-32-01_ib04kwxq bgr" src="https://github.com/user-attachments/assets/fe722162-ca36-4ca9-986f-4b2bdcb56087" />
