### PR TITLE
fix(sessions): 修复 provider 同步孤儿与归档分支删除

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,12 +213,12 @@ CLI 和桌面版的修复功能只处理 Codex 本地索引及可见性，不改
 - `src-tauri/Cargo.toml`
 - `src-tauri/tauri.conf.json`
 
-推送 `v0.4.6` 形式的 tag 会触发 GitHub Actions，并创建 Release：
+推送 `v0.4.7` 形式的 tag 会触发 GitHub Actions，并创建 Release：
 
 ```bash
-git tag -a v0.4.6 -m "v0.4.6"
+git tag -a v0.4.7 -m "v0.4.7"
 git push origin main
-git push origin v0.4.6
+git push origin v0.4.7
 ```
 
 工作流分别为 Windows、macOS Apple Silicon、macOS Intel 和 Linux 构建 Tauri 产物。macOS 打包需要 `src-tauri/icons/icon.icns`，仓库中已包含 Tauri 生成的跨平台图标。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cc-session-manager",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-session-manager",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.4",
         "@radix-ui/react-checkbox": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cc-session-manager",
   "private": true,
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "cc-session-manager"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cc-session-manager"
-version = "0.4.6"
+version = "0.4.7"
 description = "CC Sessions"
 authors = ["zjsmew"]
 edition = "2021"

