### PR TITLE
feat(sessions): 增加对话全文搜索

### DIFF
--- a/src-tauri/src/claude_sessions.rs
+++ b/src-tauri/src/claude_sessions.rs
@@ -2,11 +2,12 @@ use std::collections::VecDeque;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 
 use chrono::{DateTime, FixedOffset};
 use serde_json::Value;
 
-use crate::error::AppResult;
+use crate::error::{ensure_not_cancelled, AppResult};
 use crate::models::{PreviewEvent, SessionMetaBrief, SessionSummary};
 use crate::{fs_ops, paths};
 
@@ -16,17 +17,33 @@ const TITLE_MAX_CHARS: usize = 80;
 const PREVIEW_CAPACITY_HINT_MAX: usize = 1024;
 
 pub fn scan_sessions(claude_dir: &Path) -> AppResult<Vec<SessionSummary>> {
+    scan_sessions_impl(claude_dir, None)
+}
+
+pub fn scan_sessions_cancellable(
+    claude_dir: &Path,
+    cancel: &AtomicBool,
+) -> AppResult<Vec<SessionSummary>> {
+    scan_sessions_impl(claude_dir, Some(cancel))
+}
+
+fn scan_sessions_impl(
+    claude_dir: &Path,
+    cancel: Option<&AtomicBool>,
+) -> AppResult<Vec<SessionSummary>> {
+    ensure_not_cancelled(cancel)?;
     let root = paths::claude_projects_dir(claude_dir);
     if !root.is_dir() {
         return Ok(Vec::new());
     }
 
     let mut files = Vec::new();
-    collect_jsonl_files(&root, &mut files)?;
+    collect_jsonl_files(&root, &mut files, cancel)?;
 
     let mut sessions = Vec::new();
     for file in files {
-        if let Some(session) = parse_session(&file)? {
+        ensure_not_cancelled(cancel)?;
+        if let Some(session) = parse_session(&file, cancel)? {
             sessions.push(session);
         }
     }
@@ -139,7 +156,7 @@ pub fn sidecar_path_for(source_path: &Path) -> Option<PathBuf> {
     Some(source_path.with_file_name(stem))
 }
 
-fn parse_session(path: &Path) -> AppResult<Option<SessionSummary>> {
+fn parse_session(path: &Path, cancel: Option<&AtomicBool>) -> AppResult<Option<SessionSummary>> {
     let is_subagent = is_agent_session(path);
     let file = File::open(path)?;
     let reader = BufReader::new(file);
@@ -161,6 +178,7 @@ fn parse_session(path: &Path) -> AppResult<Option<SessionSummary>> {
     let mut reasoning_effort: Option<String> = None;
 
     for line in reader.lines() {
+        ensure_not_cancelled(cancel)?;
         let line = line?;
         if line.trim().is_empty() {
             continue;
@@ -402,12 +420,17 @@ fn claude_non_message_summary(raw: &Value) -> String {
         .to_string()
 }
 
-fn collect_jsonl_files(root: &Path, files: &mut Vec<PathBuf>) -> AppResult<()> {
+fn collect_jsonl_files(
+    root: &Path,
+    files: &mut Vec<PathBuf>,
+    cancel: Option<&AtomicBool>,
+) -> AppResult<()> {
     for entry in fs::read_dir(root)? {
+        ensure_not_cancelled(cancel)?;
         let entry = entry?;
         let path = entry.path();
         if path.is_dir() {
-            collect_jsonl_files(&path, files)?;
+            collect_jsonl_files(&path, files, cancel)?;
         } else if path.extension().and_then(|ext| ext.to_str()) == Some("jsonl") {
             files.push(path);
         }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -27,6 +27,40 @@ where
 }
 
 #[tauri::command]
+pub fn start_content_search(
+    provider: String,
+    codex_dir: String,
+    claude_dir: String,
+    query: String,
+    show_subagent_sessions: bool,
+    show_archived_sessions: bool,
+) -> AppResult<ContentSearchStart> {
+    crate::content_search::start_content_search(
+        provider,
+        codex_dir,
+        claude_dir,
+        query,
+        show_subagent_sessions,
+        show_archived_sessions,
+    )
+}
+
+#[tauri::command]
+pub fn content_search_status(job_id: u64) -> AppResult<ContentSearchStatus> {
+    crate::content_search::content_search_status(job_id)
+}
+
+#[tauri::command]
+pub fn active_content_search() -> AppResult<Option<ContentSearchStart>> {
+    crate::content_search::active_content_search()
+}
+
+#[tauri::command]
+pub fn cancel_content_search(job_id: u64) -> AppResult<()> {
+    crate::content_search::cancel_content_search(job_id)
+}
+
+#[tauri::command]
 pub async fn create_backup(
     provider: Option<String>,
     codex_dir: String,

--- a/src-tauri/src/content_search.rs
+++ b/src-tauri/src/content_search.rs
@@ -1,0 +1,649 @@
+//! Explicit, in-process conversation content search.
+//!
+//! Data flow:
+//! 1. The UI starts one job with an explicit provider and visibility scope.
+//! 2. A single worker streams matching rollout files without creating an index.
+//! 3. Existing preview classifiers decide which JSONL rows are real conversation messages.
+//! 4. The UI polls a bounded status snapshot and may cancel the active job.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::thread;
+
+use serde_json::Value;
+
+use crate::error::{AppError, AppResult};
+use crate::models::{
+    ContentSearchMatch, ContentSearchResult, ContentSearchStart, ContentSearchStatus,
+    SessionSummary,
+};
+use crate::{rollout, sessions};
+
+const MAX_MATCHING_SESSIONS: usize = 100;
+const MAX_MATCHES_PER_SESSION: usize = 3;
+const MAX_QUERY_CHARS: usize = 256;
+const PROGRESS_STEP_BYTES: u64 = 4 * 1024 * 1024;
+const SNIPPET_BEFORE_CHARS: usize = 72;
+const SNIPPET_AFTER_CHARS: usize = 160;
+
+#[derive(Clone)]
+struct SearchJob {
+    id: u64,
+    cancel: Arc<AtomicBool>,
+    status: Arc<Mutex<ContentSearchStatus>>,
+}
+
+struct SearchManager {
+    next_id: AtomicU64,
+    active: Mutex<Option<SearchJob>>,
+}
+
+struct SearchRequest {
+    provider: String,
+    codex_dir: String,
+    claude_dir: String,
+    query: String,
+    show_subagent_sessions: bool,
+    show_archived_sessions: bool,
+}
+
+struct FileScanOutcome {
+    matches: Vec<ContentSearchMatch>,
+    bytes_read: u64,
+    cancelled: bool,
+    missing: bool,
+}
+
+impl SearchManager {
+    fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            active: Mutex::new(None),
+        }
+    }
+
+    fn start(&self, request: SearchRequest) -> AppResult<ContentSearchStart> {
+        validate_request(&request)?;
+
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some(job) = active.as_ref() {
+            let status = job.status.lock().unwrap_or_else(|error| error.into_inner());
+            if status.state == "running" {
+                return Err(AppError::Other(
+                    "已有全文搜索正在运行，请先停止当前搜索".to_string(),
+                ));
+            }
+        }
+
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let job = SearchJob {
+            id,
+            cancel: Arc::new(AtomicBool::new(false)),
+            status: Arc::new(Mutex::new(ContentSearchStatus {
+                job_id: id,
+                state: "running".to_string(),
+                query: request.query.clone(),
+                scanned_files: 0,
+                total_files: 0,
+                skipped_files: 0,
+                scanned_bytes: 0,
+                total_bytes: 0,
+                results: Vec::new(),
+                truncated: false,
+                error: None,
+            })),
+        };
+        let worker_job = job.clone();
+        thread::Builder::new()
+            .name("cc-sessions-content-search".to_string())
+            .spawn(move || run_job(worker_job, request))
+            .map_err(|error| AppError::Other(format!("无法启动全文搜索任务: {error}")))?;
+        *active = Some(job);
+        Ok(ContentSearchStart { job_id: id })
+    }
+
+    fn status(&self, job_id: u64) -> AppResult<ContentSearchStatus> {
+        let active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let job = active
+            .as_ref()
+            .filter(|job| job.id == job_id)
+            .ok_or_else(|| AppError::NotFound(format!("全文搜索任务 {job_id}")))?;
+        let snapshot = job
+            .status
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clone();
+        Ok(snapshot)
+    }
+
+    fn active(&self) -> Option<ContentSearchStart> {
+        let active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let job = active.as_ref()?;
+        let status = job.status.lock().unwrap_or_else(|error| error.into_inner());
+        (status.state == "running").then_some(ContentSearchStart { job_id: job.id })
+    }
+
+    fn cancel(&self, job_id: u64) -> AppResult<()> {
+        let active = self
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let job = active
+            .as_ref()
+            .filter(|job| job.id == job_id)
+            .ok_or_else(|| AppError::NotFound(format!("全文搜索任务 {job_id}")))?;
+        let status = job.status.lock().unwrap_or_else(|error| error.into_inner());
+        if status.state == "running" {
+            job.cancel.store(true, Ordering::Release);
+        }
+        Ok(())
+    }
+}
+
+fn manager() -> &'static SearchManager {
+    static MANAGER: OnceLock<SearchManager> = OnceLock::new();
+    MANAGER.get_or_init(SearchManager::new)
+}
+
+pub fn start_content_search(
+    provider: String,
+    codex_dir: String,
+    claude_dir: String,
+    query: String,
+    show_subagent_sessions: bool,
+    show_archived_sessions: bool,
+) -> AppResult<ContentSearchStart> {
+    manager().start(SearchRequest {
+        provider,
+        codex_dir,
+        claude_dir,
+        query: query.trim().to_string(),
+        show_subagent_sessions,
+        show_archived_sessions,
+    })
+}
+
+pub fn content_search_status(job_id: u64) -> AppResult<ContentSearchStatus> {
+    manager().status(job_id)
+}
+
+pub fn active_content_search() -> AppResult<Option<ContentSearchStart>> {
+    Ok(manager().active())
+}
+
+pub fn cancel_content_search(job_id: u64) -> AppResult<()> {
+    manager().cancel(job_id)
+}
+
+fn validate_request(request: &SearchRequest) -> AppResult<()> {
+    if !matches!(request.provider.as_str(), "codex" | "claude") {
+        return Err(AppError::Other(format!(
+            "不支持的 provider: {}",
+            request.provider
+        )));
+    }
+    if request.query.chars().count() < 2 {
+        return Err(AppError::Other(
+            "全文搜索关键词至少需要 2 个字符".to_string(),
+        ));
+    }
+    if request.query.chars().count() > MAX_QUERY_CHARS {
+        return Err(AppError::Other(format!(
+            "全文搜索关键词不能超过 {MAX_QUERY_CHARS} 个字符"
+        )));
+    }
+    if request.codex_dir.trim().is_empty() {
+        return Err(AppError::Other("Codex 目录不能为空".to_string()));
+    }
+    if request.claude_dir.trim().is_empty() {
+        return Err(AppError::Other("Claude 目录不能为空".to_string()));
+    }
+    if request.query.chars().any(char::is_control) {
+        return Err(AppError::Other(
+            "全文搜索关键词不能包含控制字符".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn run_job(job: SearchJob, request: SearchRequest) {
+    let result = execute_search(&job, &request);
+    let mut status = job.status.lock().unwrap_or_else(|error| error.into_inner());
+    match result {
+        Ok(()) if job.cancel.load(Ordering::Acquire) => {
+            status.state = "cancelled".to_string();
+        }
+        Ok(()) => {
+            status.state = "completed".to_string();
+        }
+        Err(AppError::Cancelled) => {
+            status.state = "cancelled".to_string();
+        }
+        Err(error) => {
+            status.state = "failed".to_string();
+            status.error = Some(error.to_string());
+        }
+    }
+}
+
+fn execute_search(job: &SearchJob, request: &SearchRequest) -> AppResult<()> {
+    let sessions = sessions::list_sessions_cancellable(
+        Some(request.provider.clone()),
+        request.codex_dir.clone(),
+        Some(request.claude_dir.clone()),
+        &job.cancel,
+    )?
+    .into_iter()
+    .filter(|session| {
+        sessions::session_is_subagent(session) == request.show_subagent_sessions
+            && (request.provider != "codex" || session.archived == request.show_archived_sessions)
+    })
+    .collect::<Vec<_>>();
+
+    if job.cancel.load(Ordering::Acquire) {
+        return Ok(());
+    }
+
+    let total_bytes = sessions.iter().map(|session| session.rollout_bytes).sum();
+    {
+        let mut status = job.status.lock().unwrap_or_else(|error| error.into_inner());
+        status.total_files = sessions.len();
+        status.total_bytes = total_bytes;
+    }
+
+    let mut completed_bytes = 0u64;
+    for session in sessions {
+        if job.cancel.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let outcome = scan_session(job, &session, &request.query, completed_bytes)?;
+        if outcome.cancelled {
+            return Ok(());
+        }
+        completed_bytes = completed_bytes.saturating_add(if outcome.missing {
+            session.rollout_bytes
+        } else {
+            outcome.bytes_read
+        });
+
+        let mut status = job.status.lock().unwrap_or_else(|error| error.into_inner());
+        status.scanned_files += 1;
+        status.scanned_bytes = completed_bytes.min(status.total_bytes);
+        if outcome.missing {
+            status.skipped_files += 1;
+            continue;
+        }
+        if !outcome.matches.is_empty() {
+            status.results.push(ContentSearchResult {
+                session,
+                matches: outcome.matches,
+            });
+            if status.results.len() >= MAX_MATCHING_SESSIONS {
+                status.truncated = status.scanned_files < status.total_files;
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn scan_session(
+    job: &SearchJob,
+    session: &SessionSummary,
+    query: &str,
+    completed_bytes: u64,
+) -> AppResult<FileScanOutcome> {
+    let file = match File::open(&session.rollout_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(FileScanOutcome {
+                matches: Vec::new(),
+                bytes_read: 0,
+                cancelled: false,
+                missing: true,
+            });
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    let mut line_index = 0usize;
+    let mut event_offset = 0usize;
+    let mut bytes_read = 0u64;
+    let mut reported_bytes = 0u64;
+    let mut matches = Vec::new();
+    let escaped_query = json_string_content(query);
+
+    loop {
+        if job.cancel.load(Ordering::Acquire) {
+            return Ok(FileScanOutcome {
+                matches,
+                bytes_read,
+                cancelled: true,
+                missing: false,
+            });
+        }
+        line.clear();
+        let count = reader.read_line(&mut line)?;
+        if count == 0 {
+            break;
+        }
+        bytes_read = bytes_read.saturating_add(count as u64);
+        if bytes_read.saturating_sub(reported_bytes) >= PROGRESS_STEP_BYTES {
+            reported_bytes = bytes_read;
+            let mut status = job.status.lock().unwrap_or_else(|error| error.into_inner());
+            status.scanned_bytes = completed_bytes
+                .saturating_add(bytes_read)
+                .min(status.total_bytes);
+        }
+
+        let current_line_index = line_index;
+        line_index += 1;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let current_offset = event_offset;
+        event_offset += 1;
+        if matches.len() >= MAX_MATCHES_PER_SESSION
+            || !line_might_contain_query(&line, query, &escaped_query)
+        {
+            continue;
+        }
+
+        let Ok(raw) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let Some(event) = classify_event(&session.provider, current_line_index, raw) else {
+            continue;
+        };
+        let mixed_assistant_text = rollout::preview_event_has_assistant_text_tool_use(&event);
+        if !rollout::preview_event_is_conversation(&event) && !mixed_assistant_text {
+            continue;
+        }
+        let text = rollout::preview_event_text(&event);
+        if find_query(&text, query).is_none() {
+            continue;
+        }
+        matches.push(ContentSearchMatch {
+            event_index: event.index,
+            event_offset: current_offset,
+            timestamp: event.timestamp,
+            role: if mixed_assistant_text {
+                "assistant".to_string()
+            } else {
+                event.role
+            },
+            snippet: make_snippet(&text, query),
+        });
+    }
+
+    Ok(FileScanOutcome {
+        matches,
+        bytes_read,
+        cancelled: false,
+        missing: false,
+    })
+}
+
+fn classify_event(provider: &str, index: usize, raw: Value) -> Option<crate::models::PreviewEvent> {
+    match provider {
+        "codex" => Some(rollout::classify_preview(index, raw)),
+        "claude" => crate::claude_sessions::classify_preview(index, raw),
+        _ => None,
+    }
+}
+
+fn find_query(text: &str, query: &str) -> Option<usize> {
+    if query.is_ascii() {
+        text.as_bytes()
+            .windows(query.len())
+            .position(|window| window.eq_ignore_ascii_case(query.as_bytes()))
+    } else {
+        text.find(query)
+    }
+}
+
+fn json_string_content(text: &str) -> String {
+    let encoded = serde_json::to_string(text).expect("serializing a string cannot fail");
+    encoded[1..encoded.len() - 1].to_string()
+}
+
+fn line_might_contain_query(line: &str, query: &str, escaped_query: &str) -> bool {
+    find_query(line, query).is_some()
+        || (escaped_query != query && find_query(line, escaped_query).is_some())
+}
+
+fn make_snippet(text: &str, query: &str) -> String {
+    let Some(position) = find_query(text, query) else {
+        return String::new();
+    };
+    let before = text[..position]
+        .chars()
+        .rev()
+        .take(SNIPPET_BEFORE_CHARS)
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect::<String>();
+    let match_and_after = text[position..]
+        .chars()
+        .take(query.chars().count() + SNIPPET_AFTER_CHARS)
+        .collect::<String>();
+    let mut snippet = compact_whitespace(&format!("{before}{match_and_after}"));
+    if before.chars().count() == SNIPPET_BEFORE_CHARS {
+        snippet.insert_str(0, "...");
+    }
+    if text[position..].chars().count() > query.chars().count() + SNIPPET_AFTER_CHARS {
+        snippet.push_str("...");
+    }
+    snippet
+}
+
+fn compact_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use serde_json::json;
+
+    use super::*;
+
+    fn temp_file(name: &str, lines: &[Value]) -> std::path::PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("cc-sessions-search-{name}-{unique}"));
+        fs::create_dir_all(&dir).expect("temp dir");
+        let path = dir.join("session.jsonl");
+        let body = lines
+            .iter()
+            .map(|line| serde_json::to_string(line).expect("json"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&path, format!("{body}\n")).expect("fixture");
+        path
+    }
+
+    fn session(provider: &str, path: &std::path::Path) -> SessionSummary {
+        SessionSummary {
+            provider: provider.to_string(),
+            id: "search-session".to_string(),
+            resume_command: String::new(),
+            rollout_path: path.to_string_lossy().into_owned(),
+            cwd: "/tmp/project".to_string(),
+            cwd_display: "project".to_string(),
+            title: "Search session".to_string(),
+            first_user_message: "first".to_string(),
+            model: None,
+            reasoning_effort: None,
+            source: None,
+            agent_nickname: None,
+            agent_role: None,
+            conversion_origin: None,
+            tokens_used: 0,
+            created_at: 0,
+            updated_at: 0,
+            archived: false,
+            git_branch: None,
+            rollout_bytes: fs::metadata(path).expect("metadata").len(),
+            logs_count: 0,
+            has_backup: false,
+        }
+    }
+
+    fn test_job() -> SearchJob {
+        SearchJob {
+            id: 1,
+            cancel: Arc::new(AtomicBool::new(false)),
+            status: Arc::new(Mutex::new(ContentSearchStatus {
+                job_id: 1,
+                state: "running".to_string(),
+                query: "needle".to_string(),
+                scanned_files: 0,
+                total_files: 1,
+                skipped_files: 0,
+                scanned_bytes: 0,
+                total_bytes: u64::MAX,
+                results: Vec::new(),
+                truncated: false,
+                error: None,
+            })),
+        }
+    }
+
+    #[test]
+    fn searches_later_codex_conversation_messages_only() {
+        let path = temp_file(
+            "codex",
+            &[
+                json!({"type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"first prompt"}]}}),
+                json!({"type":"event_msg","payload":{"type":"user_message","message":"later needle prompt"}}),
+                json!({"type":"response_item","payload":{"type":"message","role":"user","content":[{"text":"later needle prompt"}]}}),
+                json!({"type":"response_item","payload":{"type":"function_call_output","output":"needle in tool output"}}),
+                json!({"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"later needle answer"}]}}),
+            ],
+        );
+        let result =
+            scan_session(&test_job(), &session("codex", &path), "needle", 0).expect("search");
+        assert_eq!(result.matches.len(), 2);
+        assert_eq!(result.matches[0].role, "user");
+        assert_eq!(result.matches[0].event_index, 2);
+        assert_eq!(result.matches[1].role, "assistant");
+        assert_eq!(result.matches[1].event_index, 4);
+        fs::remove_dir_all(path.parent().expect("parent")).ok();
+    }
+
+    #[test]
+    fn searches_later_claude_user_messages() {
+        let path = temp_file(
+            "claude",
+            &[
+                json!({"type":"user","message":{"role":"user","content":"first prompt"}}),
+                json!({"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"needle reasoning"}]}}),
+                json!({"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"needle_tool","input":{"query":"needle"}}]}}),
+                json!({"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"assistant needle answer"},{"type":"tool_use","name":"Search","input":{}}]}}),
+                json!({"type":"user","message":{"role":"user","content":"later needle prompt"}}),
+            ],
+        );
+        let result =
+            scan_session(&test_job(), &session("claude", &path), "needle", 0).expect("search");
+        assert_eq!(result.matches.len(), 2);
+        assert_eq!(result.matches[0].role, "assistant");
+        assert_eq!(result.matches[0].event_index, 3);
+        assert_eq!(result.matches[1].role, "user");
+        assert_eq!(result.matches[1].event_index, 4);
+        fs::remove_dir_all(path.parent().expect("parent")).ok();
+    }
+
+    #[test]
+    fn searches_text_that_is_escaped_in_json() {
+        let path = temp_file(
+            "escaped",
+            &[
+                json!({"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"text":"say \"needle\" here"}]}}),
+            ],
+        );
+        let result =
+            scan_session(&test_job(), &session("codex", &path), "\"needle\"", 0).expect("search");
+        assert_eq!(result.matches.len(), 1);
+        assert_eq!(result.matches[0].snippet, "say \"needle\" here");
+        fs::remove_dir_all(path.parent().expect("parent")).ok();
+    }
+
+    #[test]
+    fn marks_missing_rollout_without_failing_the_search() {
+        let path = temp_file("missing", &[json!({"type":"session_meta"})]);
+        let missing_session = session("codex", &path);
+        fs::remove_dir_all(path.parent().expect("parent")).expect("remove fixture");
+
+        let outcome = scan_session(&test_job(), &missing_session, "needle", 0)
+            .expect("missing rollout should be a counted search outcome");
+
+        assert!(outcome.missing);
+        assert!(!outcome.cancelled);
+        assert_eq!(outcome.bytes_read, 0);
+        assert!(outcome.matches.is_empty());
+    }
+
+    #[test]
+    fn cancellation_stops_before_claude_discovery_reads_session_files() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("cc-sessions-cancel-{unique}"));
+        let claude_dir = root.join("claude");
+        let project_dir = claude_dir.join("projects").join("project");
+        fs::create_dir_all(&project_dir).expect("project dir");
+        fs::write(project_dir.join("invalid.jsonl"), [0xff]).expect("invalid fixture");
+
+        let job = test_job();
+        job.cancel.store(true, Ordering::Release);
+        let request = SearchRequest {
+            provider: "claude".to_string(),
+            codex_dir: root.join("codex").to_string_lossy().into_owned(),
+            claude_dir: claude_dir.to_string_lossy().into_owned(),
+            query: "needle".to_string(),
+            show_subagent_sessions: false,
+            show_archived_sessions: false,
+        };
+
+        let result = execute_search(&job, &request);
+        fs::remove_dir_all(root).ok();
+
+        assert!(matches!(result, Err(AppError::Cancelled)));
+    }
+
+    #[test]
+    fn active_search_is_discoverable_only_while_running() {
+        let manager = SearchManager::new();
+        let job = test_job();
+        *manager
+            .active
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) = Some(job.clone());
+
+        assert_eq!(manager.active().expect("running job").job_id, job.id);
+        job.status
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .state = "completed".to_string();
+        assert!(manager.active().is_none());
+    }
+}

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -1,4 +1,5 @@
 use serde::{Serialize, Serializer};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
@@ -15,6 +16,8 @@ pub enum AppError {
     InvalidCodexDir(String),
     #[error("not found: {0}")]
     NotFound(String),
+    #[error("cancelled")]
+    Cancelled,
     #[error("{0}")]
     Other(String),
 }
@@ -32,3 +35,11 @@ impl Serialize for AppError {
 }
 
 pub type AppResult<T> = Result<T, AppError>;
+
+pub fn ensure_not_cancelled(cancel: Option<&AtomicBool>) -> AppResult<()> {
+    if cancel.is_some_and(|flag| flag.load(Ordering::Acquire)) {
+        Err(AppError::Cancelled)
+    } else {
+        Ok(())
+    }
+}

--- a/src-tauri/src/family.rs
+++ b/src-tauri/src/family.rs
@@ -10,13 +10,13 @@
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
-use crate::error::{AppError, AppResult};
+use crate::error::{ensure_not_cancelled, AppError, AppResult};
 use crate::models::{
     BranchStatus, Family, FamilyBranch, FamilyIntegrityItem, FamilyIntegrityReport, FamilyOverlay,
     FamilyStore,
@@ -795,8 +795,9 @@ pub fn read_session_meta(rollout: &Path) -> AppResult<Value> {
     Ok(v)
 }
 
-fn scan_rollouts_in(root: PathBuf) -> AppResult<Vec<PathBuf>> {
+fn scan_rollouts_in(root: PathBuf, cancel: Option<&AtomicBool>) -> AppResult<Vec<PathBuf>> {
     let mut out = Vec::new();
+    ensure_not_cancelled(cancel)?;
     let metadata = match fs::symlink_metadata(&root) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(out),
@@ -809,6 +810,7 @@ fn scan_rollouts_in(root: PathBuf) -> AppResult<Vec<PathBuf>> {
         )));
     }
     for entry in walkdir::WalkDir::new(&root).follow_links(false) {
+        ensure_not_cancelled(cancel)?;
         let entry = entry.map_err(|error| {
             AppError::Other(format!(
                 "扫描 rollout 目录失败 {}: {error}",
@@ -835,12 +837,19 @@ fn scan_rollouts_in(root: PathBuf) -> AppResult<Vec<PathBuf>> {
 
 /// 扫描 sessions/ 目录下所有 active `rollout-*.jsonl`。
 pub fn scan_rollouts(codex_dir: &Path) -> AppResult<Vec<PathBuf>> {
-    scan_rollouts_in(paths::sessions_dir(codex_dir))
+    scan_rollouts_in(paths::sessions_dir(codex_dir), None)
 }
 
 /// 扫描 archived_sessions/ 目录下所有 archived `rollout-*.jsonl`。
 pub fn scan_archived_rollouts(codex_dir: &Path) -> AppResult<Vec<PathBuf>> {
-    scan_rollouts_in(paths::archived_sessions_dir(codex_dir))
+    scan_rollouts_in(paths::archived_sessions_dir(codex_dir), None)
+}
+
+pub(crate) fn scan_archived_rollouts_cancellable(
+    codex_dir: &Path,
+    cancel: &AtomicBool,
+) -> AppResult<Vec<PathBuf>> {
+    scan_rollouts_in(paths::archived_sessions_dir(codex_dir), Some(cancel))
 }
 
 pub fn get_family_store_with_lock(codex_dir: String, lock: &FamilyLock) -> AppResult<FamilyStore> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bundle;
 pub mod claude_sessions;
 #[cfg(feature = "desktop")]
 pub mod commands;
+pub mod content_search;
 pub mod convert;
 pub mod edit;
 pub mod error;
@@ -70,6 +71,10 @@ pub fn run() {
             commands::list_sessions,
             commands::group_sessions_by_project,
             commands::search_sessions,
+            commands::start_content_search,
+            commands::content_search_status,
+            commands::active_content_search,
+            commands::cancel_content_search,
             commands::set_archived,
             commands::rename_session,
             commands::move_session_cwd,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -82,6 +82,41 @@ pub struct SessionSummary {
     pub resume_command: String,
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct ContentSearchMatch {
+    pub event_index: usize,
+    pub event_offset: usize,
+    pub timestamp: String,
+    pub role: String,
+    pub snippet: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContentSearchResult {
+    pub session: SessionSummary,
+    pub matches: Vec<ContentSearchMatch>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContentSearchStart {
+    pub job_id: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContentSearchStatus {
+    pub job_id: u64,
+    pub state: String,
+    pub query: String,
+    pub scanned_files: usize,
+    pub total_files: usize,
+    pub skipped_files: usize,
+    pub scanned_bytes: u64,
+    pub total_bytes: u64,
+    pub results: Vec<ContentSearchResult>,
+    pub truncated: bool,
+    pub error: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SessionConversionOrigin {
     pub source_provider: String,

--- a/src-tauri/src/repair.rs
+++ b/src-tauri/src/repair.rs
@@ -10,11 +10,12 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 
 use serde_json::Value;
 
 use crate::atomic_file;
-use crate::error::{AppError, AppResult};
+use crate::error::{ensure_not_cancelled, AppError, AppResult};
 use crate::family;
 use crate::models::{
     BranchStatus, BranchSyncReport, BranchSyncState, CloneReport, DiagnosticReport,
@@ -662,6 +663,23 @@ fn scan_active_rollout_identities(codex: &Path) -> AppResult<Vec<(PathBuf, Rollo
 }
 
 pub(crate) fn read_rollout_brief(codex_dir: &Path, path: &Path) -> AppResult<Option<RolloutBrief>> {
+    read_rollout_brief_impl(codex_dir, path, None)
+}
+
+pub(crate) fn read_rollout_brief_cancellable(
+    codex_dir: &Path,
+    path: &Path,
+    cancel: &AtomicBool,
+) -> AppResult<Option<RolloutBrief>> {
+    read_rollout_brief_impl(codex_dir, path, Some(cancel))
+}
+
+fn read_rollout_brief_impl(
+    codex_dir: &Path,
+    path: &Path,
+    cancel: Option<&AtomicBool>,
+) -> AppResult<Option<RolloutBrief>> {
+    ensure_not_cancelled(cancel)?;
     let f = fs::File::open(path)?;
     let reader = BufReader::new(f);
     let mut id: Option<String> = None;
@@ -678,6 +696,7 @@ pub(crate) fn read_rollout_brief(codex_dir: &Path, path: &Path) -> AppResult<Opt
     let mut created_ms: i64 = 0;
     let mut last_ms: i64 = 0;
     for (i, line) in reader.lines().enumerate() {
+        ensure_not_cancelled(cancel)?;
         let line = line?;
         if line.trim().is_empty() {
             continue;

--- a/src-tauri/src/rollout.rs
+++ b/src-tauri/src/rollout.rs
@@ -1,10 +1,11 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 
 use serde_json::Value;
 
-use crate::error::AppResult;
+use crate::error::{ensure_not_cancelled, AppResult};
 use crate::models::{
     PreviewEvent, SessionMetaBrief, TimelineMessageBrief, UserPromptBrief, UserPromptList,
 };
@@ -112,6 +113,10 @@ fn classify(index: usize, raw: Value) -> PreviewEvent {
     }
 }
 
+pub(crate) fn classify_preview(index: usize, raw: Value) -> PreviewEvent {
+    classify(index, raw)
+}
+
 fn subagent_activity_summary(raw: &Value) -> String {
     let payload = raw.get("payload");
     let agent = payload
@@ -202,6 +207,34 @@ pub fn preview_event_is_conversation(event: &PreviewEvent) -> bool {
     }
 
     raw_type(event) == "response_item" && payload_type(event) == "message"
+}
+
+pub(crate) fn preview_event_has_assistant_text_tool_use(event: &PreviewEvent) -> bool {
+    if event.role != "tool_call" {
+        return false;
+    }
+    let Some(message) = event.raw.get("message") else {
+        return false;
+    };
+    if message.get("role").and_then(Value::as_str) != Some("assistant") {
+        return false;
+    }
+    message
+        .get("content")
+        .and_then(Value::as_array)
+        .is_some_and(|items| {
+            let has_tool_use = items
+                .iter()
+                .any(|item| item.get("type").and_then(Value::as_str) == Some("tool_use"));
+            let has_text = items.iter().any(|item| {
+                item.get("type").and_then(Value::as_str) == Some("text")
+                    && item
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .is_some_and(|text| !text.trim().is_empty())
+            });
+            has_tool_use && has_text
+        })
 }
 
 pub fn preview_event_is_conversation_or_reasoning(event: &PreviewEvent) -> bool {
@@ -619,14 +652,27 @@ fn timeline_user_text(text: &str) -> String {
 }
 
 pub fn read_rollout_token_total(path: &Path) -> AppResult<i64> {
+    read_rollout_token_total_impl(path, None)
+}
+
+pub(crate) fn read_rollout_token_total_cancellable(
+    path: &Path,
+    cancel: &AtomicBool,
+) -> AppResult<i64> {
+    read_rollout_token_total_impl(path, Some(cancel))
+}
+
+fn read_rollout_token_total_impl(path: &Path, cancel: Option<&AtomicBool>) -> AppResult<i64> {
     const REVERSE_SCAN_CHUNK_BYTES: usize = 64 * 1024;
 
+    ensure_not_cancelled(cancel)?;
     let mut file = File::open(path)?;
     let mut scan_end = file.metadata()?.len();
     let mut line_end = scan_end;
     let mut chunk = vec![0u8; REVERSE_SCAN_CHUNK_BYTES];
 
     while scan_end > 0 {
+        ensure_not_cancelled(cancel)?;
         let chunk_start = scan_end.saturating_sub(REVERSE_SCAN_CHUNK_BYTES as u64);
         let chunk_len = usize::try_from(scan_end - chunk_start).map_err(|_| {
             std::io::Error::new(std::io::ErrorKind::InvalidData, "rollout 扫描窗口过大")
@@ -638,6 +684,7 @@ pub fn read_rollout_token_total(path: &Path) -> AppResult<i64> {
             if chunk[offset] != b'\n' {
                 continue;
             }
+            ensure_not_cancelled(cancel)?;
             let separator = chunk_start + offset as u64;
             if let Some(total) = read_token_total_from_range(&mut file, separator + 1, line_end)? {
                 return Ok(total);

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -2,11 +2,12 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 
 use rusqlite::{params, OptionalExtension};
 
 use crate::atomic_file;
-use crate::error::{AppError, AppResult};
+use crate::error::{ensure_not_cancelled, AppError, AppResult};
 use crate::family;
 use crate::history;
 use crate::logs_db;
@@ -27,14 +28,19 @@ fn provider_or_codex(provider: Option<String>) -> String {
 /// state_5.sqlite 的 threads.title 可能仍停留在首条用户消息，即使 Codex App 已经
 /// 为会话生成了简短标题。索引不是核心数据库，单行损坏时跳过该行并回退数据库
 /// 标题，避免因为可选缓存损坏导致整个会话列表不可用。
-fn read_session_index_titles(codex_dir: &Path) -> AppResult<HashMap<String, String>> {
+fn read_session_index_titles(
+    codex_dir: &Path,
+    cancel: Option<&AtomicBool>,
+) -> AppResult<HashMap<String, String>> {
     let path = paths::session_index_path(codex_dir);
     let mut titles = HashMap::new();
+    ensure_not_cancelled(cancel)?;
     if !path.is_file() {
         return Ok(titles);
     }
 
     for line in BufReader::new(File::open(path)?).lines() {
+        ensure_not_cancelled(cancel)?;
         let line = line?;
         if line.trim().is_empty() {
             continue;
@@ -67,7 +73,7 @@ fn read_session_index_titles(codex_dir: &Path) -> AppResult<HashMap<String, Stri
 
 /// 返回 Codex 当前对外展示的会话标题：显式 name 优先，活跃索引其次，title 兜底。
 pub(crate) fn codex_display_title(codex_dir: &Path, id: &str) -> AppResult<Option<String>> {
-    let index_title = read_session_index_titles(codex_dir)?.remove(id);
+    let index_title = read_session_index_titles(codex_dir, None)?.remove(id);
     if !paths::state_db_path(codex_dir).is_file() {
         return Ok(index_title);
     }
@@ -134,10 +140,16 @@ fn query_summaries(
     codex_dir: &Path,
     where_clause: &str,
     params: &[&dyn rusqlite::ToSql],
+    cancel: Option<&AtomicBool>,
 ) -> AppResult<Vec<SessionSummary>> {
+    ensure_not_cancelled(cancel)?;
     let state = state_db::open_ro(codex_dir)?;
-    let logs_conn = logs_db::open_ro(codex_dir).ok();
-    let index_titles = read_session_index_titles(codex_dir)?;
+    let logs_conn = cancel
+        .is_none()
+        .then(|| logs_db::open_ro(codex_dir).ok())
+        .flatten();
+    let index_titles = read_session_index_titles(codex_dir, cancel)?;
+    ensure_not_cancelled(cancel)?;
     let has_name = crate::repair::threads_table_columns(&state)?
         .iter()
         .any(|column| column == "name");
@@ -152,78 +164,76 @@ fn query_summaries(
          ORDER BY updated_at DESC"
     );
     let mut stmt = state.prepare(&sql)?;
+    let mut rows = stmt.query(params)?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        ensure_not_cancelled(cancel)?;
+        let id: String = row.get(0)?;
+        let rollout_path_raw: String = row.get(1)?;
+        let cwd_raw: String = row.get(2)?;
+        let database_title: String = row.get(3)?;
+        let database_name: String = row.get(4)?;
+        let first_user_message: String = row.get(5)?;
+        let model: Option<String> = row.get(6)?;
+        let reasoning_effort: Option<String> = row.get(7)?;
+        let tokens_used: i64 = row.get(8)?;
+        let created_at: i64 = row.get(9)?;
+        let updated_at: i64 = row.get(10)?;
+        let archived: i64 = row.get(11)?;
+        let git_branch: Option<String> = row.get(12)?;
+        let source: Option<String> = row.get(13)?;
+        let agent_nickname: Option<String> = row.get(14)?;
+        let agent_role: Option<String> = row.get(15)?;
 
-    let rows: Vec<SessionSummary> = stmt
-        .query_map(params, |row| {
-            let id: String = row.get(0)?;
-            let rollout_path_raw: String = row.get(1)?;
-            let cwd_raw: String = row.get(2)?;
-            let database_title: String = row.get(3)?;
-            let database_name: String = row.get(4)?;
-            let first_user_message: String = row.get(5)?;
-            let model: Option<String> = row.get(6)?;
-            let reasoning_effort: Option<String> = row.get(7)?;
-            let tokens_used: i64 = row.get(8)?;
-            let created_at: i64 = row.get(9)?;
-            let updated_at: i64 = row.get(10)?;
-            let archived: i64 = row.get(11)?;
-            let git_branch: Option<String> = row.get(12)?;
-            let source: Option<String> = row.get(13)?;
-            let agent_nickname: Option<String> = row.get(14)?;
-            let agent_role: Option<String> = row.get(15)?;
-
-            let rollout_path =
-                paths::host_path_string_from_codex_record(codex_dir, &rollout_path_raw);
-            let cwd = paths::host_path_string_from_codex_record(codex_dir, &cwd_raw);
-            let cwd_display = paths::basename_display(&cwd);
-
-            let rollout_bytes = fs::metadata(&rollout_path).map(|m| m.len()).unwrap_or(0);
-
-            let resume_command = format!("codex resume {}", id);
-            let title = select_codex_title(
-                index_titles.get(&id).map(String::as_str),
-                &database_name,
-                database_title,
-                &first_user_message,
-                archived != 0,
-            );
-            Ok(SessionSummary {
-                provider: "codex".into(),
-                id,
-                resume_command,
-                rollout_path,
-                cwd,
-                cwd_display,
-                title,
-                first_user_message,
-                model,
-                reasoning_effort,
-                source,
-                agent_nickname,
-                agent_role,
-                conversion_origin: None,
-                tokens_used,
-                created_at,
-                updated_at,
-                archived: archived != 0,
-                git_branch,
-                rollout_bytes,
-                logs_count: 0,
-                has_backup: false,
-            })
-        })?
-        .collect::<Result<Vec<_>, _>>()?;
+        let rollout_path = paths::host_path_string_from_codex_record(codex_dir, &rollout_path_raw);
+        let cwd = paths::host_path_string_from_codex_record(codex_dir, &cwd_raw);
+        let cwd_display = paths::basename_display(&cwd);
+        let rollout_bytes = fs::metadata(&rollout_path).map(|m| m.len()).unwrap_or(0);
+        let resume_command = format!("codex resume {}", id);
+        let title = select_codex_title(
+            index_titles.get(&id).map(String::as_str),
+            &database_name,
+            database_title,
+            &first_user_message,
+            archived != 0,
+        );
+        out.push(SessionSummary {
+            provider: "codex".into(),
+            id,
+            resume_command,
+            rollout_path,
+            cwd,
+            cwd_display,
+            title,
+            first_user_message,
+            model,
+            reasoning_effort,
+            source,
+            agent_nickname,
+            agent_role,
+            conversion_origin: None,
+            tokens_used,
+            created_at,
+            updated_at,
+            archived: archived != 0,
+            git_branch,
+            rollout_bytes,
+            logs_count: 0,
+            has_backup: false,
+        });
+    }
 
     // 补充 logs_count（批量预查，避免 N+1）
     // NOTE: 在 SQL 层过滤 NULL / 空 thread_id，避免 `r.get::<_, String>(0)` 在 NULL 上报
     // "Invalid column type Null"。某些历史数据里 logs.thread_id 存在 NULL 值。
-    let mut out = rows;
     for s in out.iter_mut() {
+        ensure_not_cancelled(cancel)?;
         if s.tokens_used <= 0 {
-            s.tokens_used = rollout_token_total(&s.rollout_path);
+            s.tokens_used = rollout_token_total(&s.rollout_path, cancel)?;
         }
     }
     if let Some(conn) = logs_conn {
+        ensure_not_cancelled(cancel)?;
         let mut counts: HashMap<String, i64> = HashMap::new();
         let mut stmt = conn.prepare(
             "SELECT thread_id, COUNT(*) FROM logs \
@@ -232,6 +242,7 @@ fn query_summaries(
         )?;
         let iter = stmt.query_map([], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))?;
         for it in iter {
+            ensure_not_cancelled(cancel)?;
             let (id, count) = it?;
             counts.insert(id, count);
         }
@@ -244,9 +255,19 @@ fn query_summaries(
     Ok(out)
 }
 
-fn rollout_token_total(rollout_path: &str) -> i64 {
+fn rollout_token_total(rollout_path: &str, cancel: Option<&AtomicBool>) -> AppResult<i64> {
     let cleaned = paths::strip_verbatim(rollout_path);
-    crate::rollout::read_rollout_token_total(Path::new(&cleaned)).unwrap_or(0)
+    let result = match cancel {
+        Some(cancel) => {
+            crate::rollout::read_rollout_token_total_cancellable(Path::new(&cleaned), cancel)
+        }
+        None => crate::rollout::read_rollout_token_total(Path::new(&cleaned)),
+    };
+    match result {
+        Err(AppError::Cancelled) => Err(AppError::Cancelled),
+        Ok(total) => Ok(total),
+        Err(_) => Ok(0),
+    }
 }
 
 pub fn list_sessions(
@@ -254,17 +275,38 @@ pub fn list_sessions(
     codex_dir: String,
     claude_dir: Option<String>,
 ) -> AppResult<Vec<SessionSummary>> {
+    list_sessions_impl(provider, codex_dir, claude_dir, None)
+}
+
+pub fn list_sessions_cancellable(
+    provider: Option<String>,
+    codex_dir: String,
+    claude_dir: Option<String>,
+    cancel: &AtomicBool,
+) -> AppResult<Vec<SessionSummary>> {
+    list_sessions_impl(provider, codex_dir, claude_dir, Some(cancel))
+}
+
+fn list_sessions_impl(
+    provider: Option<String>,
+    codex_dir: String,
+    claude_dir: Option<String>,
+    cancel: Option<&AtomicBool>,
+) -> AppResult<Vec<SessionSummary>> {
+    ensure_not_cancelled(cancel)?;
     let codex = PathBuf::from(&codex_dir);
     match provider_or_codex(provider).as_str() {
         "codex" => {
-            let mut list = query_summaries(&codex, "", &[])?;
+            let mut list = query_summaries(&codex, "", &[], cancel)?;
+            ensure_not_cancelled(cancel)?;
             // 官方 Codex app 归档会把 rollout 移到 archived_sessions/；
             // threads 记录缺失或漂移时，从归档目录补扫，保证归档会话可见。
-            let extra = supplement_archived_summaries(&codex, &list)?;
+            let extra = supplement_archived_summaries(&codex, &list, cancel)?;
             if !extra.is_empty() {
                 list.extend(extra);
                 list.sort_by_key(|s| std::cmp::Reverse(s.updated_at));
             }
+            ensure_not_cancelled(cancel)?;
             provenance::annotate_sessions(&codex, &mut list);
             Ok(list)
         }
@@ -273,7 +315,11 @@ pub fn list_sessions(
                 claude_dir
                     .unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned()),
             );
-            let mut list = crate::claude_sessions::scan_sessions(&p)?;
+            let mut list = match cancel {
+                Some(cancel) => crate::claude_sessions::scan_sessions_cancellable(&p, cancel)?,
+                None => crate::claude_sessions::scan_sessions(&p)?,
+            };
+            ensure_not_cancelled(cancel)?;
             provenance::annotate_sessions(&codex, &mut list);
             Ok(list)
         }
@@ -285,6 +331,7 @@ pub fn list_sessions(
 fn supplement_archived_summaries(
     codex_dir: &Path,
     existing: &[SessionSummary],
+    cancel: Option<&AtomicBool>,
 ) -> AppResult<Vec<SessionSummary>> {
     let known_names: std::collections::HashSet<String> = existing
         .iter()
@@ -295,14 +342,23 @@ fn supplement_archived_summaries(
         })
         .collect();
     let mut out = Vec::new();
-    for p in crate::family::scan_archived_rollouts(codex_dir)? {
+    let archived_rollouts = match cancel {
+        Some(cancel) => crate::family::scan_archived_rollouts_cancellable(codex_dir, cancel)?,
+        None => crate::family::scan_archived_rollouts(codex_dir)?,
+    };
+    for p in archived_rollouts {
+        ensure_not_cancelled(cancel)?;
         let Some(name) = p.file_name().map(|n| n.to_string_lossy().into_owned()) else {
             continue;
         };
         if known_names.contains(&name) {
             continue;
         }
-        let Some(brief) = crate::repair::read_rollout_brief(codex_dir, &p)? else {
+        let brief = match cancel {
+            Some(cancel) => crate::repair::read_rollout_brief_cancellable(codex_dir, &p, cancel)?,
+            None => crate::repair::read_rollout_brief(codex_dir, &p)?,
+        };
+        let Some(brief) = brief else {
             continue;
         };
         if existing.iter().any(|s| s.id == brief.id) {

--- a/src-tauri/src/webui.rs
+++ b/src-tauri/src/webui.rs
@@ -13,8 +13,8 @@ use url::Url;
 use crate::error::{AppError, AppResult};
 use crate::models::{ImportMode, ProjectPathMapping, Settings, SwitchStrategy};
 use crate::{
-    backup, bundle, convert, edit, family, fs_ops, markdown_export, repair, rollout, sessions,
-    settings, stats,
+    backup, bundle, content_search, convert, edit, family, fs_ops, markdown_export, repair,
+    rollout, sessions, settings, stats,
 };
 
 const WEBUI_TOKEN_HEADER: &str = "X-CC-Sessions-Webui-Token";
@@ -179,6 +179,21 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
             string_arg(&args, "codexDir")?,
             opt_string_arg(&args, "claudeDir")?,
             string_arg(&args, "query")?,
+        )),
+        "start_content_search" => to_result_value(content_search::start_content_search(
+            string_arg(&args, "provider")?,
+            string_arg(&args, "codexDir")?,
+            string_arg(&args, "claudeDir")?,
+            string_arg(&args, "query")?,
+            bool_arg(&args, "showSubagentSessions")?,
+            bool_arg(&args, "showArchivedSessions")?,
+        )),
+        "content_search_status" => to_result_value(content_search::content_search_status(
+            usize_arg(&args, "jobId")? as u64,
+        )),
+        "active_content_search" => to_result_value(content_search::active_content_search()),
+        "cancel_content_search" => to_result_value(content_search::cancel_content_search(
+            usize_arg(&args, "jobId")? as u64,
         )),
         "set_archived" => to_result_value(sessions::set_archived_with_lock(
             opt_string_arg(&args, "provider")?,

--- a/src/components/ContentSearchDialog.tsx
+++ b/src/components/ContentSearchDialog.tsx
@@ -1,0 +1,429 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { FileSearch, Loader2, Search, Square, User, Bot } from "lucide-react";
+
+import {
+  api,
+  type ContentSearchMatch,
+  type ContentSearchStatus,
+  type SessionProvider,
+  type SessionSummary,
+} from "@/lib/api";
+import { formatTimeString, highlight, humanBytes } from "@/lib/format";
+import { sessionDisplayTitle } from "@/lib/sessionText";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  provider: SessionProvider;
+  codexDir: string;
+  claudeDir: string;
+  showSubagentSessions: boolean;
+  showArchivedSessions: boolean;
+  onOpenResult: (
+    session: SessionSummary,
+    match: ContentSearchMatch,
+    query: string,
+  ) => void;
+};
+
+export function ContentSearchDialog({
+  open,
+  onOpenChange,
+  provider,
+  codexDir,
+  claudeDir,
+  showSubagentSessions,
+  showArchivedSessions,
+  onOpenResult,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [jobId, setJobId] = useState<number | null>(null);
+  const [status, setStatus] = useState<ContentSearchStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const activeJobRef = useRef<number | null>(null);
+  const jobScopeKeyRef = useRef<string | null>(null);
+  const mountedRef = useRef(false);
+  const openRef = useRef(open);
+  const requestGenerationRef = useRef(0);
+  const pendingStartGenerationRef = useRef<number | null>(null);
+  const scopeKey = `${provider}\u0000${codexDir}\u0000${claudeDir}\u0000${showSubagentSessions}\u0000${showArchivedSessions}`;
+  const scopeKeyRef = useRef(scopeKey);
+  const previousScopeKeyRef = useRef(scopeKey);
+
+  openRef.current = open;
+  scopeKeyRef.current = scopeKey;
+
+  const cancelActiveSearch = useCallback(async (reportError: boolean) => {
+    requestGenerationRef.current += 1;
+
+    const activeJobId = activeJobRef.current;
+    if (activeJobId === null) return;
+    if (mountedRef.current) setCancelling(true);
+    try {
+      await api.cancelContentSearch(activeJobId);
+    } catch (cancelError) {
+      if (mountedRef.current && activeJobRef.current === activeJobId) {
+        setCancelling(false);
+        if (reportError) {
+          setError(String((cancelError as Error)?.message ?? cancelError));
+        }
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      requestGenerationRef.current += 1;
+      const activeJobId = activeJobRef.current;
+      activeJobRef.current = null;
+      jobScopeKeyRef.current = null;
+      if (activeJobId !== null) {
+        void api.cancelContentSearch(activeJobId).catch(() => undefined);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (previousScopeKeyRef.current === scopeKey) return;
+    previousScopeKeyRef.current = scopeKey;
+    setStatus(null);
+    setError(null);
+    void cancelActiveSearch(false);
+  }, [cancelActiveSearch, scopeKey]);
+
+  useEffect(() => {
+    if (!open || jobId !== null || starting) return;
+    let disposed = false;
+    const generation = requestGenerationRef.current;
+
+    void api.activeContentSearch().then((active) => {
+      if (
+        disposed
+        || !active
+        || !mountedRef.current
+        || !openRef.current
+        || activeJobRef.current !== null
+        || pendingStartGenerationRef.current !== null
+        || requestGenerationRef.current !== generation
+      ) {
+        return;
+      }
+      activeJobRef.current = active.job_id;
+      jobScopeKeyRef.current = null;
+      setStatus(null);
+      setError("检测到仍在运行的全文搜索，可先停止后重新搜索");
+      setJobId(active.job_id);
+    }).catch(() => undefined);
+
+    return () => {
+      disposed = true;
+    };
+  }, [jobId, open, starting]);
+
+  useEffect(() => {
+    if (jobId === null) return;
+    let disposed = false;
+
+    const poll = async () => {
+      try {
+        const next = await api.contentSearchStatus(jobId);
+        if (disposed || activeJobRef.current !== jobId) return;
+        const ownsCurrentScope = jobScopeKeyRef.current === scopeKeyRef.current;
+        if (ownsCurrentScope) {
+          setStatus(next);
+          setError(null);
+        }
+        if (next.state === "running") {
+          timerRef.current = window.setTimeout(poll, 300);
+        } else {
+          activeJobRef.current = null;
+          jobScopeKeyRef.current = null;
+          setJobId((current) => current === jobId ? null : current);
+          setCancelling(false);
+          if (!ownsCurrentScope) setError(null);
+        }
+      } catch (pollError) {
+        if (disposed || activeJobRef.current !== jobId) return;
+        const active = await api.activeContentSearch().catch(() => undefined);
+        if (disposed || activeJobRef.current !== jobId) return;
+        if (active !== undefined && active?.job_id !== jobId) {
+          activeJobRef.current = null;
+          jobScopeKeyRef.current = null;
+          setJobId((current) => current === jobId ? null : current);
+          setCancelling(false);
+          setError("全文搜索任务已结束或服务已重启");
+          return;
+        }
+        if (jobScopeKeyRef.current === scopeKeyRef.current) {
+          setError(String((pollError as Error)?.message ?? pollError));
+        }
+        timerRef.current = window.setTimeout(poll, 300);
+      }
+    };
+
+    void poll();
+    return () => {
+      disposed = true;
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    };
+  }, [jobId]);
+
+  const running = jobId !== null || starting;
+  const progress = useMemo(() => {
+    if (!status || status.total_bytes === 0) return 0;
+    return Math.min(100, Math.round((status.scanned_bytes / status.total_bytes) * 100));
+  }, [status]);
+  const skippedLabel = status?.skipped_files
+    ? `，跳过 ${status.skipped_files} 个无正文记录`
+    : "";
+
+  const startSearch = async (event: FormEvent) => {
+    event.preventDefault();
+    const normalized = query.trim();
+    if (normalized.length < 2 || running) return;
+    const generation = requestGenerationRef.current + 1;
+    requestGenerationRef.current = generation;
+    pendingStartGenerationRef.current = generation;
+    const requestScopeKey = scopeKey;
+    setStarting(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const started = await api.startContentSearch({
+        provider,
+        codexDir,
+        claudeDir,
+        query: normalized,
+        showSubagentSessions,
+        showArchivedSessions,
+      });
+      if (
+        !mountedRef.current
+        || requestGenerationRef.current !== generation
+        || scopeKeyRef.current !== requestScopeKey
+        || !openRef.current
+      ) {
+        await api.cancelContentSearch(started.job_id).catch(() => undefined);
+        return;
+      }
+      activeJobRef.current = started.job_id;
+      jobScopeKeyRef.current = requestScopeKey;
+      setJobId(started.job_id);
+    } catch (startError) {
+      if (
+        mountedRef.current
+        && requestGenerationRef.current === generation
+        && scopeKeyRef.current === requestScopeKey
+        && openRef.current
+      ) {
+        setError(String((startError as Error)?.message ?? startError));
+      }
+    } finally {
+      if (pendingStartGenerationRef.current === generation) {
+        pendingStartGenerationRef.current = null;
+      }
+      if (mountedRef.current && pendingStartGenerationRef.current === null) {
+        setStarting(false);
+      }
+    }
+  };
+
+  const stopSearch = async () => {
+    if (activeJobRef.current === null) return;
+    setError(null);
+    await cancelActiveSearch(true);
+  };
+
+  const changeOpen = (next: boolean) => {
+    if (!next) void cancelActiveSearch(false);
+    onOpenChange(next);
+  };
+
+  const scopeLabel = showSubagentSessions
+    ? "子代理"
+    : provider === "codex" && showArchivedSessions
+      ? "已归档"
+      : "主会话";
+
+  return (
+    <Dialog open={open} onOpenChange={changeOpen}>
+      <DialogContent className="flex h-[min(82vh,760px)] max-w-[min(960px,calc(100vw-2rem))] min-w-0 flex-col gap-0 p-0">
+        <DialogHeader className="shrink-0 border-b border-border/60 px-5 pb-4 pt-5 pr-12 sm:px-6 sm:pr-12">
+          <div className="flex min-w-0 items-center gap-3">
+            <div className="grid h-9 w-9 shrink-0 place-items-center rounded-md bg-muted text-muted-foreground">
+              <FileSearch className="h-[18px] w-[18px]" />
+            </div>
+            <div className="min-w-0">
+              <DialogTitle className="text-[15px] leading-tight">对话全文搜索</DialogTitle>
+              <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                <Badge variant="outline" className="h-5 px-1.5 text-[10px] font-normal">
+                  {provider === "codex" ? "Codex" : "Claude"}
+                </Badge>
+                <Badge variant="secondary" className="h-5 px-1.5 text-[10px] font-normal">
+                  {scopeLabel}
+                </Badge>
+              </div>
+            </div>
+          </div>
+          <DialogDescription className="sr-only">
+            手动扫描当前范围内的用户与助手对话内容
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={startSearch} className="shrink-0 border-b border-border/60 p-4 sm:px-6">
+          <div className="flex min-w-0 gap-2">
+            <div className="relative min-w-0 flex-1">
+              <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                autoFocus
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                maxLength={256}
+                disabled={running}
+                placeholder="搜索用户与助手对话"
+                className="h-10 pl-9"
+              />
+            </div>
+            {jobId !== null ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={stopSearch}
+                disabled={cancelling}
+                className="h-10 gap-2 active:scale-95"
+              >
+                {cancelling ? <Loader2 className="h-4 w-4 animate-spin" /> : <Square className="h-3.5 w-3.5" />}
+                停止
+              </Button>
+            ) : (
+              <Button
+                type="submit"
+                disabled={query.trim().length < 2 || starting}
+                className="h-10 gap-2 active:scale-95"
+              >
+                {starting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+                搜索
+              </Button>
+            )}
+          </div>
+
+          {status && (
+            <div className="mt-3 space-y-1.5">
+              <div className="flex min-w-0 items-center justify-between gap-4 text-[11px] text-muted-foreground">
+                <span className="min-w-0 truncate">
+                  {status.state === "running"
+                    ? status.total_files === 0
+                      ? "正在读取会话列表"
+                      : `正在扫描 ${status.scanned_files}/${status.total_files} 个会话${skippedLabel}`
+                    : status.state === "completed"
+                      ? `已扫描 ${status.scanned_files} 个会话${skippedLabel}`
+                      : status.state === "cancelled"
+                        ? `搜索已停止${skippedLabel}`
+                        : "搜索失败"}
+                </span>
+                <span className="shrink-0 tabular-nums">
+                  {humanBytes(status.scanned_bytes)} / {humanBytes(status.total_bytes)}
+                </span>
+              </div>
+              <div className="h-1 overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-primary transition-[width] duration-200"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+            </div>
+          )}
+
+          {(error || status?.error) && (
+            <p className="mt-3 text-xs text-destructive">{error ?? status?.error}</p>
+          )}
+        </form>
+
+        <ScrollArea className="min-h-0 flex-1">
+          {!status ? (
+            <div className="grid min-h-64 place-items-center px-6 text-center text-sm text-muted-foreground">
+              <div>
+                <FileSearch className="mx-auto mb-3 h-7 w-7 opacity-45" />
+                {jobId !== null ? (cancelling ? "正在停止搜索" : "正在读取会话列表") : "尚未搜索"}
+              </div>
+            </div>
+          ) : status.results.length === 0 ? (
+            <div className="grid min-h-64 place-items-center px-6 text-center text-sm text-muted-foreground">
+              {status.state === "running" ? "正在查找匹配内容" : "没有匹配的对话"}
+            </div>
+          ) : (
+            <div className="divide-y divide-border/60">
+              {status.results.map((result) => (
+                <section key={`${result.session.provider}:${result.session.id}`} className="px-4 py-4 sm:px-6">
+                  <div className="mb-2.5 flex min-w-0 items-center gap-2">
+                    <h3 className="min-w-0 flex-1 truncate text-sm font-semibold">
+                      {sessionDisplayTitle(result.session.title, result.session.first_user_message)}
+                    </h3>
+                    <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+                      {result.session.id.slice(0, 8)}
+                    </span>
+                  </div>
+                  <div className="space-y-1.5">
+                    {result.matches.map((match) => (
+                      <button
+                        key={`${result.session.id}:${match.event_index}`}
+                        type="button"
+                        onClick={() => {
+                          changeOpen(false);
+                          onOpenResult(result.session, match, status.query);
+                        }}
+                        className="group grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)] gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:scale-[0.995]"
+                      >
+                        <span className="mt-0.5 grid h-6 w-6 place-items-center rounded-md bg-muted text-muted-foreground group-hover:text-foreground">
+                          {match.role === "user" ? <User className="h-3.5 w-3.5" /> : <Bot className="h-3.5 w-3.5" />}
+                        </span>
+                        <span className="min-w-0">
+                          <span className="flex min-w-0 items-center gap-2 text-[10px] text-muted-foreground">
+                            <span>{match.role === "user" ? "用户" : "助手"}</span>
+                            {match.timestamp && <span>{formatTimeString(match.timestamp)}</span>}
+                            <span className="font-mono">第 {match.event_index + 1} 行</span>
+                          </span>
+                          <span className="mt-0.5 block min-w-0 text-[13px] leading-relaxed text-foreground/85 wrap-anywhere">
+                            <HighlightedText text={match.snippet} query={status.query} />
+                          </span>
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </section>
+              ))}
+              {status.truncated && (
+                <div className="px-6 py-3 text-center text-xs text-muted-foreground">
+                  结果已达到 100 个会话
+                </div>
+              )}
+            </div>
+          )}
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function HighlightedText({ text, query }: { text: string; query: string }) {
+  return highlight(text, query).map((part, index) =>
+    part.hit ? <mark key={index}>{part.t}</mark> : <span key={index}>{part.t}</span>,
+  );
+}

--- a/src/components/PreviewDialog.tsx
+++ b/src/components/PreviewDialog.tsx
@@ -93,6 +93,13 @@ type Props = {
   backupDir?: string;
   onForked?: () => void | Promise<void>;
   onEdited?: () => void | Promise<void>;
+  initialJump?: PreviewJump | null;
+};
+
+export type PreviewJump = {
+  eventIndex: number;
+  eventOffset: number;
+  query: string;
 };
 
 type DiffCommentPrompt = {
@@ -138,6 +145,7 @@ export function PreviewDialog({
   backupDir,
   onForked,
   onEdited,
+  initialJump,
 }: Props) {
   const rolloutPath = customRolloutPath ?? session?.rollout_path ?? "";
   const provider = session?.provider ?? "codex";
@@ -456,6 +464,13 @@ export function PreviewDialog({
     el.classList.add("preview-jump-flash");
     window.setTimeout(() => el.classList.remove("preview-jump-flash"), 1700);
   }, []);
+
+  useEffect(() => {
+    if (!open || !rolloutPath || !initialJump) return;
+    setFilter(initialJump.query);
+    pendingJumpRef.current = initialJump.eventIndex;
+    void loadUpTo(initialJump.eventOffset).then(() => scrollPendingIntoView());
+  }, [initialJump, loadUpTo, open, rolloutPath, scrollPendingIntoView]);
 
   /** 滚动跟随：视口上沿 1/3 处上方最近的一条用户提问视为当前时间线位置。 */
   const updateActiveFromScroll = useCallback(() => {

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useLocation } from "react-router-dom";
-import { Archive, ArrowDown10, Clock, FolderKanban, RefreshCw, Trash2, X } from "lucide-react";
+import { Archive, ArrowDown10, Clock, FileSearch, FolderKanban, RefreshCw, Trash2, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/SearchInput";
@@ -17,6 +17,7 @@ type Props = {
   refreshing?: boolean;
   onBulkBackup?: () => void;
   onBulkDelete?: () => void;
+  onContentSearch?: () => void;
   showListTools?: boolean;
   children?: React.ReactNode;
 };
@@ -28,6 +29,7 @@ export function TopBar({
   refreshing = false,
   onBulkBackup,
   onBulkDelete,
+  onContentSearch,
   showListTools,
   children,
 }: Props) {
@@ -73,6 +75,22 @@ export function TopBar({
               onChange={setQuery}
               className="min-w-0 flex-1 basis-64 sm:max-w-96 lg:min-w-48 xl:max-w-[30rem]"
             />
+            {onContentSearch && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={onContentSearch}
+                    className="h-9 w-9 shrink-0 text-muted-foreground hover:text-foreground active:scale-95"
+                    aria-label="搜索对话全文"
+                  >
+                    <FileSearch className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>搜索对话全文</TooltipContent>
+              </Tooltip>
+            )}
             <Tabs value={view} onValueChange={(v) => setView(v as View)} className="shrink-0">
               <TabsList className="h-9">
                 <TabsTrigger value="time" className="gap-1.5 px-2.5 text-xs">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -123,6 +123,33 @@ export type SessionSummary = {
   resume_command: string;
 };
 
+export type ContentSearchMatch = {
+  event_index: number;
+  event_offset: number;
+  timestamp: string;
+  role: string;
+  snippet: string;
+};
+
+export type ContentSearchResult = {
+  session: SessionSummary;
+  matches: ContentSearchMatch[];
+};
+
+export type ContentSearchStatus = {
+  job_id: number;
+  state: "running" | "completed" | "cancelled" | "failed";
+  query: string;
+  scanned_files: number;
+  total_files: number;
+  skipped_files: number;
+  scanned_bytes: number;
+  total_bytes: number;
+  results: ContentSearchResult[];
+  truncated: boolean;
+  error: string | null;
+};
+
 export type ProjectGroup = {
   cwd: string;
   cwd_display: string;
@@ -778,6 +805,20 @@ export const api = {
     invokeCommand<ProjectGroup[]>("group_sessions_by_project", { provider, codexDir, claudeDir }),
   searchSessions: (provider: SessionProvider, codexDir: string, claudeDir: string | undefined, query: string) =>
     invokeCommand<SessionSummary[]>("search_sessions", { provider, codexDir, claudeDir, query }),
+  startContentSearch: (p: {
+    provider: SessionProvider;
+    codexDir: string;
+    claudeDir: string;
+    query: string;
+    showSubagentSessions: boolean;
+    showArchivedSessions: boolean;
+  }) => invokeCommand<{ job_id: number }>("start_content_search", p),
+  contentSearchStatus: (jobId: number) =>
+    invokeCommand<ContentSearchStatus>("content_search_status", { jobId }),
+  activeContentSearch: () =>
+    invokeCommand<{ job_id: number } | null>("active_content_search"),
+  cancelContentSearch: (jobId: number) =>
+    invokeCommand<void>("cancel_content_search", { jobId }),
   setArchived: (provider: SessionProvider, codexDir: string, id: string, v: boolean) =>
     invokeCommand<void>("set_archived", { provider, codexDir, id, v }),
   renameSession: (provider: SessionProvider, codexDir: string, id: string, title: string) =>

--- a/src/routes/sessions.tsx
+++ b/src/routes/sessions.tsx
@@ -14,6 +14,8 @@ import {
 import { TopBar } from "@/components/TopBar";
 import { SessionList } from "@/components/SessionList";
 import { PreviewDialog } from "@/components/PreviewDialog";
+import type { PreviewJump } from "@/components/PreviewDialog";
+import { ContentSearchDialog } from "@/components/ContentSearchDialog";
 import { MarkdownExportDialog } from "@/components/MarkdownExportDialog";
 import { BackupCreateDialog } from "@/components/BackupCreateDialog";
 import { ConvertSessionDialog } from "@/components/ConvertSessionDialog";
@@ -39,6 +41,7 @@ import { useView } from "@/stores/view";
 import { useHotkeys } from "@/hooks/useHotkeys";
 import {
   api,
+  type ContentSearchMatch,
   type DeleteResult,
   type FamilyOverlay,
   type SessionProvider,
@@ -90,6 +93,8 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
   );
 
   const [preview, setPreview] = useState<SessionSummary | null>(null);
+  const [previewJump, setPreviewJump] = useState<PreviewJump | null>(null);
+  const [contentSearchOpen, setContentSearchOpen] = useState(false);
   const [exportTarget, setExportTarget] = useState<SessionSummary | null>(null);
   const [renameTarget, setRenameTarget] = useState<SessionSummary | null>(null);
   const [moveTarget, setMoveTarget] = useState<SessionSummary | null>(null);
@@ -155,6 +160,8 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
   useEffect(() => {
     clearSelection();
     setPreview(null);
+    setPreviewJump(null);
+    setContentSearchOpen(false);
     setExportTarget(null);
     setBackupTargets([]);
     setDeleteTargets([]);
@@ -488,6 +495,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
         refreshing={loading}
         onBulkBackup={onBulkBackup}
         onBulkDelete={onBulkDelete}
+        onContentSearch={() => setContentSearchOpen(true)}
         showListTools
       >
         <DropdownMenu>
@@ -644,7 +652,10 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
             syncingSessionIds={providerSyncState.sessionIds}
             syncActionsDisabled={providerSyncState.batchActive}
             duplicatingSessionIds={duplicatingSessionIds}
-            onPreview={setPreview}
+            onPreview={(session) => {
+              setPreviewJump(null);
+              setPreview(session);
+            }}
             onCopyResume={onCopyResume}
             onRevealCwd={onReveal}
             onArchiveToggle={isCodex ? onArchiveToggle : undefined}
@@ -661,10 +672,35 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
         )}
       </ScrollArea>
 
+      <ContentSearchDialog
+        open={contentSearchOpen}
+        onOpenChange={setContentSearchOpen}
+        provider={provider}
+        codexDir={settings.codex_dir}
+        claudeDir={settings.claude_dir}
+        showSubagentSessions={showSubagentSessions}
+        showArchivedSessions={showArchivedSessions}
+        onOpenResult={(session, match: ContentSearchMatch, searchQuery) => {
+          setPreviewJump({
+            eventIndex: match.event_index,
+            eventOffset: match.event_offset,
+            query: searchQuery,
+          });
+          setContentSearchOpen(false);
+          setPreview(session);
+        }}
+      />
+
       <PreviewDialog
         open={!!preview}
-        onOpenChange={(v) => !v && setPreview(null)}
+        onOpenChange={(v) => {
+          if (!v) {
+            setPreview(null);
+            setPreviewJump(null);
+          }
+        }}
         session={preview}
+        initialJump={previewJump}
         allSessions={allSessions}
         codexDir={settings.codex_dir}
         backupDir={settings.backup_dir}


### PR DESCRIPTION
# PR：增加对话全文搜索

## 变更内容

在原有会话摘要搜索旁增加独立的全文搜索入口。搜索由用户手动触发，不影响现有列表过滤。

- 后端使用单个进程内工作线程逐行扫描 JSONL，不建立持久索引。
- 同时只运行一个搜索任务，取消信号覆盖会话发现和正文扫描。
- Dialog 关闭、组件卸载或搜索范围变化时会取消所属任务；状态轮询失败时仍可停止，页面刷新后也能重新发现活动任务。
- 默认最多返回 100 个会话，每个会话最多 3 个匹配片段。
- 点击结果后打开现有预览，并跳转到对应事件。

## 搜索范围

搜索范围跟随当前 provider 和页面状态：Codex 支持主会话、子代理和归档会话，Claude 支持主会话和子代理。

只匹配真实用户消息和助手回复，排除环境上下文、AGENTS 指令、reasoning、工具调用和工具输出。Claude 同一条消息中同时包含助手文字和 `tool_use` 时，只搜索其中的助手文字。

ASCII 查询不区分大小写，其他 Unicode 查询按原文匹配。关键词至少需要 2 个字符，控制字符会被拒绝。

## 缺失正文处理

会话元数据可能仍在本地数据库中，但对应 JSONL 已被删除。扫描遇到 `NotFound` 时会跳过该记录，并在界面显示跳过数量，不再中断整个搜索。权限错误和其他 I/O 错误仍会明确失败。

## 验证

- Codex 用户消息和助手回复可命中，重复的展示事件和工具输出不会误报。
- Claude 用户消息及混合 `text + tool_use` 的助手文字可命中，reasoning 和纯工具调用不会误报。
- JSON 转义内容可正常搜索。
- 缺失 JSONL 会被计数跳过。
- Rust 搜索测试 6 项通过，Claude 会话测试 15 项通过，CLI `cargo check` 通过。
- TypeScript 和 Vite 生产构建通过。
- Web 端验证了发现阶段立即取消，以及轮询失败后关闭 Dialog 可取消后台任务。
