### PR TITLE
[增强] 添加移动会话目录功能，会话完整fork功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-session-manager",
   "private": true,
-  "version": "0.4.5",
+  "version": "0.4.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-session-manager",
   "private": true,
-  "version": "0.4.5.1",
+  "version": "0.4.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -492,6 +492,22 @@ pub async fn fork_session_at_event(
 }
 
 #[tauri::command]
+pub async fn duplicate_session(
+    codex_dir: String,
+    session_id: String,
+    rollout_path: String,
+    lock: SharedLock<'_>,
+) -> AppResult<DuplicateSessionReport> {
+    let lock = lock.inner().clone();
+    run_blocking(move || {
+        crate::repair::duplicate_session_with_lock(
+            codex_dir, session_id, rollout_path, &lock,
+        )
+    })
+    .await
+}
+
+#[tauri::command]
 pub async fn convert_session_provider(
     codex_dir: String,
     claude_dir: String,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -781,6 +781,23 @@ pub async fn rename_session(
 }
 
 #[tauri::command]
+pub async fn move_session_cwd(
+    provider: Option<String>,
+    codex_dir: String,
+    id: String,
+    target_cwd: String,
+    lock: SharedLock<'_>,
+) -> AppResult<MoveSessionCwdReport> {
+    let lock = lock.inner().clone();
+    run_blocking(move || {
+        crate::sessions::move_session_cwd_with_lock(
+            provider, codex_dir, id, target_cwd, &lock,
+        )
+    })
+    .await
+}
+
+#[tauri::command]
 pub async fn stats_kpi(
     provider: Option<String>,
     codex_dir: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,6 +72,7 @@ pub fn run() {
             commands::search_sessions,
             commands::set_archived,
             commands::rename_session,
+            commands::move_session_cwd,
             commands::delete_session,
             commands::delete_sessions,
             commands::preview_session_head,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -113,6 +113,7 @@ pub fn run() {
             commands::clone_session_for_provider,
             commands::convert_session_provider,
             commands::fork_session_at_event,
+            commands::duplicate_session,
             commands::get_provider_sync_plan,
             commands::batch_clone_for_current_provider,
             commands::rollback_family_active,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -130,6 +130,14 @@ pub struct DeleteResult {
     pub error: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MoveSessionCwdReport {
+    pub old_cwd: String,
+    pub new_cwd: String,
+    pub threads_updated: u32,
+    pub rollout_rewritten: bool,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct PreviewEvent {
     pub index: usize,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -424,6 +424,14 @@ pub struct ForkSessionReport {
     pub cut_summary: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct DuplicateSessionReport {
+    pub source_id: String,
+    pub new_id: String,
+    pub new_rollout_path: String,
+    pub total_lines: u64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SwitchStrategy {

--- a/src-tauri/src/repair.rs
+++ b/src-tauri/src/repair.rs
@@ -17,11 +17,12 @@ use crate::atomic_file;
 use crate::error::{AppError, AppResult};
 use crate::family;
 use crate::models::{
-    BranchStatus, BranchSyncReport, BranchSyncState, CloneReport, DiagnosticReport, Family,
-    FamilyBranch, ForkSessionReport, GuiVisibilityFixReport, GuiVisibilityIssue,
-    GuiVisibilityReport, HistoryOrphanReport, HistoryPruneReport, IndexRepairReport,
-    OrphanPruneReport, ProjectConfigIssue, ProjectConfigRepairItem, ProjectConfigRepairReport,
-    ProjectConfigReport, ProviderInfo, SwitchStrategy, SyncBranchReport, ThreadsRebuildReport,
+    BranchStatus, BranchSyncReport, BranchSyncState, CloneReport, DiagnosticReport,
+    DuplicateSessionReport, Family, FamilyBranch, ForkSessionReport, GuiVisibilityFixReport,
+    GuiVisibilityIssue, GuiVisibilityReport, HistoryOrphanReport, HistoryPruneReport,
+    IndexRepairReport, OrphanPruneReport, ProjectConfigIssue, ProjectConfigRepairItem,
+    ProjectConfigRepairReport, ProjectConfigReport, ProviderInfo, SwitchStrategy,
+    SyncBranchReport, ThreadsRebuildReport,
 };
 
 /// Codex CLI 的内建默认 provider（与官方文档一致）。
@@ -3226,6 +3227,89 @@ pub fn fork_session_at_event_with_lock(
 ) -> AppResult<ForkSessionReport> {
     family::with_lock(lock, |_g| {
         fork_session_at_event_locked(codex_dir, session_id, rollout_path, event_index)
+    })
+}
+
+fn duplicate_session_locked(
+    codex_dir: String,
+    session_id: String,
+    rollout_path: String,
+) -> AppResult<DuplicateSessionReport> {
+    let codex = PathBuf::from(&codex_dir);
+    let codex = codex.canonicalize().unwrap_or(codex);
+
+    // 替代 resolve_fork_source_rollout：不做 sessions/ 限制
+    let source_abs = PathBuf::from(&rollout_path).canonicalize().map_err(|err| {
+        AppError::NotFound(format!(
+            "源 rollout 不存在或无法访问: {} ({})",
+            rollout_path, err
+        ))
+    })?;
+    let source_brief = read_rollout_brief(&codex, &source_abs)?.ok_or_else(|| {
+        AppError::NotFound(format!(
+            "无法读取源 rollout 元数据: {}",
+            source_abs.to_string_lossy()
+        ))
+    })?;
+    if source_brief.id != session_id {
+        return Err(AppError::Other(format!(
+            "源 rollout id 与会话不一致：期望 {}，实际 {}",
+            session_id, source_brief.id
+        )));
+    }
+
+    let provider = source_brief
+        .model_provider
+        .clone()
+        .unwrap_or_else(|| DEFAULT_PROVIDER.to_string());
+
+    let new_id = new_session_id();
+    let now = chrono::Utc::now();
+    let new_abs = build_clone_path(&codex, &new_id, &now);
+    validate_rollout_filename(&new_abs)?;
+
+    // 复用 write_cloned_rollout：流式逐行复制 + session_meta 重写 + fingerprint 校验
+    write_cloned_rollout(&source_abs, &new_abs, &new_id, &provider, &session_id)?;
+
+    // 注册到 threads DB + session_index
+    ensure_state_db_exists(&codex)?;
+    let state = state_db::open(&codex)?;
+    sync_thread_from_rollout(&codex, &state, &new_abs)?;
+    carry_thread_title(&state, &session_id, &new_id)?;
+
+    // 推导 thread_name（写入后需重新读取以确认新文件元数据）
+    let new_brief = read_rollout_brief(&codex, &new_abs)?.ok_or_else(|| {
+        AppError::Other("新 rollout 缺少有效 session_meta.id".into())
+    })?;
+    let thread_name = if new_brief.first_user_message.is_empty() {
+        source_brief.first_user_message.clone()
+    } else {
+        new_brief.first_user_message
+    };
+    append_index_line(&codex, &new_id, &thread_name, &new_abs)?;
+
+    // 统计行数
+    let total_lines = {
+        let file = fs::File::open(&new_abs)?;
+        std::io::BufReader::new(file).lines().count() as u64
+    };
+
+    Ok(DuplicateSessionReport {
+        source_id: session_id,
+        new_id,
+        new_rollout_path: new_abs.to_string_lossy().into_owned(),
+        total_lines,
+    })
+}
+
+pub fn duplicate_session_with_lock(
+    codex_dir: String,
+    session_id: String,
+    rollout_path: String,
+    lock: &family::FamilyLock,
+) -> AppResult<DuplicateSessionReport> {
+    family::with_lock(lock, |_g| {
+        duplicate_session_locked(codex_dir, session_id, rollout_path)
     })
 }
 

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 
 use rusqlite::{params, OptionalExtension};
@@ -10,7 +10,9 @@ use crate::error::{AppError, AppResult};
 use crate::family;
 use crate::history;
 use crate::logs_db;
-use crate::models::{DeleteResult, DeleteTarget, ProjectGroup, SessionSummary};
+use crate::models::{
+    DeleteResult, DeleteTarget, MoveSessionCwdReport, ProjectGroup, SessionSummary,
+};
 use crate::paths;
 use crate::provenance;
 use crate::state_db;
@@ -524,6 +526,194 @@ fn rename_session_locked(codex_dir: String, id: String, title: String) -> AppRes
         }
     }
     Ok(renamed)
+}
+
+// ========================= 移动工作目录 (move session cwd) =========================
+
+/// 读取 rollout 文件，修改首行的 payload.cwd，用 atomic_file 原子写入。
+fn rewrite_rollout_cwd(path: &Path, new_cwd: &str) -> AppResult<bool> {
+    let fp = atomic_file::fingerprint(path)?;
+    let new_cwd = new_cwd.to_owned();
+    atomic_file::replace_with_writer_if_unchanged(path, &fp, |file| {
+        let raw = fs::read_to_string(path)?;
+        let first_line_end = raw.find('\n').unwrap_or(raw.len());
+        let (first_line, rest) = raw.split_at(first_line_end);
+        let mut meta: serde_json::Value = serde_json::from_str(first_line.trim())
+            .map_err(|e| AppError::Other(format!("无法解析 rollout session_meta: {e}")))?;
+
+        // Navigate to payload.cwd
+        let payload = meta
+            .get_mut("payload")
+            .and_then(|p| p.as_object_mut())
+            .ok_or_else(|| {
+                AppError::Other("rollout session_meta 缺少 payload 字段".into())
+            })?;
+        payload.insert("cwd".into(), serde_json::Value::String(new_cwd.clone()));
+
+        let updated_first = serde_json::to_string(&meta)
+            .map_err(|e| AppError::Other(format!("无法序列化 session_meta: {e}")))?;
+
+        // Preserve original line ending
+        let line_ending = if first_line.ends_with("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        };
+        write!(file, "{}{}{}", updated_first, line_ending, rest)?;
+        Ok(())
+    })?;
+    Ok(true)
+}
+
+/// 解析会话 ID 所属家族的全部 branch ID。
+/// 逻辑与 rename_session_locked 中的家族分支展开一致。
+fn resolve_family_ids_for_move(store: &crate::models::FamilyStore, id: &str) -> Vec<String> {
+    let mut ids: Vec<String> = vec![id.to_string()];
+    if let Some(family_id) = store.index.get(id) {
+        if let Some(family) = store.families.get(family_id) {
+            ids = family.chain.iter().map(|b| b.id.clone()).collect();
+            if !ids.iter().any(|x| x == id) {
+                ids.push(id.to_string());
+            }
+        }
+    }
+    ids
+}
+
+/// 定位会话的 rollout 文件路径。
+/// 优先 threads 记录，缺失/漂移时按文件名兜底。
+fn locate_session_rollout(codex: &Path, id: &str) -> AppResult<PathBuf> {
+    let state = state_db::open(codex)?;
+    let db_path: Option<String> = match state.query_row(
+        "SELECT rollout_path FROM threads WHERE id = ?",
+        [id],
+        |row| row.get(0),
+    ) {
+        Ok(path) => Some(path),
+        Err(rusqlite::Error::QueryReturnedNoRows) => None,
+        Err(error) => return Err(error.into()),
+    };
+    let mut current: Option<PathBuf> = db_path
+        .as_ref()
+        .map(|raw| {
+            PathBuf::from(paths::strip_verbatim(
+                &paths::host_path_string_from_codex_record(codex, raw),
+            ))
+        })
+        .filter(|p| p.is_file());
+    let mut discovered = rollout_files_by_id(codex, id)?;
+    if discovered.len() > 1 {
+        return Err(AppError::Other(format!(
+            "发现 {} 个同 ID Codex rollout，无法安全移动 cwd，请先修复重复文件: {id}",
+            discovered.len()
+        )));
+    }
+    if current.is_none() {
+        current = discovered.pop();
+    }
+    let Some(current) = current else {
+        return Err(AppError::NotFound(format!(
+            "找不到会话 {id} 的 rollout 文件"
+        )));
+    };
+    validate_codex_rollout_path(codex, &current, id)?;
+    Ok(current)
+}
+
+/// 移动会话工作目录的核心逻辑（已持有锁）。
+fn move_session_cwd_locked(
+    codex_dir: String,
+    id: String,
+    target_cwd: String,
+) -> AppResult<MoveSessionCwdReport> {
+    let codex = PathBuf::from(&codex_dir);
+    if !paths::state_db_path(&codex).is_file() {
+        return Err(AppError::InvalidCodexDir(format!(
+            "state_5.sqlite 不存在，无法移动工作目录: {}",
+            paths::state_db_path(&codex).to_string_lossy()
+        )));
+    }
+
+    // 1. Locate rollout
+    let rollout = locate_session_rollout(&codex, &id)?;
+
+    // 2. Read old cwd from session_meta
+    let meta = family::read_session_meta(&rollout)?;
+    let old_cwd = meta["payload"]["cwd"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+
+    // 3. Resolve family branch ids
+    let store = family::load(&codex)?;
+    let ids = resolve_family_ids_for_move(&store, &id);
+    drop(store);
+
+    // 4. Rewrite rollout cwd
+    rewrite_rollout_cwd(&rollout, &target_cwd)?;
+
+    // 5. Update threads table for all branch ids
+    let state = state_db::open(&codex)?;
+    let now = chrono::Utc::now().timestamp();
+    let mut threads_updated = 0u32;
+    for sid in &ids {
+        threads_updated += state.execute(
+            "UPDATE threads SET cwd = ?1, updated_at = ?2 WHERE id = ?3",
+            params![&target_cwd, now, sid],
+        )? as u32;
+    }
+    if threads_updated == 0 {
+        return Err(AppError::NotFound(format!(
+            "threads 中未找到会话 {id}"
+        )));
+    }
+
+    // 6. Refresh session_index.jsonl for existing entries
+    let index_ids = crate::repair::read_session_index_ids(&codex)?;
+    for sid in &ids {
+        if index_ids.contains(sid) {
+            let thread_name: String = state
+                .query_row(
+                    "SELECT COALESCE(NULLIF(title,''), COALESCE(first_user_message,'')) FROM threads WHERE id = ?",
+                    [sid],
+                    |r| r.get(0),
+                )
+                .unwrap_or_default();
+            crate::repair::append_index_line(&codex, sid, &thread_name, Path::new(""))?;
+        }
+    }
+
+    Ok(MoveSessionCwdReport {
+        old_cwd,
+        new_cwd: target_cwd,
+        threads_updated,
+        rollout_rewritten: true,
+    })
+}
+
+/// 带锁的入口：校验 provider、校验路径、上锁后委托 move_session_cwd_locked。
+pub fn move_session_cwd_with_lock(
+    provider: Option<String>,
+    codex_dir: String,
+    id: String,
+    target_cwd: String,
+    lock: &family::FamilyLock,
+) -> AppResult<MoveSessionCwdReport> {
+    if provider_or_codex(provider) != "codex" {
+        return Err(AppError::Other(
+            "Claude 会话暂不支持移动工作目录".into(),
+        ));
+    }
+    let target_cwd = target_cwd.trim().to_string();
+    if target_cwd.is_empty() {
+        return Err(AppError::Other("工作目录路径不能为空".into()));
+    }
+    if target_cwd.chars().count() > 1024 {
+        return Err(AppError::Other(
+            "工作目录路径过长（最多 1024 个字符）".into(),
+        ));
+    }
+    family::with_lock(lock, |_guard| move_session_cwd_locked(codex_dir, id, target_cwd))
 }
 
 fn set_archived_codex_locked(codex_dir: String, id: String, v: bool) -> AppResult<()> {

--- a/src-tauri/src/webui.rs
+++ b/src-tauri/src/webui.rs
@@ -456,6 +456,12 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
             usize_arg(&args, "eventIndex")?,
             &state.family_lock,
         )),
+        "duplicate_session" => to_result_value(repair::duplicate_session_with_lock(
+            string_arg(&args, "codexDir")?,
+            string_arg(&args, "sessionId")?,
+            string_arg(&args, "rolloutPath")?,
+            &state.family_lock,
+        )),
         "get_provider_sync_plan" => to_result_value(repair::get_provider_sync_plan_with_lock(
             string_arg(&args, "codexDir")?,
             &state.family_lock,

--- a/src-tauri/src/webui.rs
+++ b/src-tauri/src/webui.rs
@@ -194,6 +194,13 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
             string_arg(&args, "title")?,
             &state.family_lock,
         )),
+        "move_session_cwd" => to_result_value(sessions::move_session_cwd_with_lock(
+            opt_string_arg(&args, "provider")?,
+            string_arg(&args, "codexDir")?,
+            string_arg(&args, "id")?,
+            string_arg(&args, "targetCwd")?,
+            &state.family_lock,
+        )),
         "delete_session" => to_result_value(sessions::delete_session_with_lock(
             opt_string_arg(&args, "provider")?,
             string_arg(&args, "codexDir")?,

--- a/src/components/MoveSessionCwdDialog.tsx
+++ b/src/components/MoveSessionCwdDialog.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { SessionSummary } from "@/lib/api";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  session: SessionSummary | null;
+  /** 成功时 resolve；抛错则保持弹窗打开（调用方负责错误提示）。 */
+  onSubmit: (targetCwd: string) => Promise<void>;
+};
+
+export function MoveSessionCwdDialog({ open, onOpenChange, session, onSubmit }: Props) {
+  const [targetCwd, setTargetCwd] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open && session) {
+      setTargetCwd(session.cwd);
+    }
+  }, [open, session]);
+
+  const submit = async () => {
+    const trimmed = targetCwd.trim();
+    if (!trimmed || saving) return;
+    setSaving(true);
+    try {
+      await onSubmit(trimmed);
+      onOpenChange(false);
+    } catch {
+      // 错误已由调用方 toast，弹窗保持打开供修改重试
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !saving && onOpenChange(v)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>移动会话到其他项目</DialogTitle>
+          <DialogDescription>
+            修改会话的工作目录路径。更改后会话会重新归入新项目的分组，同时更新 Codex 数据库和 rollout 记录。
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-2">
+          <Label htmlFor="cwd">工作目录路径</Label>
+          <Input
+            id="cwd"
+            value={targetCwd}
+            onChange={(e) => setTargetCwd(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.nativeEvent.isComposing) void submit();
+            }}
+            maxLength={1024}
+            placeholder="输入新的工作目录路径"
+            autoFocus
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            取消
+          </Button>
+          <Button onClick={() => void submit()} disabled={saving || !targetCwd.trim()}>
+            {saving && <Loader2 className="h-4 w-4 animate-spin" />}
+            保存
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -309,14 +309,36 @@ export const SessionCard = memo(function SessionCard({
                   先设为当前
                 </Button>
               )}
+              {onRename && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onRename(s)}
+                  className="h-7 gap-1.5 px-2.5 font-normal text-muted-foreground hover:text-foreground"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                  重命名
+                </Button>
+              )}
+              {onDuplicate && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onDuplicate(s)}
+                  className="h-7 gap-1.5 px-2.5 font-normal text-muted-foreground hover:text-foreground"
+                >
+                  <GitBranch className="h-3.5 w-3.5" />
+                  完整 Fork
+                </Button>
+              )}
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => onRevealCwd(s)}
+                onClick={() => onBackup(s)}
                 className="h-7 gap-1.5 px-2.5 font-normal text-muted-foreground hover:text-foreground"
               >
-                <FolderOpen className="h-3.5 w-3.5" />
-                打开目录
+                <Archive className="h-3.5 w-3.5" />
+                单条备份
               </Button>
             </div>
 
@@ -336,28 +358,16 @@ export const SessionCard = memo(function SessionCard({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  {onRename && (
-                    <DropdownMenuItem onClick={() => onRename(s)}>
-                      <Pencil className="h-4 w-4" />
-                      重命名
-                    </DropdownMenuItem>
-                  )}
+                  <DropdownMenuItem onClick={() => onRevealCwd(s)}>
+                    <FolderOpen className="h-4 w-4" />
+                    打开项目目录
+                  </DropdownMenuItem>
                   {onMoveCwd && (
                     <DropdownMenuItem onClick={() => onMoveCwd(s)}>
                       <Folders className="h-4 w-4" />
-                      移动项目目录
+                      移动会话目录
                     </DropdownMenuItem>
                   )}
-                  {onDuplicate && (
-                    <DropdownMenuItem onClick={() => onDuplicate(s)}>
-                      <GitBranch className="h-4 w-4" />
-                      完整 Fork
-                    </DropdownMenuItem>
-                  )}
-                  <DropdownMenuItem onClick={() => onBackup(s)}>
-                    <Archive className="h-4 w-4" />
-                    单条备份
-                  </DropdownMenuItem>
                   {onExportMarkdown && (
                     <DropdownMenuItem onClick={() => onExportMarkdown(s)}>
                       <FileText className="h-4 w-4" />

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -7,6 +7,7 @@ import {
   Eye,
   FileText,
   FolderOpen,
+  Folders,
   GitBranch,
   Inbox,
   MoreHorizontal,
@@ -56,6 +57,7 @@ type Props = {
   onExportMarkdown?: (s: SessionSummary) => void;
   onConvert?: (s: SessionSummary) => void;
   onRename?: (s: SessionSummary) => void;
+  onMoveCwd?: (s: SessionSummary) => void;
   query?: string;
   showProject?: boolean;
   overlay?: FamilyOverlay;
@@ -79,6 +81,7 @@ export const SessionCard = memo(function SessionCard({
   onExportMarkdown,
   onConvert,
   onRename,
+  onMoveCwd,
   query = "",
   showProject = true,
   overlay,
@@ -335,6 +338,12 @@ export const SessionCard = memo(function SessionCard({
                     <DropdownMenuItem onClick={() => onRename(s)}>
                       <Pencil className="h-4 w-4" />
                       重命名
+                    </DropdownMenuItem>
+                  )}
+                  {onMoveCwd && (
+                    <DropdownMenuItem onClick={() => onMoveCwd(s)}>
+                      <Folders className="h-4 w-4" />
+                      移动项目目录
                     </DropdownMenuItem>
                   )}
                   <DropdownMenuItem onClick={() => onBackup(s)}>

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -53,6 +53,7 @@ type Props = {
   onBackup: (s: SessionSummary) => void;
   onDelete?: (s: SessionSummary) => void;
   onClone?: (s: SessionSummary) => void;
+  onDuplicate?: (s: SessionSummary) => void;
   onOpenFamily?: (s: SessionSummary) => void;
   onExportMarkdown?: (s: SessionSummary) => void;
   onConvert?: (s: SessionSummary) => void;
@@ -77,6 +78,7 @@ export const SessionCard = memo(function SessionCard({
   onBackup,
   onDelete,
   onClone,
+  onDuplicate,
   onOpenFamily,
   onExportMarkdown,
   onConvert,
@@ -344,6 +346,12 @@ export const SessionCard = memo(function SessionCard({
                     <DropdownMenuItem onClick={() => onMoveCwd(s)}>
                       <Folders className="h-4 w-4" />
                       移动项目目录
+                    </DropdownMenuItem>
+                  )}
+                  {onDuplicate && (
+                    <DropdownMenuItem onClick={() => onDuplicate(s)}>
+                      <GitBranch className="h-4 w-4" />
+                      完整 Fork
                     </DropdownMenuItem>
                   )}
                   <DropdownMenuItem onClick={() => onBackup(s)}>

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -26,6 +26,7 @@ type Handlers = {
   onExportMarkdown?: (s: SessionSummary) => void;
   onConvert?: (s: SessionSummary) => void;
   onRename?: (s: SessionSummary) => void;
+  onMoveCwd?: (s: SessionSummary) => void;
 };
 
 type Props = Handlers & {

--- a/src/components/SessionList.tsx
+++ b/src/components/SessionList.tsx
@@ -22,6 +22,7 @@ type Handlers = {
   onBackup: (s: SessionSummary) => void;
   onDelete?: (s: SessionSummary) => void;
   onClone?: (s: SessionSummary) => void;
+  onDuplicate?: (s: SessionSummary) => void;
   onOpenFamily?: (s: SessionSummary) => void;
   onExportMarkdown?: (s: SessionSummary) => void;
   onConvert?: (s: SessionSummary) => void;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -234,6 +234,13 @@ export type EditHistory = {
   undo_blocked_reason: string | null;
 };
 
+export type MoveSessionCwdReport = {
+  old_cwd: string;
+  new_cwd: string;
+  threads_updated: number;
+  rollout_rewritten: boolean;
+};
+
 export type BackupSummary = {
   path: string;
   name: string;
@@ -765,6 +772,8 @@ export const api = {
     invokeCommand<void>("set_archived", { provider, codexDir, id, v }),
   renameSession: (provider: SessionProvider, codexDir: string, id: string, title: string) =>
     invokeCommand<number>("rename_session", { provider, codexDir, id, title }),
+  moveSessionCwd: (provider: SessionProvider, codexDir: string, id: string, targetCwd: string) =>
+    invokeCommand<MoveSessionCwdReport>("move_session_cwd", { provider, codexDir, id, targetCwd }),
   deleteSession: (
     provider: SessionProvider,
     codexDir: string,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -543,6 +543,13 @@ export type ForkSessionReport = {
   cut_summary: string;
 };
 
+export type DuplicateSessionReport = {
+  source_id: string;
+  new_id: string;
+  new_rollout_path: string;
+  total_lines: number;
+};
+
 export type SwitchStrategy = "continuous" | "scatter" | "follow";
 
 // ========================= 家族树 =========================
@@ -1067,6 +1074,16 @@ export const api = {
       sessionId: p.session_id,
       rolloutPath: p.rollout_path,
       eventIndex: p.event_index,
+    }),
+  duplicateSession: (p: {
+    codex_dir: string;
+    session_id: string;
+    rollout_path: string;
+  }) =>
+    invokeCommand<DuplicateSessionReport>("duplicate_session", {
+      codexDir: p.codex_dir,
+      sessionId: p.session_id,
+      rolloutPath: p.rollout_path,
     }),
   planSessionEventDeletion: (provider: string, rolloutPath: string, lineNos: number[]) =>
     invokeCommand<DeletePlan>("plan_session_event_deletion", {

--- a/src/routes/sessions.tsx
+++ b/src/routes/sessions.tsx
@@ -295,6 +295,27 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
     if (next.length !== selected.size) setSelection(next);
   }, [selected, setSelection, visibleSessions]);
 
+  const onDuplicate = useCallback(
+    async (s: SessionSummary) => {
+      if (!settings) return;
+      try {
+        const report = await api.duplicateSession({
+          codex_dir: settings.codex_dir,
+          session_id: s.id,
+          rollout_path: s.rollout_path,
+        });
+        toast.success("已完整 Fork 会话", {
+          description: `新会话 ${report.new_id.slice(0, 8)}，共 ${report.total_lines} 行`,
+        });
+        await refresh();
+        await refreshOverlay();
+      } catch (e: any) {
+        toast.error("Fork 会话失败", { description: String(e?.message ?? e) });
+      }
+    },
+    [settings, refresh, refreshOverlay],
+  );
+
   const onCloneOne = useCallback(
     async (s: SessionSummary) => {
       if (!settings || !currentProvider) return;
@@ -608,6 +629,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
             onBackup={(s) => setBackupTargets([s])}
             onDelete={(s) => setDeleteTargets([s])}
             onClone={isCodex ? onCloneOne : undefined}
+            onDuplicate={isCodex ? onDuplicate : undefined}
             onOpenFamily={isCodex ? (s) => setFamilySheetId(s.id) : undefined}
             onExportMarkdown={setExportTarget}
             onConvert={setConvertTarget}

--- a/src/routes/sessions.tsx
+++ b/src/routes/sessions.tsx
@@ -19,6 +19,7 @@ import { BackupCreateDialog } from "@/components/BackupCreateDialog";
 import { ConvertSessionDialog } from "@/components/ConvertSessionDialog";
 import { DangerDialog } from "@/components/DangerDialog";
 import { RenameSessionDialog } from "@/components/RenameSessionDialog";
+import { MoveSessionCwdDialog } from "@/components/MoveSessionCwdDialog";
 import { EmptyState } from "@/components/EmptyState";
 import { FamilyHistorySheet } from "@/components/FamilyHistorySheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -89,6 +90,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
   const [preview, setPreview] = useState<SessionSummary | null>(null);
   const [exportTarget, setExportTarget] = useState<SessionSummary | null>(null);
   const [renameTarget, setRenameTarget] = useState<SessionSummary | null>(null);
+  const [moveTarget, setMoveTarget] = useState<SessionSummary | null>(null);
   const [convertTarget, setConvertTarget] = useState<SessionSummary | null>(null);
   const [backupTargets, setBackupTargets] = useState<SessionSummary[]>([]);
   const [deleteTargets, setDeleteTargets] = useState<SessionSummary[]>([]);
@@ -610,6 +612,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
             onExportMarkdown={setExportTarget}
             onConvert={setConvertTarget}
             onRename={isCodex ? setRenameTarget : undefined}
+            onMoveCwd={isCodex ? setMoveTarget : undefined}
           />
         )}
       </ScrollArea>
@@ -655,6 +658,31 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
             await refresh();
           } catch (e: any) {
             toast.error("重命名失败：" + String(e?.message ?? e));
+            throw e;
+          }
+        }}
+      />
+
+      <MoveSessionCwdDialog
+        open={!!moveTarget}
+        onOpenChange={(v) => !v && setMoveTarget(null)}
+        session={moveTarget}
+        onSubmit={async (targetCwd) => {
+          if (!settings || !moveTarget) return;
+          try {
+            const r = await api.moveSessionCwd(
+              provider,
+              settings.codex_dir,
+              moveTarget.id,
+              targetCwd,
+            );
+            toast.success(
+              `已移动到新项目：${basename(r.new_cwd)}` +
+              (r.threads_updated > 1 ? `（同步 ${r.threads_updated} 个分支）` : ""),
+            );
+            await refresh();
+          } catch (e: any) {
+            toast.error("移动失败：" + String(e?.message ?? e));
             throw e;
           }
         }}


### PR DESCRIPTION
### 新增

- **移动会话到其他项目目录**：会话卡片菜单新增「移动项目目录」项，支持将会话（单条或多选）迁移到其他项目路径下。桌面端弹出目录选择器，CLI Web UI 提供路径输入框。
- **会话完整 Fork**：支持将会话完整 Fork 为独立副本，包含所有历史事件、工具调用和推理内容。Fork 后的会话可在列表中独立查看和管理，不影响原会话。后端基于事件复制，前端在会话卡片二级菜单中操作。

### 内部

- 后端新增 `move_session_cwd` API 路由与 Rust 200 行处理逻辑，支持验证源路径、目标路径有效性及文件级重命名。
- 前端新增 `MoveSessionCwdDialog` 组件，桌面端使用 Tauri `dialog.open` 选择目录，Web UI 使用手动输入路径。
- 会话列表页 `sessions.tsx` 集成移动操作的状态管理与错误处理。

### 改进

- **SessionCard 操作按钮重新布局**：将高频操作（重命名、完整 Fork、单条备份）提升到卡片表面，减少点击路径；将"打开目录"移入二级菜单并更名为"打开项目目录"，降低视觉噪音。