--- a/src-tauri/src/bin/cc-sessions.rs
+++ b/src-tauri/src/bin/cc-sessions.rs
@@ -1038,22 +1038,35 @@ fn cmd_repair(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
         "prune" => {
             let prune_index = take_flag(&mut args, "--index");
             let prune_threads = take_flag(&mut args, "--threads");
+            let prune_family = take_flag(&mut args, "--family");
             let dry_run = take_flag(&mut args, "--dry-run");
             ensure_no_args(&args)?;
-            if !prune_index && !prune_threads {
-                return Err(CliError::message("prune 需要显式指定 --index 或 --threads"));
+            if !prune_index && !prune_threads && !prune_family {
+                return Err(CliError::message(
+                    "prune 需要显式指定 --index、--threads 或 --family",
+                ));
             }
-            let report = repair::prune_orphan_entries(
+            let report = repair::prune_orphan_entries_with_lock(
                 ctx.codex_dir.clone(),
                 prune_index,
                 prune_threads,
+                prune_family,
                 dry_run,
+                &ctx.family_lock,
             )?;
             output(ctx, &report, |report| {
                 println!(
-                    "index_removed={}\tthreads_removed={}\tdry_run={}",
-                    report.index_removed, report.threads_removed, report.dry_run
+                    "index_removed={}\tthreads_removed={}\tfamily_branches_removed={}\tfamilies_removed={}\tfamilies_skipped={}\tdry_run={}",
+                    report.index_removed,
+                    report.threads_removed,
+                    report.family_branches_removed,
+                    report.families_removed,
+                    report.families_skipped.len(),
+                    report.dry_run
                 );
+                for family_id in &report.families_skipped {
+                    println!("family_skipped\t{family_id}");
+                }
             })
         }
         "claude-history" => {

--- a/src-tauri/src/cli_menu.rs
+++ b/src-tauri/src/cli_menu.rs
@@ -1717,18 +1717,33 @@ fn repair_threads(ctx: &MenuContext) -> MenuResult<()> {
 fn repair_prune(ctx: &MenuContext) -> MenuResult<()> {
     let prune_index = confirm_default_no("是否清理 session_index.jsonl 里的 orphan？")?;
     let prune_threads = confirm_default_no("是否清理 threads 表里的 orphan？")?;
-    if !prune_index && !prune_threads {
+    let prune_family = confirm_default_no("是否清理 session_family.json 里可安全确认的 orphan？")?;
+    if !prune_index && !prune_threads && !prune_family {
         println!("未选择任何清理目标。");
         return pause().map(|_| ());
     }
     let dry_run = choose_dry_run("清理 orphan 记录")?;
-    let report =
-        repair::prune_orphan_entries(ctx.codex_dir.clone(), prune_index, prune_threads, dry_run)
-            .map_err(to_string)?;
+    let report = repair::prune_orphan_entries_with_lock(
+        ctx.codex_dir.clone(),
+        prune_index,
+        prune_threads,
+        prune_family,
+        dry_run,
+        &ctx.family_lock,
+    )
+    .map_err(to_string)?;
     println!(
-        "index_removed={} threads_removed={} dry_run={}",
-        report.index_removed, report.threads_removed, report.dry_run
+        "index_removed={} threads_removed={} family_branches_removed={} families_removed={} families_skipped={} dry_run={}",
+        report.index_removed,
+        report.threads_removed,
+        report.family_branches_removed,
+        report.families_removed,
+        report.families_skipped.len(),
+        report.dry_run
     );
+    for family_id in report.families_skipped {
+        println!("family_skipped {family_id}");
+    }
     pause()?;
     Ok(())
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -424,10 +424,20 @@ pub async fn prune_orphan_entries(
     codex_dir: String,
     prune_index: bool,
     prune_threads: bool,
+    prune_family: bool,
     dry_run: bool,
+    lock: SharedLock<'_>,
 ) -> AppResult<OrphanPruneReport> {
+    let lock = lock.inner().clone();
     run_blocking(move || {
-        crate::repair::prune_orphan_entries(codex_dir, prune_index, prune_threads, dry_run)
+        crate::repair::prune_orphan_entries_with_lock(
+            codex_dir,
+            prune_index,
+            prune_threads,
+            prune_family,
+            dry_run,
+            &lock,
+        )
     })
     .await
 }

--- a/src-tauri/src/family.rs
+++ b/src-tauri/src/family.rs
@@ -456,6 +456,16 @@ pub fn remove_non_active_branch(
         .get_mut(family_id)
         .ok_or_else(|| AppError::NotFound(format!("family not found: {family_id}")))?;
     let removed = family.chain.remove(position);
+    if family.root_id == branch_id {
+        family.root_id = family
+            .chain
+            .first()
+            .ok_or_else(|| {
+                inconsistent_family(format!("family {family_id} 删除分支后 chain 为空"))
+            })?
+            .id
+            .clone();
+    }
     family.updated_at = now_iso();
     store.index.remove(branch_id);
     Ok(removed)
@@ -711,9 +721,7 @@ pub fn verify_integrity(codex_dir: &Path) -> AppResult<FamilyIntegrityReport> {
         for b in family.chain.iter() {
             let expected_sha = b.sha256.clone();
             let expected_lines = b.line_count;
-            if expected_sha.is_none() && b.id == family.active_id {
-                continue; // 当前可写分支不会固化校验
-            }
+            let unsealed_active = expected_sha.is_none() && b.id == family.active_id;
             let rel = paths::checked_relative_path(&b.rollout_relpath)?;
             let abs_main = codex_dir.join(&rel);
             let abs_archived =
@@ -736,6 +744,9 @@ pub fn verify_integrity(codex_dir: &Path) -> AppResult<FamilyIntegrityReport> {
                 });
                 continue;
             };
+            if unsealed_active {
+                continue; // 当前可写分支只检查是否存在，不做 sha256/行数校验
+            }
             match compute_integrity(&candidate) {
                 Ok((sha, lines)) => {
                     let sha_ok = expected_sha.as_deref() == Some(sha.as_str());
@@ -1233,6 +1244,47 @@ mod tests {
             store.index.get("active-a").map(String::as_str),
             Some("family-a")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn remove_non_active_branch_repairs_root_when_root_branch_is_removed() -> AppResult<()> {
+        let mut store = two_branch_store();
+        let family = store.families.get_mut("family-a").expect("family fixture");
+        family.root_id = "history-a".to_string();
+        family.chain.swap(0, 1);
+
+        let removed = remove_non_active_branch(&mut store, "family-a", "history-a")?;
+
+        assert_eq!(removed.id, "history-a");
+        let family = store.families.get("family-a").expect("family remains");
+        assert_eq!(family.root_id, "active-a");
+        assert_eq!(family.active_id, "active-a");
+        assert_eq!(family.chain.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn verify_integrity_reports_missing_unsealed_active_branch() -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-family-missing-active-integrity-test");
+        fs::create_dir_all(&codex)?;
+        let mut store = FamilyStore::default();
+        ensure_family_for(
+            &mut store,
+            "missing-active",
+            "openai",
+            "sessions/2026/04/24/rollout-missing-active.jsonl",
+            "missing active",
+        );
+        save(&codex, &store)?;
+
+        let report = verify_integrity(&codex)?;
+
+        assert!(!report.all_ok);
+        assert_eq!(report.items.len(), 1);
+        assert_eq!(report.items[0].branch_id, "missing-active");
+        assert!(report.items[0].missing);
+        fs::remove_dir_all(codex).ok();
         Ok(())
     }
 

--- a/src-tauri/src/family.rs
+++ b/src-tauri/src/family.rs
@@ -892,6 +892,7 @@ pub fn get_session_family_overlay_with_lock(
 
     // 3) 读 current provider
     let cur = Some(crate::repair::read_current_provider_export(&codex)?);
+    let sessions_root = paths::sessions_dir(&codex);
 
     let mut out: Vec<FamilyOverlay> = Vec::with_capacity(thread_state_of.len());
     for (id, (rollout_path, provider, source, archived)) in &thread_state_of {
@@ -900,23 +901,37 @@ pub fn get_session_family_overlay_with_lock(
                 &paths::host_path_string_from_codex_record(&codex, raw),
             ))
         });
-        let record_usable = if let (Some(provider), Some(rollout)) = (provider.as_deref(), rollout)
+        let recorded_rollout_available = rollout
+            .as_ref()
+            .is_some_and(|path| path.starts_with(&sessions_root) && path.is_file());
+        let record_usable =
+            if let (Some(provider), Some(rollout)) = (provider.as_deref(), rollout.as_deref()) {
+                crate::repair::rollout_record_is_usable_provider(
+                    &codex,
+                    id,
+                    provider,
+                    rollout,
+                    rollout_path.as_deref(),
+                    Some(provider),
+                    source.as_deref(),
+                    *archived,
+                    index_ids.contains(id),
+                )?
+            } else {
+                false
+            };
+        let family_id = store.index.get(id).cloned();
+        let family_rollout_available = if let Some(branch) = family_id
+            .as_ref()
+            .and_then(|family_id| store.families.get(family_id))
+            .and_then(|family| family.chain.iter().find(|branch| branch.id == *id))
         {
-            crate::repair::rollout_record_is_usable_provider(
-                &codex,
-                id,
-                provider,
-                &rollout,
-                rollout_path.as_deref(),
-                Some(provider),
-                source.as_deref(),
-                *archived,
-                index_ids.contains(id),
-            )?
+            let relative = paths::checked_relative_path(&branch.rollout_relpath)?;
+            relative.starts_with("sessions") && codex.join(relative).is_file()
         } else {
             false
         };
-        let family_id = store.index.get(id).cloned();
+        let source_rollout_available = recorded_rollout_available || family_rollout_available;
         let (branch_count, is_active_branch, clone_state) = match family_id.as_ref() {
             None => {
                 let cs = compute_clone_state(
@@ -927,6 +942,7 @@ pub fn get_session_family_overlay_with_lock(
                     source.as_deref(),
                     *archived,
                     record_usable,
+                    source_rollout_available,
                 );
                 (0u32, false, cs)
             }
@@ -973,6 +989,7 @@ pub fn get_session_family_overlay_with_lock(
                     source.as_deref(),
                     *archived,
                     record_usable,
+                    source_rollout_available,
                 );
                 (branch_count, is_active, cs)
             }
@@ -997,12 +1014,16 @@ fn compute_clone_state(
     source: Option<&str>,
     archived: bool,
     record_usable: bool,
+    source_rollout_available: bool,
 ) -> String {
     if archived {
         return "matches".into();
     }
     if crate::repair::is_subagent_source(source) {
         return "subagent".into();
+    }
+    if !source_rollout_available {
+        return "unknown".into();
     }
     match (provider, current) {
         (Some(p), Some(cur)) if p == cur => {
@@ -1388,6 +1409,83 @@ mod tests {
             .find(|item| item.session_id == "overlay-source")
             .expect("source overlay");
         assert_eq!(source.clone_state, "has_clone");
+
+        fs::remove_dir_all(&codex).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn overlay_does_not_offer_provider_sync_when_source_rollout_is_missing() -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-overlay-missing-rollout-test");
+        fs::create_dir_all(&codex)?;
+        fs::write(
+            paths::session_index_path(&codex),
+            "{\"id\":\"missing-active\"}\n",
+        )?;
+        let conn = rusqlite::Connection::open(paths::state_db_path(&codex))?;
+        conn.execute(
+            "CREATE TABLE threads (
+                id TEXT PRIMARY KEY,
+                rollout_path TEXT,
+                model_provider TEXT,
+                source TEXT,
+                archived INTEGER
+            )",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO threads (id, rollout_path, model_provider, source, archived)
+             VALUES (?1, ?2, 'openai', 'cli', 0)",
+            params![
+                "missing-active",
+                codex
+                    .join("sessions/2026/04/24/rollout-missing-active.jsonl")
+                    .to_string_lossy()
+            ],
+        )?;
+        let family = Family {
+            family_id: "missing-family".to_string(),
+            root_id: "missing-active".to_string(),
+            title: "missing rollout".to_string(),
+            chain: vec![FamilyBranch {
+                id: "missing-active".to_string(),
+                provider: "openai".to_string(),
+                created_at: "2026-04-24T00:00:00Z".to_string(),
+                status: BranchStatus::Active,
+                rollout_relpath: "sessions/2026/04/24/rollout-missing-active.jsonl".to_string(),
+                sha256: None,
+                line_count: None,
+                note: None,
+            }],
+            active_id: "missing-active".to_string(),
+            updated_at: "2026-04-24T00:00:00Z".to_string(),
+        };
+        let mut families = BTreeMap::new();
+        families.insert("missing-family".to_string(), family);
+        let mut index = BTreeMap::new();
+        index.insert("missing-active".to_string(), "missing-family".to_string());
+        save(
+            &codex,
+            &FamilyStore {
+                version: 1,
+                families,
+                index,
+            },
+        )?;
+        drop(conn);
+
+        let overlay = get_session_family_overlay_with_lock(
+            codex.to_string_lossy().into_owned(),
+            &FamilyLock::default(),
+        )?;
+        let item = overlay
+            .iter()
+            .find(|item| item.session_id == "missing-active")
+            .expect("missing thread overlay");
+        assert_eq!(
+            item.clone_state, "unknown",
+            "缺少源 rollout 的 orphan 记录应交给 orphan 清理，而不是展示必然失败的同步操作"
+        );
 
         fs::remove_dir_all(&codex).ok();
         Ok(())

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -654,6 +654,9 @@ pub struct ProjectConfigRepairReport {
 pub struct OrphanPruneReport {
     pub index_removed: u32,
     pub threads_removed: u32,
+    pub family_branches_removed: u32,
+    pub families_removed: u32,
+    pub families_skipped: Vec<String>,
     pub dry_run: bool,
 }
 

--- a/src-tauri/src/repair.rs
+++ b/src-tauri/src/repair.rs
@@ -1076,11 +1076,157 @@ pub fn repair_session_index(codex_dir: String, dry_run: bool) -> AppResult<Index
 //
 // 与 `repair_session_index`/`rebuild_threads_table` 不同：此命令**只删除**
 // 指向已消失 rollout 的孤儿行（session_index.jsonl 里多出来的 id、threads
-// 表里多出来的 id），不会从 rollout 重建。适合只想"把残留清干净"的场景。
+// 表里多出来的 id，以及 session_family.json 中可安全确认的孤儿 family/分支），
+// 不会从 rollout 重建。适合只想"把残留清干净"的场景。
 pub fn prune_orphan_entries(
     codex_dir: String,
     prune_index: bool,
     prune_threads: bool,
+    dry_run: bool,
+) -> AppResult<OrphanPruneReport> {
+    let lock = family::FamilyLock::default();
+    prune_orphan_entries_with_lock(
+        codex_dir,
+        prune_index,
+        prune_threads,
+        prune_index || prune_threads,
+        dry_run,
+        &lock,
+    )
+}
+
+pub fn prune_orphan_entries_with_lock(
+    codex_dir: String,
+    prune_index: bool,
+    prune_threads: bool,
+    prune_family: bool,
+    dry_run: bool,
+    lock: &family::FamilyLock,
+) -> AppResult<OrphanPruneReport> {
+    family::with_lock(lock, |_g| {
+        prune_orphan_entries_locked(codex_dir, prune_index, prune_threads, prune_family, dry_run)
+    })
+}
+
+#[derive(Default)]
+struct FamilyOrphanPrunePlan {
+    family_ids: Vec<String>,
+    branches: Vec<(String, String)>,
+    skipped_family_ids: Vec<String>,
+}
+
+fn family_branch_rollout_exists(
+    codex: &Path,
+    branch: &FamilyBranch,
+    rollout_ids: &BTreeSet<String>,
+) -> Option<bool> {
+    if rollout_ids.contains(&branch.id) {
+        return Some(true);
+    }
+    let relative = paths::checked_relative_path(&branch.rollout_relpath).ok()?;
+    Some(codex.join(relative).is_file())
+}
+
+fn family_metadata_is_consistent(
+    store: &crate::models::FamilyStore,
+    family_id: &str,
+    family_record: &Family,
+) -> bool {
+    if family_record.family_id != family_id {
+        return false;
+    }
+    let chain_ids = family_record
+        .chain
+        .iter()
+        .map(|branch| branch.id.as_str())
+        .collect::<BTreeSet<_>>();
+    if store.index.iter().any(|(branch_id, mapped_family_id)| {
+        mapped_family_id == family_id && !chain_ids.contains(branch_id.as_str())
+    }) {
+        return false;
+    }
+    let Some(branch) = family_record.chain.first() else {
+        return true;
+    };
+    matches!(
+        family::resolve_family_id_strict(store, &branch.id),
+        Ok(Some(resolved_family_id)) if resolved_family_id == family_id
+    )
+}
+
+fn existing_family_branch_ids(
+    codex: &Path,
+    family_record: &Family,
+    rollout_ids: &BTreeSet<String>,
+) -> Option<BTreeSet<String>> {
+    let mut existing_branch_ids = BTreeSet::new();
+    for branch in &family_record.chain {
+        if family_branch_rollout_exists(codex, branch, rollout_ids)? {
+            existing_branch_ids.insert(branch.id.clone());
+        }
+    }
+    Some(existing_branch_ids)
+}
+
+fn plan_family_orphan_prune(
+    codex: &Path,
+    store: &crate::models::FamilyStore,
+    rollout_ids: &BTreeSet<String>,
+) -> FamilyOrphanPrunePlan {
+    let mut plan = FamilyOrphanPrunePlan::default();
+
+    for (family_id, family_record) in &store.families {
+        if !family_metadata_is_consistent(store, family_id, family_record) {
+            plan.skipped_family_ids.push(family_id.clone());
+            continue;
+        }
+        let Some(existing_branch_ids) =
+            existing_family_branch_ids(codex, family_record, rollout_ids)
+        else {
+            plan.skipped_family_ids.push(family_id.clone());
+            continue;
+        };
+
+        if existing_branch_ids.is_empty() {
+            plan.family_ids.push(family_id.clone());
+            continue;
+        }
+
+        let active_exists = family_record
+            .chain
+            .iter()
+            .find(|branch| branch.id == family_record.active_id)
+            .is_some_and(|branch| existing_branch_ids.contains(&branch.id));
+        if !active_exists {
+            plan.skipped_family_ids.push(family_id.clone());
+            continue;
+        }
+
+        let missing_branch_ids = family_record
+            .chain
+            .iter()
+            .filter(|branch| !existing_branch_ids.contains(&branch.id))
+            .map(|branch| branch.id.clone())
+            .collect::<Vec<_>>();
+        if missing_branch_ids.is_empty() {
+            continue;
+        }
+
+        plan.branches.extend(
+            missing_branch_ids
+                .into_iter()
+                .map(|branch_id| (family_id.clone(), branch_id)),
+        );
+    }
+
+    plan
+}
+
+fn prune_orphan_entries_locked(
+    codex_dir: String,
+    prune_index: bool,
+    prune_threads: bool,
+    prune_family: bool,
     dry_run: bool,
 ) -> AppResult<OrphanPruneReport> {
     let codex = PathBuf::from(&codex_dir);
@@ -1102,6 +1248,27 @@ pub fn prune_orphan_entries(
 
     let mut index_removed = 0u32;
     let mut threads_removed = 0u32;
+    let mut family_branches_removed = 0u32;
+    let mut families_removed = 0u32;
+    let mut families_skipped = Vec::new();
+
+    if prune_family {
+        let mut store = family::load(&codex)?;
+        let plan = plan_family_orphan_prune(&codex, &store, &all_rollout_ids);
+        family_branches_removed = plan.branches.len() as u32;
+        families_removed = plan.family_ids.len() as u32;
+        families_skipped = plan.skipped_family_ids;
+
+        if !dry_run && (family_branches_removed > 0 || families_removed > 0) {
+            for family_id in &plan.family_ids {
+                family::remove_family(&mut store, family_id)?;
+            }
+            for (family_id, branch_id) in &plan.branches {
+                family::remove_non_active_branch(&mut store, family_id, branch_id)?;
+            }
+            family::save(&codex, &store)?;
+        }
+    }
 
     if prune_index {
         let index_path = paths::session_index_path(&codex);
@@ -1155,6 +1322,9 @@ pub fn prune_orphan_entries(
     Ok(OrphanPruneReport {
         index_removed,
         threads_removed,
+        family_branches_removed,
+        families_removed,
+        families_skipped,
         dry_run,
     })
 }
@@ -7360,6 +7530,164 @@ mod tests {
         assert_eq!(diag.threads_archived_count, 1);
         assert!(diag.orphan_in_threads.is_empty());
         assert_eq!(prune.threads_removed, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn prune_family_orphans_removes_fully_missing_families() -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-prune-missing-family-test");
+        fs::create_dir_all(&codex)?;
+        save_two_branch_family(
+            &codex,
+            "missing-active",
+            DEFAULT_PROVIDER,
+            "sessions/2026/04/24/rollout-missing-active.jsonl",
+            "missing-history",
+            "custom",
+            "archived_sessions/rollout-missing-history.jsonl",
+        )?;
+
+        let report = prune_orphan_entries_with_lock(
+            codex.to_string_lossy().into_owned(),
+            false,
+            false,
+            true,
+            false,
+            &family::FamilyLock::default(),
+        )?;
+        let store = family::load(&codex)?;
+
+        assert_eq!(report.families_removed, 1);
+        assert_eq!(report.family_branches_removed, 0);
+        assert!(report.families_skipped.is_empty());
+        assert!(store.families.is_empty());
+        assert!(store.index.is_empty());
+        fs::remove_dir_all(&codex).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn prune_family_orphans_removes_missing_non_active_branches_and_honors_dry_run() -> AppResult<()>
+    {
+        let codex = temp_codex_dir("cc-session-manager-prune-missing-branch-test");
+        write_rollout(&codex, "active-branch", DEFAULT_PROVIDER)?;
+        save_two_branch_family(
+            &codex,
+            "active-branch",
+            DEFAULT_PROVIDER,
+            "sessions/2026/04/22/rollout-active-branch.jsonl",
+            "missing-history",
+            "custom",
+            "archived_sessions/rollout-missing-history.jsonl",
+        )?;
+        let mut store = family::load(&codex)?;
+        let family = store
+            .families
+            .get_mut("active-branch")
+            .expect("family fixture");
+        family.root_id = "missing-history".to_string();
+        family.chain.swap(0, 1);
+        family::save(&codex, &store)?;
+        let before = serde_json::to_value(&store)?;
+        let lock = family::FamilyLock::default();
+
+        let preview = prune_orphan_entries_with_lock(
+            codex.to_string_lossy().into_owned(),
+            false,
+            false,
+            true,
+            true,
+            &lock,
+        )?;
+        assert_eq!(preview.family_branches_removed, 1);
+        assert_eq!(serde_json::to_value(family::load(&codex)?)?, before);
+
+        let report = prune_orphan_entries_with_lock(
+            codex.to_string_lossy().into_owned(),
+            false,
+            false,
+            true,
+            false,
+            &lock,
+        )?;
+        let store = family::load(&codex)?;
+        let family = store
+            .families
+            .get("active-branch")
+            .expect("surviving family");
+        assert_eq!(report.family_branches_removed, 1);
+        assert_eq!(report.families_removed, 0);
+        assert_eq!(family.root_id, "active-branch");
+        assert_eq!(family.active_id, "active-branch");
+        assert_eq!(family.chain.len(), 1);
+        assert!(!store.index.contains_key("missing-history"));
+        fs::remove_dir_all(&codex).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn prune_family_orphans_preserves_archived_rollouts() -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-prune-archived-family-test");
+        write_rollout(&codex, "active-branch", DEFAULT_PROVIDER)?;
+        write_rollout_in(&codex, "archived_sessions", "archived-branch", "custom")?;
+        save_two_branch_family(
+            &codex,
+            "active-branch",
+            DEFAULT_PROVIDER,
+            "sessions/2026/04/22/rollout-active-branch.jsonl",
+            "archived-branch",
+            "custom",
+            "archived_sessions/rollout-archived-branch.jsonl",
+        )?;
+
+        let report = prune_orphan_entries_with_lock(
+            codex.to_string_lossy().into_owned(),
+            false,
+            false,
+            true,
+            false,
+            &family::FamilyLock::default(),
+        )?;
+        let store = family::load(&codex)?;
+
+        assert_eq!(report.family_branches_removed, 0);
+        assert_eq!(report.families_removed, 0);
+        assert!(report.families_skipped.is_empty());
+        assert_eq!(store.families["active-branch"].chain.len(), 2);
+        fs::remove_dir_all(&codex).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn prune_family_orphans_preserves_partial_family_when_active_rollout_is_missing(
+    ) -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-prune-missing-active-test");
+        write_rollout_in(&codex, "archived_sessions", "surviving-history", "custom")?;
+        save_two_branch_family(
+            &codex,
+            "missing-active",
+            DEFAULT_PROVIDER,
+            "sessions/2026/04/22/rollout-missing-active.jsonl",
+            "surviving-history",
+            "custom",
+            "archived_sessions/rollout-surviving-history.jsonl",
+        )?;
+        let before = serde_json::to_value(family::load(&codex)?)?;
+
+        let report = prune_orphan_entries_with_lock(
+            codex.to_string_lossy().into_owned(),
+            false,
+            false,
+            true,
+            false,
+            &family::FamilyLock::default(),
+        )?;
+
+        assert_eq!(report.family_branches_removed, 0);
+        assert_eq!(report.families_removed, 0);
+        assert_eq!(report.families_skipped, vec!["missing-active".to_string()]);
+        assert_eq!(serde_json::to_value(family::load(&codex)?)?, before);
+        fs::remove_dir_all(&codex).ok();
         Ok(())
     }
 

--- a/src-tauri/src/repair.rs
+++ b/src-tauri/src/repair.rs
@@ -650,6 +650,17 @@ fn read_rollout_identity(path: &Path) -> AppResult<Option<RolloutIdentity>> {
     Ok(None)
 }
 
+fn scan_active_rollout_identities(codex: &Path) -> AppResult<Vec<(PathBuf, RolloutIdentity)>> {
+    let mut rollouts = Vec::new();
+    for path in family::scan_rollouts(codex)? {
+        let Some(identity) = read_rollout_identity(&path)? else {
+            continue;
+        };
+        rollouts.push((path, identity));
+    }
+    Ok(rollouts)
+}
+
 pub(crate) fn read_rollout_brief(codex_dir: &Path, path: &Path) -> AppResult<Option<RolloutBrief>> {
     let f = fs::File::open(path)?;
     let reader = BufReader::new(f);
@@ -4357,6 +4368,11 @@ fn list_mismatched_session_ids(codex: &Path, target_provider: &str) -> AppResult
     let mut out: Vec<String> = Vec::new();
     let thread_states = read_thread_state_map(codex)?;
     let index_ids = read_session_index_ids(codex)?;
+    let active_rollouts = scan_active_rollout_identities(codex)?;
+    let active_rollout_ids = active_rollouts
+        .iter()
+        .map(|(_, identity)| identity.id.as_str())
+        .collect::<BTreeSet<_>>();
 
     let store = family::load(codex)?;
     family_managed_ids.extend(store.index.keys().cloned());
@@ -4364,6 +4380,11 @@ fn list_mismatched_session_ids(codex: &Path, target_provider: &str) -> AppResult
         family_managed_ids.extend(f.chain.iter().map(|b| b.id.clone()));
         if let Some(active) = f.chain.iter().find(|b| b.id == f.active_id) {
             if !matches!(active.status, BranchStatus::Active) {
+                continue;
+            }
+            // family/threads 可能遗留已经不存在的 active 分支。没有源 rollout 时，
+            // provider 克隆无从执行；这类记录应由 orphan 清理处理，而不是制造必然失败的同步任务。
+            if !active_rollout_ids.contains(active.id.as_str()) {
                 continue;
             }
             // 手工归档的 family head 仍保持逻辑 Active 角色，但不应被 provider
@@ -4409,10 +4430,7 @@ fn list_mismatched_session_ids(codex: &Path, target_provider: &str) -> AppResult
         }
     }
 
-    for p in family::scan_rollouts(codex)? {
-        let Some(identity) = read_rollout_identity(&p)? else {
-            continue;
-        };
+    for (p, identity) in active_rollouts {
         if family_managed_ids.contains(&identity.id) {
             continue;
         }
@@ -7061,7 +7079,8 @@ mod tests {
     }
 
     #[test]
-    fn mismatched_scan_includes_unregistered_rollouts_when_family_store_exists() -> AppResult<()> {
+    fn mismatched_scan_includes_unregistered_rollouts_but_skips_missing_family_heads(
+    ) -> AppResult<()> {
         let codex = temp_codex_dir("cc-session-manager-repair-test");
         fs::create_dir_all(&codex)?;
 
@@ -7116,11 +7135,17 @@ mod tests {
         write_rollout(&codex, "legacy-session", "anthropic")?;
 
         let targets = list_mismatched_session_ids(&codex, "openai")?;
+        let plan = get_provider_sync_plan_with_lock(
+            codex.to_string_lossy().into_owned(),
+            &family::FamilyLock::default(),
+        )?;
         fs::remove_dir_all(&codex).ok();
 
+        assert_eq!(targets, plan, "对外同步计划必须与内部可执行目标完全一致");
         assert_eq!(
-            targets,
-            vec!["managed-source".to_string(), "legacy-session".to_string()]
+            plan,
+            vec!["legacy-session".to_string()],
+            "family 元数据不能把已经没有 active rollout 的孤儿记录变成不可执行的同步任务"
         );
         Ok(())
     }

--- a/src-tauri/src/repair.rs
+++ b/src-tauri/src/repair.rs
@@ -7626,6 +7626,113 @@ mod tests {
     }
 
     #[test]
+    fn prune_family_orphans_skips_family_when_missing_branch_lacks_index_entry() -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-prune-branch-index-gap-test");
+        write_rollout(&codex, "active-branch", DEFAULT_PROVIDER)?;
+        save_two_branch_family(
+            &codex,
+            "active-branch",
+            DEFAULT_PROVIDER,
+            "sessions/2026/04/22/rollout-active-branch.jsonl",
+            "missing-history",
+            "custom",
+            "archived_sessions/rollout-missing-history.jsonl",
+        )?;
+        let mut store = family::load(&codex)?;
+        store.index.remove("missing-history");
+        family::save(&codex, &store)?;
+        let before = serde_json::to_value(&store)?;
+
+        let report = prune_orphan_entries_with_lock(
+            codex.to_string_lossy().into_owned(),
+            false,
+            false,
+            true,
+            false,
+            &family::FamilyLock::default(),
+        )?;
+
+        assert_eq!(report.family_branches_removed, 0);
+        assert_eq!(report.families_removed, 0);
+        assert_eq!(report.families_skipped, vec!["active-branch".to_string()]);
+        assert_eq!(serde_json::to_value(family::load(&codex)?)?, before);
+        fs::remove_dir_all(&codex).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn prune_family_orphans_skips_families_sharing_a_duplicated_branch() -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-prune-cross-family-dup-test");
+        write_rollout(&codex, "active-a", DEFAULT_PROVIDER)?;
+        write_rollout(&codex, "active-b", DEFAULT_PROVIDER)?;
+        let dup_branch = FamilyBranch {
+            id: "dup-branch".to_string(),
+            provider: "custom".to_string(),
+            created_at: "2026-04-24T00:00:00Z".to_string(),
+            status: BranchStatus::Archived,
+            rollout_relpath: "archived_sessions/rollout-dup-branch.jsonl".to_string(),
+            sha256: None,
+            line_count: None,
+            note: None,
+        };
+        let make_family = |family_id: &str, active_id: &str| Family {
+            family_id: family_id.to_string(),
+            root_id: active_id.to_string(),
+            title: "dup family".to_string(),
+            chain: vec![
+                FamilyBranch {
+                    id: active_id.to_string(),
+                    provider: DEFAULT_PROVIDER.to_string(),
+                    created_at: "2026-04-24T00:00:00Z".to_string(),
+                    status: BranchStatus::Active,
+                    rollout_relpath: format!("sessions/2026/04/22/rollout-{active_id}.jsonl"),
+                    sha256: None,
+                    line_count: None,
+                    note: None,
+                },
+                dup_branch.clone(),
+            ],
+            active_id: active_id.to_string(),
+            updated_at: "2026-04-24T00:00:00Z".to_string(),
+        };
+        let mut families = BTreeMap::new();
+        families.insert("family-a".to_string(), make_family("family-a", "active-a"));
+        families.insert("family-b".to_string(), make_family("family-b", "active-b"));
+        let mut index = BTreeMap::new();
+        index.insert("active-a".to_string(), "family-a".to_string());
+        index.insert("active-b".to_string(), "family-b".to_string());
+        index.insert("dup-branch".to_string(), "family-a".to_string());
+        family::save(
+            &codex,
+            &FamilyStore {
+                version: 1,
+                families,
+                index,
+            },
+        )?;
+        let before = serde_json::to_value(family::load(&codex)?)?;
+
+        let report = prune_orphan_entries_with_lock(
+            codex.to_string_lossy().into_owned(),
+            false,
+            false,
+            true,
+            false,
+            &family::FamilyLock::default(),
+        )?;
+
+        assert_eq!(report.family_branches_removed, 0);
+        assert_eq!(report.families_removed, 0);
+        assert_eq!(
+            report.families_skipped,
+            vec!["family-a".to_string(), "family-b".to_string()]
+        );
+        assert_eq!(serde_json::to_value(family::load(&codex)?)?, before);
+        fs::remove_dir_all(&codex).ok();
+        Ok(())
+    }
+
+    #[test]
     fn prune_family_orphans_preserves_archived_rollouts() -> AppResult<()> {
         let codex = temp_codex_dir("cc-session-manager-prune-archived-family-test");
         write_rollout(&codex, "active-branch", DEFAULT_PROVIDER)?;

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -1262,6 +1262,10 @@ fn validate_delete_id(id: &str) -> AppResult<()> {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum CodexDeletePlanKey {
     Family(String),
+    Branch {
+        family_id: String,
+        branch_id: String,
+    },
     Session(String),
 }
 
@@ -1272,16 +1276,48 @@ fn delete_codex_targets_locked(
     let mut store = family::load(codex_dir)?;
     // Resolve every target before the first destructive write. A broken family/index mapping
     // must never leave a half-deleted logical conversation.
-    let plans = targets
+    let resolved = targets
         .iter()
         .map(|target| {
             validate_delete_id(&target.id)
                 .and_then(|()| family::resolve_family_id_strict(&store, &target.id))
-                .map(|family_id| match family_id {
-                    Some(id) => CodexDeletePlanKey::Family(id),
-                    None => CodexDeletePlanKey::Session(target.id.clone()),
+                .map(|family_id| {
+                    let is_active = family_id.as_ref().is_some_and(|family_id| {
+                        store
+                            .families
+                            .get(family_id)
+                            .is_some_and(|family| family.active_id == target.id)
+                    });
+                    (family_id, is_active)
                 })
                 .map_err(|error| error.to_string())
+        })
+        .collect::<Vec<_>>();
+    // 同一批次只要选中了 family 的 active 分支，仍按用户确认的“整组删除”执行；
+    // 这样 active + 历史分支混选时只进行一次物理删除，也保持输入结果顺序。
+    let families_selected_for_full_delete = resolved
+        .iter()
+        .filter_map(|resolution| match resolution {
+            Ok((Some(family_id), true)) => Some(family_id.clone()),
+            _ => None,
+        })
+        .collect::<HashSet<_>>();
+    let plans = targets
+        .iter()
+        .zip(resolved)
+        .map(|(target, resolution)| {
+            resolution.map(|(family_id, is_active)| match family_id {
+                Some(family_id)
+                    if is_active || families_selected_for_full_delete.contains(&family_id) =>
+                {
+                    CodexDeletePlanKey::Family(family_id)
+                }
+                Some(family_id) => CodexDeletePlanKey::Branch {
+                    family_id,
+                    branch_id: target.id.clone(),
+                },
+                None => CodexDeletePlanKey::Session(target.id.clone()),
+            })
         })
         .collect::<Vec<_>>();
 
@@ -1301,6 +1337,11 @@ fn delete_codex_targets_locked(
                     delete_codex_family_locked(codex_dir, &mut store, family_id, &target.id)
                         .unwrap_or_else(|error| failed_delete_result(target, error.to_string()))
                 }
+                CodexDeletePlanKey::Branch {
+                    family_id,
+                    branch_id,
+                } => delete_codex_family_branch_locked(codex_dir, &mut store, family_id, branch_id)
+                    .unwrap_or_else(|error| failed_delete_result(target, error.to_string())),
                 CodexDeletePlanKey::Session(id) => delete_codex_artifacts(codex_dir, id)
                     .map(|outcome| outcome.result)
                     .unwrap_or_else(|error| failed_delete_result(target, error.to_string())),
@@ -1315,6 +1356,60 @@ fn delete_codex_targets_locked(
         results.push(result);
     }
     Ok(results)
+}
+
+fn delete_codex_family_branch_locked(
+    codex_dir: &Path,
+    store: &mut crate::models::FamilyStore,
+    family_id: &str,
+    branch_id: &str,
+) -> AppResult<DeleteResult> {
+    let resolved_family_id = family::resolve_family_id_strict(store, branch_id)?
+        .ok_or_else(|| AppError::NotFound(format!("family branch: {branch_id}")))?;
+    if resolved_family_id != family_id {
+        return Err(AppError::Other(format!(
+            "分支 {branch_id} 属于 family {resolved_family_id}，请求却指定了 {family_id}"
+        )));
+    }
+    let family = store
+        .families
+        .get(family_id)
+        .ok_or_else(|| AppError::NotFound(format!("family: {family_id}")))?;
+    if family.active_id == branch_id {
+        return Err(AppError::Other(format!(
+            "不能单独删除 active 分支 {branch_id}"
+        )));
+    }
+
+    // 在删除物理数据前确认 family store 可写，避免普通权限问题留下半完成状态。
+    family::save(codex_dir, store)?;
+    let outcome = delete_codex_artifacts(codex_dir, branch_id)?;
+    let mut result = outcome.result;
+    if !outcome.structurally_removed {
+        if result.error.is_none() {
+            append_error(
+                &mut result,
+                format!("分支 {branch_id} 的核心记录未删除干净，family 元数据已保留"),
+            );
+        }
+        result.ok = false;
+        return Ok(result);
+    }
+
+    let before_metadata = store.clone();
+    if let Err(error) = family::remove_non_active_branch(store, family_id, branch_id)
+        .and_then(|_| family::save(codex_dir, store))
+    {
+        *store = before_metadata;
+        append_error(
+            &mut result,
+            format!("分支 {branch_id} 的文件已删除，但 family 元数据保存失败: {error}"),
+        );
+        result.ok = false;
+        return Ok(result);
+    }
+    result.ok = result.error.is_none();
+    Ok(result)
 }
 
 fn delete_codex_family_locked(
@@ -3689,6 +3784,81 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(remaining, 0);
+
+        drop(conn);
+        fs::remove_dir_all(codex).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn archived_list_delete_removes_only_selected_non_active_family_branch() -> AppResult<()> {
+        let codex = temp_dir("codex-delete-archived-family-branch");
+        let family_id = "family-archived-delete";
+        let archived_id = "019d-family-archived-delete-history";
+        let active_id = "019d-family-archived-delete-active";
+        let paths_by_id = codex_family_fixture(
+            &codex,
+            family_id,
+            active_id,
+            &[
+                FamilyBranchFixture {
+                    id: archived_id,
+                    archived: true,
+                },
+                FamilyBranchFixture {
+                    id: active_id,
+                    archived: false,
+                },
+            ],
+        )?;
+        let lock = family::FamilyLock::default();
+
+        let results = delete_sessions_with_lock(
+            Some("codex".to_string()),
+            codex.to_string_lossy().into_owned(),
+            None,
+            vec![archived_id.to_string()],
+            None,
+            &lock,
+        )?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, archived_id);
+        assert!(results[0].ok, "{:?}", results[0].error);
+        assert_eq!(results[0].threads_rows_deleted, 1);
+        assert!(!paths_by_id[archived_id].exists());
+        assert!(
+            paths_by_id[active_id].is_file(),
+            "删除归档分支绝不能删除仍在使用的 active rollout"
+        );
+
+        let store = family::load(&codex)?;
+        let family = store
+            .families
+            .get(family_id)
+            .expect("active family remains");
+        assert_eq!(family.active_id, active_id);
+        assert_eq!(family.chain.len(), 1);
+        assert_eq!(family.chain[0].id, active_id);
+        assert!(!store.index.contains_key(archived_id));
+        assert_eq!(
+            store.index.get(active_id).map(String::as_str),
+            Some(family_id)
+        );
+
+        let conn = rusqlite::Connection::open(paths::state_db_path(&codex))?;
+        let remaining: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM threads WHERE id IN (?1, ?2)",
+            params![archived_id, active_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(remaining, 1);
+        let remaining_id: String = conn.query_row(
+            "SELECT id FROM threads WHERE id IN (?1, ?2)",
+            params![archived_id, active_id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(remaining_id, active_id);
 
         drop(conn);
         fs::remove_dir_all(codex).ok();

--- a/src-tauri/src/webui.rs
+++ b/src-tauri/src/webui.rs
@@ -410,11 +410,13 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
             string_arg(&args, "codexDir")?,
             bool_arg(&args, "dryRun")?,
         )),
-        "prune_orphan_entries" => to_result_value(repair::prune_orphan_entries(
+        "prune_orphan_entries" => to_result_value(repair::prune_orphan_entries_with_lock(
             string_arg(&args, "codexDir")?,
             bool_arg(&args, "pruneIndex")?,
             bool_arg(&args, "pruneThreads")?,
+            bool_arg(&args, "pruneFamily")?,
             bool_arg(&args, "dryRun")?,
+            &state.family_lock,
         )),
         "diagnose_claude_history_orphans" => to_result_value(
             repair::diagnose_claude_history_orphans(string_arg(&args, "claudeDir")?),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CC Sessions",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "identifier": "dev.cc.session-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -388,6 +388,9 @@ export type ProjectConfigRepairReport = {
 export type OrphanPruneReport = {
   index_removed: number;
   threads_removed: number;
+  family_branches_removed: number;
+  families_removed: number;
+  families_skipped: string[];
   dry_run: boolean;
 };
 
@@ -1015,12 +1018,14 @@ export const api = {
     codex_dir: string;
     prune_index: boolean;
     prune_threads: boolean;
+    prune_family: boolean;
     dry_run: boolean;
   }) =>
     invokeCommand<OrphanPruneReport>("prune_orphan_entries", {
       codexDir: p.codex_dir,
       pruneIndex: p.prune_index,
       pruneThreads: p.prune_threads,
+      pruneFamily: p.prune_family,
       dryRun: p.dry_run,
     }),
   diagnoseClaudeHistoryOrphans: (claudeDir: string) =>

--- a/src/routes/repair.tsx
+++ b/src/routes/repair.tsx
@@ -63,6 +63,7 @@ import {
   type FamilyIntegrityReport,
   type GuiVisibilityReport,
   type HistoryOrphanReport,
+  type OrphanPruneReport,
   type ProjectConfigReport,
   type ProviderInfo,
   type SessionProvider,
@@ -86,7 +87,9 @@ function CodexRepairRoute() {
   const [strategy, setStrategy] = useState<SwitchStrategy>("continuous");
   const [confirmBatch, setConfirmBatch] = useState(false);
   const [confirmProjectConfigRepair, setConfirmProjectConfigRepair] = useState(false);
-  const [confirmPrune, setConfirmPrune] = useState<null | "index" | "threads">(null);
+  const [confirmPrune, setConfirmPrune] = useState<null | "index" | "threads" | "family">(
+    null,
+  );
   const [running, setRunning] = useState<string | null>(null);
   const [dryRun, setDryRun] = useState(false);
   const expectedThreadsCount =
@@ -95,6 +98,7 @@ function CodexRepairRoute() {
     diag == null
       ? undefined
       : `threads 表包含 ${diag.threads_active_count} 条活跃会话和 ${diag.threads_archived_count} 条本工具归档备份；归档备份存放在 archived_sessions/，不等同于 Codex 官方设置页的“已归档对话”。`;
+  const missingFamilyBranches = integrity?.items.filter((item) => item.missing).length ?? 0;
 
   const refresh = useCallback(async () => {
     if (!codexDir) return;
@@ -129,6 +133,18 @@ function CodexRepairRoute() {
       toast.error(String((e as Error)?.message ?? e));
     } finally {
       setRunning(null);
+    }
+  };
+
+  const showFamilyPruneResult = (report: OrphanPruneReport, preview: boolean) => {
+    const action = preview ? "预览：将移除" : "已移除";
+    const message = `${action} ${report.family_branches_removed} 个孤儿分支、${report.families_removed} 个空 family`;
+    if (report.families_skipped.length > 0) {
+      toast.warning(`${message}；跳过 ${report.families_skipped.length} 个需人工确认的 family`, {
+        description: report.families_skipped.slice(0, 3).join("\n"),
+      });
+    } else {
+      toast.success(message);
     }
   };
 
@@ -310,6 +326,7 @@ function CodexRepairRoute() {
                                   codex_dir: codexDir,
                                   prune_index: true,
                                   prune_threads: false,
+                                  prune_family: false,
                                   dry_run: true,
                                 });
                                 toast.success(
@@ -355,6 +372,7 @@ function CodexRepairRoute() {
                                   codex_dir: codexDir,
                                   prune_index: false,
                                   prune_threads: true,
+                                  prune_family: false,
                                   dry_run: true,
                                 });
                                 toast.success(
@@ -673,8 +691,8 @@ function CodexRepairRoute() {
                         <Info className="h-3.5 w-3.5 text-muted-foreground" />
                       </TooltipTrigger>
                       <TooltipContent className="max-w-sm text-xs">
-                        对每次克隆时归档的旧分支做 sha256 + 行数校验，
-                        发现文件被外部改过或丢失时会在这里亮红。
+                        检查 family 中各分支的 rollout 是否存在，并对已归档旧分支做 sha256 +
+                        行数校验。文件被外部改过或丢失时会在这里亮红。
                       </TooltipContent>
                     </Tooltip>
                   </CardTitle>
@@ -688,7 +706,7 @@ function CodexRepairRoute() {
                     </div>
                   ) : (
                     <div className="space-y-1.5">
-                      <div className="flex items-center gap-2 text-xs">
+                      <div className="flex flex-wrap items-center gap-2 text-xs">
                         {integrity.all_ok ? (
                           <>
                             <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500" />
@@ -703,6 +721,47 @@ function CodexRepairRoute() {
                             </span>
                           </>
                         )}
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              size="sm"
+                              variant={dryRun ? "outline" : "destructive"}
+                              onClick={() => {
+                                if (dryRun) {
+                                  void run("prune_family", async () => {
+                                    const report = await api.pruneOrphanEntries({
+                                      codex_dir: codexDir,
+                                      prune_index: false,
+                                      prune_threads: false,
+                                      prune_family: true,
+                                      dry_run: true,
+                                    });
+                                    showFamilyPruneResult(report, true);
+                                  });
+                                } else {
+                                  setConfirmPrune("family");
+                                }
+                              }}
+                              disabled={!!running || missingFamilyBranches === 0}
+                              className="ml-auto gap-1.5"
+                            >
+                              <Eraser className="h-3.5 w-3.5" />
+                              清理 family 残留
+                              {missingFamilyBranches > 0 && (
+                                <Badge
+                                  variant="outline"
+                                  className="ml-0.5 h-4 border-current/30 bg-background/20 px-1 text-[10px] font-normal"
+                                >
+                                  {missingFamilyBranches}
+                                </Badge>
+                              )}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-sm text-xs">
+                            清理 <code>session_family.json</code> 中已确认没有 rollout
+                            的空 family 或非 active 历史分支。若 active 文件缺失但仍有历史分支，会保留并提示人工确认。
+                          </TooltipContent>
+                        </Tooltip>
                       </div>
                       <div className="max-h-64 max-w-full overflow-auto rounded-md border">
                         <table className="w-full text-xs">
@@ -864,23 +923,33 @@ function CodexRepairRoute() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {confirmPrune === "index" ? "清理索引残留" : "清理数据库残留"}
+              {confirmPrune === "index"
+                ? "清理索引残留"
+                : confirmPrune === "threads"
+                  ? "清理数据库残留"
+                  : "清理 family 残留"}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              即将从{" "}
               {confirmPrune === "index" ? (
                 <>
-                  <code>session_index.jsonl</code> 删除{" "}
-                  <b>{diag?.orphan_in_index.length ?? 0}</b> 行
+                  即将从 <code>session_index.jsonl</code> 删除{" "}
+                  <b>{diag?.orphan_in_index.length ?? 0}</b> 行。这些条目指向的会话文件已经不存在，
+                  删除后不可撤销。对应的历史会话文件不会因此被再次修改。
+                </>
+              ) : confirmPrune === "threads" ? (
+                <>
+                  即将从应用数据库的 <code>threads</code> 表删除{" "}
+                  <b>{diag?.orphan_in_threads.length ?? 0}</b> 行。这些条目指向的会话文件已经不存在，
+                  删除后不可撤销。对应的历史会话文件不会因此被再次修改。
                 </>
               ) : (
                 <>
-                  应用数据库的 <code>threads</code> 表删除{" "}
-                  <b>{diag?.orphan_in_threads.length ?? 0}</b> 行
+                  即将检查 <code>session_family.json</code> 中的{" "}
+                  <b>{missingFamilyBranches}</b> 个缺失分支。只会自动删除没有任何 rollout 的空 family，
+                  或 active 文件仍存在时缺失的非 active 历史分支；active 文件缺失但仍有历史分支的
+                  family 会保留并报告，避免自动改变当前分支。
                 </>
               )}
-              。这些条目指向的会话文件已经不存在，删除后不可撤销。对应的历史会话文件
-              不会因此被再次修改。
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -891,18 +960,27 @@ function CodexRepairRoute() {
                 const kind = confirmPrune;
                 setConfirmPrune(null);
                 if (!kind) return;
-                void run(kind === "index" ? "prune_index" : "prune_threads", async () => {
+                const runKey =
+                  kind === "index"
+                    ? "prune_index"
+                    : kind === "threads"
+                      ? "prune_threads"
+                      : "prune_family";
+                void run(runKey, async () => {
                   const r = await api.pruneOrphanEntries({
                     codex_dir: codexDir,
                     prune_index: kind === "index",
                     prune_threads: kind === "threads",
+                    prune_family: kind === "family",
                     dry_run: false,
                   });
-                  toast.success(
-                    kind === "index"
-                      ? `已从 session_index 删除 ${r.index_removed} 行`
-                      : `已从 threads 表删除 ${r.threads_removed} 行`,
-                  );
+                  if (kind === "index") {
+                    toast.success(`已从 session_index 删除 ${r.index_removed} 行`);
+                  } else if (kind === "threads") {
+                    toast.success(`已从 threads 表删除 ${r.threads_removed} 行`);
+                  } else {
+                    showFamilyPruneResult(r, false);
+                  }
                   await refresh();
                 });
               }}

--- a/src/routes/sessions.tsx
+++ b/src/routes/sessions.tsx
@@ -885,26 +885,38 @@ function DeleteSummary({
 }) {
   const totalBytes = targets.reduce((a, b) => a + b.rollout_bytes, 0);
   const totalTokens = targets.reduce((a, b) => a + b.tokens_used, 0);
-  const logicalGroups = new Map<string, number>();
+  const familiesToDelete = new Map<string, number>();
   for (const target of targets) {
     const item = overlay.get(target.id);
-    const key = item?.family_id ? `family:${item.family_id}` : `session:${target.id}`;
-    logicalGroups.set(key, Math.max(logicalGroups.get(key) ?? 0, item?.branch_count ?? 1));
+    if (!item?.family_id || !item.is_active_branch) continue;
+    familiesToDelete.set(
+      item.family_id,
+      Math.max(familiesToDelete.get(item.family_id) ?? 0, item.branch_count || 1),
+    );
   }
-  const totalBranches = Array.from(logicalGroups.values()).reduce((sum, count) => sum + count, 0);
-  const deletesFamily = provider === "codex" && Array.from(logicalGroups.values()).some((count) => count > 1);
+  const totalFamilyBranches = Array.from(familiesToDelete.values()).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+  const scopedTargets = targets.filter((target) => {
+    const familyId = overlay.get(target.id)?.family_id;
+    return !familyId || !familiesToDelete.has(familyId);
+  }).length;
+  const deletesFamily = provider === "codex" && familiesToDelete.size > 0;
   return (
     <div className="min-w-0 max-w-full space-y-2 wrap-anywhere">
       <div className="min-w-0 whitespace-normal">
         {deletesFamily ? (
           <>
-            将删除 <b>{logicalGroups.size}</b> 条逻辑会话及其全部 <b>{totalBranches}</b> 个
-            provider/历史分支。各分支的 threads、日志、rollout 和索引都会一并清理；若只想删除某个历史分支，请在“分支历史”面板操作。
+            将整组删除 <b>{familiesToDelete.size}</b> 条 active 会话及其全部{" "}
+            <b>{totalFamilyBranches}</b> 个 provider/历史分支
+            {scopedTargets > 0 && <>，并单独删除另外 <b>{scopedTargets}</b> 个所选会话或历史分支</>}。
+            只有选中 family 的 active 分支才会整组删除；单独选中的非 active 历史分支不会影响当前 active 会话。
           </>
         ) : provider === "codex" ? (
           <>
-            将删除 <b>{targets.length}</b> 条所选逻辑会话对应的 threads、日志、rollout 与索引。
-            若其中会话属于 provider/历史分支组，后端会删除整个会话组的全部分支；只删除单个历史分支请进入“分支历史”面板。
+            将删除 <b>{targets.length}</b> 个所选会话或历史分支对应的 threads、日志、rollout 与索引。
+            非 active 历史分支只删除自身，不会影响同一 family 的当前 active 会话。
           </>
         ) : (
           <>


### PR DESCRIPTION
## 变更

- provider 同步计划只纳入 sessions/ 中实际存在的 active rollout，避免孤儿 family/threads 记录产生必然失败的批量同步任务。
- 缺少 active rollout 的记录不再展示 provider 同步操作。
- Codex 删除计划新增非 active family 分支级删除：归档历史分支只删除自身；选中 active 分支时仍保持整组删除语义。
- orphan 清理新增显式 family 元数据清理：
  - 所有 rollout 都缺失时移除整个空 family；
  - active rollout 存在时移除缺失的非 active 历史分支；
  - active rollout 缺失但仍有历史 rollout 时保留 family 并报告，避免自动切换用户状态；
  - active 与 archived rollout 都计入存活判断，dry-run 不写入。
- 删除作为 root_id 的历史分支后，将 root 修复为剩余 chain 的首个分支，避免悬空引用。
- 完整性检查现在会报告缺失的未固化 active rollout，并在修复页面提供 family 残留预览/清理入口。
- 桌面端、WebUI、交互式菜单和 CLI 共用 family 锁，并同步输出清理报告。

## 根因与影响

#18 的同步计划信任 family/threads 元数据，即使源 rollout 已不存在仍会加入任务，执行阶段因此报“未在 sessions/ 中找到”。原 orphan 清理又只处理 session_index.jsonl 与 threads，导致 session_family.json 残留无法收敛。

#19 的删除计划原先只有 Family 与 Session 两种类型，任何 family 成员都会被提升为整组删除，导致归档历史分支连带删除 active 分支；分支删除后也可能留下悬空 root_id。

归档列表继续按历史分支逐项展示，这是安全删除单个历史分支所需的交互，不做 family 折叠。

## 验证

- cargo test --manifest-path src-tauri/Cargo.toml --all-targets：223 个库测试 + 5 个 CLI 测试全部通过
- npm run build：通过
- cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check：通过
- git diff --check：通过

新增回归覆盖：完整缺失 family、缺失非 active 分支、dry-run、archived rollout 保留、缺失 active 时保守跳过、未固化 active 缺失可见，以及删除 root 分支后的 root_id 修复。

## 发布

- 版本号已统一更新为 0.4.7：package、Cargo 与 Tauri 元数据保持一致。
- 合并后通过 v0.4.7 tag 触发多平台 Release workflow。
- Release 正文仅保留 0.4.7 的本次修复记录。

Fixes #18
Fixes #19