### PR TITLE
feat(cursor): 接入 Cursor 作为第四个 provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-CC Sessions 用来管理 Codex、Claude Code 和 OpenCode 保存在本机的会话。你可以在一个界面里查找对话、预览内容、备份恢复、移动会话目录，也可以修复部分索引和可见性问题。
+CC Sessions 用来管理 Codex、Claude Code、OpenCode 和 Cursor 保存在本机的会话。你可以在一个界面里查找对话、预览内容、备份恢复、移动会话目录，也可以修复部分索引和可见性问题。
 
 [下载最新版](https://github.com/ccpopy/cc-sessions/releases/latest) · [查看功能](#功能模块) · [进阶功能](#进阶功能) · [常见问题](#常见问题) · [开发与打包](#开发与打包)
 
@@ -16,7 +16,7 @@ CC Sessions 用来管理 Codex、Claude Code 和 OpenCode 保存在本机的会�
 
 | 你属于哪类用户 | 推荐方式 | 从哪里开始 |
 | --- | --- | --- |
-| 在电脑上使用 Codex、Claude Code 或 OpenCode | 桌面版 | [安装](#安装) |
+| 在电脑上使用 Codex、Claude Code、OpenCode 或 Cursor | 桌面版 | [安装](#安装) |
 | 在 WSL、服务器或 SSH 环境中管理会话 | `cc-sessions` 命令行或自带网页界面 | [命令行与 WSL](#命令行与-wsl) |
 | 想修改源码或自行构建安装包 | 从源码运行 | [开发与打包](#开发与打包) |
 
@@ -24,24 +24,26 @@ CC Sessions 用来管理 Codex、Claude Code 和 OpenCode 保存在本机的会�
 
 ## 功能模块
 
-| 模块 | 可以做什么 | Codex | Claude Code | OpenCode |
-| --- | --- | --- | --- | --- |
-| 会话浏览 | 按标题、首条消息、目录或 ID 查找会话 | 支持 | 支持 | 支持 |
-| 会话整理 | 重命名、删除、按项目分组，并复制继续对话的命令 | 支持 | 支持 | 支持 |
-| 正文搜索与预览 | 搜索完整对话，按时间线查看消息和工具过程 | 支持 | 支持 | 支持 |
-| 编辑与撤销 | 修改文本、删除上下文事件、撤销编辑或恢复原始快照 | 支持 | 支持 | 支持 |
-| 备份与恢复 | 为选中的会话创建备份，并在需要时恢复 | 支持 | 支持 | 支持 |
-| 导入与导出 | 生成可迁移的会话包，或导出为 Markdown | 支持 | 支持 | 支持 |
-| 移动会话目录 | 把会话关联到新的项目目录，并更新相关记录 | 支持 | 支持 | 支持 |
-| 归档 | 隐藏暂时不用的会话，之后可以取消归档 | 支持 | 不支持 | 支持 |
-| 会话转换 | 在 Codex 与 Claude Code 之间创建新的可续聊会话 | 支持 | 支持 | 不支持 |
-| Memory 管理 | 新建、浏览、编辑、重命名和删除项目 Memory 文件 | 不接管 | 支持 | 不支持 |
-| 子代理会话 | 单独筛选由子代理产生的会话 | 支持 | 支持 | 支持 |
-| 分支管理 | 切换模型服务配置后复制会话，或从较早的对话位置创建新分支 | 支持 | 不支持 | 不支持 |
-| 使用统计 | 查看会话趋势、项目、模型和活跃时间 | 支持 | 支持 | 支持 |
-| 修复工具 | 修复部分索引、项目配置和列表可见性问题 | 支持 | 部分支持 | 不支持 |
+| 模块 | 可以做什么 | Codex | Claude Code | OpenCode | Cursor |
+| --- | --- | --- | --- | --- | --- |
+| 会话浏览 | 按标题、首条消息、目录或 ID 查找会话 | 支持 | 支持 | 支持 | 支持 |
+| 会话整理 | 重命名、删除、按项目分组，并复制继续对话的命令 | 支持 | 支持 | 支持 | 支持 |
+| 正文搜索与预览 | 搜索完整对话，按时间线查看消息和工具过程 | 支持 | 支持 | 支持 | 支持 |
+| 编辑与撤销 | 修改文本、删除上下文事件、撤销编辑或恢复原始快照 | 支持 | 支持 | 支持 | 不支持 |
+| 备份与恢复 | 为选中的会话创建备份，并在需要时恢复 | 支持 | 支持 | 支持 | 支持 |
+| 导入与导出 | 生成可迁移的会话包，或导出为 Markdown | 支持 | 支持 | 支持 | 支持 |
+| 移动会话目录 | 把会话关联到新的项目目录，并更新相关记录 | 支持 | 支持 | 支持 | 不支持 |
+| 归档 | 隐藏暂时不用的会话，之后可以取消归档 | 支持 | 不支持 | 支持 | 支持 |
+| 会话转换 | 创建新的可续聊会话 | 支持 | 支持 | 不支持 | 只能转出 |
+| Memory 管理 | 新建、浏览、编辑、重命名和删除项目 Memory 文件 | 不接管 | 支持 | 不支持 | 不支持 |
+| 子代理会话 | 单独筛选由子代理产生的会话 | 支持 | 支持 | 支持 | 随主会话管理 |
+| 分支管理 | 切换模型服务配置后复制会话，或从较早的对话位置创建新分支 | 支持 | 不支持 | 不支持 | 不支持 |
+| 使用统计 | 查看会话趋势、项目、模型和活跃时间 | 支持 | 支持 | 支持 | 支持 |
+| 修复工具 | 修复部分索引、项目配置和列表可见性问题 | 支持 | 部分支持 | 不支持 | 清理数据库残留 |
 
 会话转换会创建新的目标会话，不修改来源文件。编辑、导入、移动、恢复和删除会写入本地数据。桌面版会在高风险操作前显示确认信息，CLI 交互菜单会要求输入 `yes`。
+
+Cursor 的会话存在一个共享数据库里，改动方式和其他三个工具不同，使用前请看 [Cursor 会话](#cursor-会话)。
 
 ## 安装
 
@@ -71,7 +73,7 @@ CC Sessions 用来管理 Codex、Claude Code 和 OpenCode 保存在本机的会�
 
 Release 最下方的 `Source code (zip)` 和 `Source code (tar.gz)` 是 GitHub 自动生成的源码压缩包，不是桌面版安装包。
 
-第一次打开后，到设置页确认 Codex、Claude Code 和 OpenCode 的数据路径。应用会尝试使用默认位置，没有安装的工具可以留空。
+第一次打开后，到设置页确认 Codex、Claude Code、OpenCode 和 Cursor 的数据路径。应用会尝试使用默认位置，没有安装的工具可以留空。
 
 ### 快速开始
 
@@ -90,7 +92,8 @@ Release 最下方的 `Source code (zip)` 和 `Source code (tar.gz)` 是 GitHub �
 - CC Sessions 不要求账号，也不会把会话上传到第三方服务。只有检查更新或打开发布页时会访问 GitHub。
 - 编辑前会保存快照，可以逐步撤销，也可以恢复到编辑前状态。
 - 移动目录会检查目标冲突和写入结果。失败时会尝试恢复原状态。
-- OpenCode 会话包只包含所选会话的数据，不包含账号信息、登录凭据或本机分享密钥。
+- OpenCode 和 Cursor 的会话包只包含所选会话的数据，不包含账号信息、登录凭据或本机分享密钥。Cursor 的 `state.vscdb` 里混有凭据和全部工作区状态，因此备份和会话包都只取该会话自己的记录，不会整库复制。
+- 修改 Cursor 会话前需要完全退出 Cursor。它会在内存里缓存会话状态，运行期间改数据库很可能被它按旧状态覆盖回去，因此应用检测到 Cursor 在运行时会直接拒绝写入。
 - 跨机器导入时，桌面版和自带网页界面可以把原项目路径映射到新电脑的目录。
 - 覆盖导入和覆盖恢复不会自动再创建一份备份。重要会话仍建议保留独立备份，尤其是在移动目录、覆盖恢复或批量删除前。
 
@@ -104,7 +107,7 @@ Release 最下方的 `Source code (zip)` 和 `Source code (tar.gz)` 是 GitHub �
 
 ### 归档
 
-Codex 和 OpenCode 支持归档，Claude Code 暂不支持。归档不会删除会话，普通列表会隐藏归档记录，切换到归档视图后可以取消归档。
+Codex、OpenCode 和 Cursor 支持归档，Claude Code 暂不支持。归档不会删除会话，普通列表会隐藏归档记录，切换到归档视图后可以取消归档。
 
 Codex 归档视图会按归档来源分组显示：我的归档（手动归档，以及没有来源标识的归档）、切换模型服务时自动归档的同步分支、备份恢复或会话包导入产生的迁移记录；可以用顶部筛选条只看某一类。导出页会保留归档记录供手动选择，并显示“已归档”徽标。Codex 使用本地归档目录保存会话文件，OpenCode 使用自身的原生归档状态。
 
@@ -118,17 +121,45 @@ Codex 归档视图会按归档来源分组显示：我的归档（手动归档�
 
 主会话和子代理会话可以分开查看。列表、搜索、项目分组和大小排序都支持子代理筛选，但子代理会话不参与 Codex 与 Claude Code 的格式转换。
 
+Cursor 是例外：它的子会话只跟着主会话管理，列表里不单独出现，删除主会话时会连同它的子会话一起删掉。这样可以避免删掉子会话后，主会话留下指向已消失会话的引用。
+
 Codex 用户还可以处理切换模型服务配置后留下的旧会话，或从较早的稳定对话位置创建新分支。创建回溯分支时，应用会保留来源会话，并把原来的当前分支归档。
 
-### Codex 与 Claude Code 会话转换
+### 会话转换
 
 简洁模式是默认选项，只保留用户消息和稳定的最终答复，适合继续对话。原生模式会尝试保留工具调用、图片和过程消息，适合需要完整上下文的场景，但兼容性不如简洁模式稳定。
 
+Codex 与 Claude Code 之间可以互相转换。Cursor 只能转出，可以转成 Claude Code 或 Codex 会话继续聊，但不能把别的工具的会话转进 Cursor——Cursor 的编辑器内会话没有命令行入口，转进去也没法打开。
+
 转换始终创建新会话，不会修改来源文件。OpenCode 暂不参与格式转换。
+
+### Cursor 会话
+
+Cursor 的会话不是一个会话一个文件，而是全部存在 `state.vscdb` 这一个数据库里，所以有几点和其他工具不同。
+
+**改动前要先退出 Cursor。** 归档、重命名、删除、清理和压缩都会先检查 Cursor 是否在运行，在运行就直接拒绝。
+
+**子会话跟着主会话走。** 详见[子代理与 Codex 分支](#子代理与-codex-分支)。
+
+**删除会真正清干净。** Cursor 自己删会话时，检查点、代码差异、文件快照等数据会留在库里不再回收。CC Sessions 删除时会把这些一并带走。
+
+**数据库可能比你以为的大得多。** 长期使用后，库里会积压大量已删会话的残留。修复页的“Cursor 数据库残留”可以先诊断再清理：
+
+| 类别 | 是什么 | 会不会丢对话 |
+| --- | --- | --- |
+| 空会话 | 只有会话头、一条消息都没有 | 不会 |
+| 孤儿记录 | 会话头已经不在，检查点和气泡还留着 | 不会 |
+| 无引用的内容块 | 没有任何会话引用得到的文件快照和代理消息 | 不会 |
+| 无主子会话 | 父会话已经不在，界面上再也访问不到 | 会 |
+| 项目目录已不存在 | 会话有完整对话，只是当初的项目目录被删或改名 | 会 |
+
+前三类默认勾选，后两类需要自己确认。清理只把数据库内的页面标成空闲，文件不会立刻变小，要点“压缩数据库”才会把磁盘还回去。几 GB 的库压缩需要几分钟。
+
+判断“无引用的内容块”要做一次全库可达性扫描，大库上诊断需要一些时间。判定规则取的是宽松口径，宁可多留也不会误删；扫描中只要有一处读不出来，这一类就整体跳过，不影响其他类别的清理。
 
 ### 统计
 
-统计页汇总本机的 Codex、Claude Code 和 OpenCode 数据，可以查看会话数量、活跃趋势、常用项目、模型分布和活跃时段。没有安装或没有配置的数据源会按零会话处理，不影响其他工具。
+统计页汇总本机的 Codex、Claude Code、OpenCode 和 Cursor 数据，可以查看会话数量、活跃趋势、常用项目、模型分布和活跃时段。没有安装或没有配置的数据源会按零会话处理，不影响其他工具。
 
 ### 修复工具
 
@@ -143,6 +174,8 @@ Codex 用户还可以处理切换模型服务配置后留下的旧会话，或�
 | 克隆到当前模型服务 | Codex 切换模型服务配置后，旧会话无法直接使用 | 创建副本，不改来源 |
 | 补全归档来源标记 | 旧版归档会话缺少来源记录，自动识别切换模型服务产生的克隆分支和回溯分支 | 只写 CC Sessions 自己的来源记录，不改会话文件 |
 | Claude 列表可见性修复 | Claude Code 能续聊，但会话列表不显示标题 | 会在文件末尾补充标题记录 |
+| Cursor 数据库残留 | Cursor 数据库越用越大，里面积压了已删会话的数据 | 只删已经没有会话的记录 |
+| 压缩 Cursor 数据库 | 清理之后磁盘占用没有回落 | 不会改会话数据 |
 
 ## 命令行与 WSL
 
@@ -167,13 +200,14 @@ chmod +x cc-sessions
 
 ### 常用命令
 
-`--provider` 用来选择 Codex、Claude Code 或 OpenCode，可填写 `codex`、`claude` 或 `opencode`。列表、搜索、项目和统计命令还可以使用 `all` 汇总多个数据源。
+`--provider` 用来选择要管理的工具，可填写 `codex`、`claude`、`opencode` 或 `cursor`。列表、搜索、项目和统计命令还可以使用 `all` 汇总多个数据源。
 
 | 用途 | 命令 |
 | --- | --- |
 | 查看完整帮助 | `cc-sessions --help` |
 | 查看最近会话 | `cc-sessions list --limit 20` |
 | 查看 OpenCode 会话 | `cc-sessions --provider opencode list --limit 20` |
+| 查看 Cursor 会话 | `cc-sessions --provider cursor list --limit 20` |
 | 只看子代理会话 | `cc-sessions --provider codex list --subagent` |
 | 按项目查看并包含归档会话 | `cc-sessions --provider codex projects --archived` |
 | 搜索 Claude Code 对话 | `cc-sessions --provider claude search "关键词"` |
@@ -183,10 +217,15 @@ chmod +x cc-sessions
 | 创建备份 | `cc-sessions backup create --backup-dir ./backups --id <session-id> --name my-backup` |
 | 导出会话包 | `cc-sessions bundle export --out-dir ./bundles --id <session-id>` |
 | 导入 OpenCode 会话包 | `cc-sessions --provider opencode bundle import --src-dir ./bundles --mode overwrite --strict` |
+| 把 Cursor 会话转成 Claude Code | `cc-sessions --provider cursor convert <定位符> --to claude` |
 | 检查 Codex 索引问题 | `cc-sessions repair diagnose --json` |
+| 诊断 Cursor 数据库残留 | `cc-sessions repair cursor-residue` |
+| 清理 Cursor 数据库残留 | `cc-sessions repair cursor-residue --prune --kinds orphan_records,orphan_blobs --dry-run` |
 | 启动本地 Web UI | `cc-sessions webui --host 127.0.0.1 --port 17888` |
 
-CLI 默认读取与桌面版相同的数据位置。需要指定其他目录时，可以使用 `--codex-dir`、`--claude-dir` 或 `--opencode-dir`。
+CLI 默认读取与桌面版相同的数据位置。需要指定其他目录时，可以使用 `--codex-dir`、`--claude-dir`、`--opencode-dir` 或 `--cursor-dir`。
+
+清理 Cursor 残留时，`--kinds` 必须自己写明要清哪几类，去掉 `--dry-run` 才会真正执行。可选类别是 `empty_sessions`、`orphan_records`、`orphan_blobs`、`orphan_subagents`、`missing_project`，后两类会丢对话。Cursor 的会话没有单独的文件路径，`convert` 和 `preview` 需要的定位符可以用 `cc-sessions --provider cursor --json list` 从 `rollout_path` 字段取。
 
 `list`、`search` 和 `projects` 默认显示主会话。加入 `--subagent` 后只显示子代理会话。`list` 和 `search` 支持 `--sort size`，可以按会话大小排序。
 
@@ -230,7 +269,7 @@ WSL2 通常可以通过 `http://localhost:17888` 访问。如果必须绑定 `0.
 <details>
 <summary>CC Sessions 默认从哪里读取会话？</summary>
 
-Codex 默认读取 `~/.codex`，Claude Code 默认读取 `~/.claude`，OpenCode 读取当前安装使用的 `opencode.db`。实际路径可以在设置页查看和修改，CLI 也可以通过目录参数覆盖。
+Codex 默认读取 `~/.codex`，Claude Code 默认读取 `~/.claude`，OpenCode 读取当前安装使用的 `opencode.db`。Cursor 读取用户数据目录下的 `globalStorage/state.vscdb`（macOS 在 `~/Library/Application Support/Cursor/User`，Windows 在 `%APPDATA%\Cursor\User`，Linux 在 `~/.config/Cursor/User`），另外还会读取 `~/.cursor/chats` 里 cursor-agent 命令行产生的会话。实际路径可以在设置页查看和修改，CLI 也可以通过目录参数覆盖。
 
 </details>
 
@@ -287,6 +326,38 @@ Codex 归档视图会按归档来源分组：我的归档（手动归档，以�
 <summary>为什么看不到旧版 OpenCode storage 目录里的会话？</summary>
 
 CC Sessions 读取当前 OpenCode 使用的数据库，不会把旧版 `storage/` JSON 与当前数据混在一起。如果旧会话还没有迁入当前 OpenCode，请先用 OpenCode 自身提供的方式处理。
+
+</details>
+
+<details>
+<summary>为什么修改 Cursor 会话前一定要退出 Cursor？</summary>
+
+Cursor 把会话状态缓存在内存里，退出或空闲时才写回数据库。它在运行时改数据库，改动很可能被它按内存中的旧状态覆盖回去，反而更容易出问题。所以 CC Sessions 检测到 Cursor 在运行时会直接拒绝写入，而不是先改了再看运气。后台进程也要一起退出。
+
+</details>
+
+<details>
+<summary>Cursor 数据库为什么会有几个 GB？清理安全吗？</summary>
+
+Cursor 删除会话时只清掉一部分数据，检查点、代码差异、文件快照这些会留在库里，而且没有回收机制，用久了就会积压。
+
+清理只删已经没有会话的记录：按会话归属的数据看它的会话头还在不在，按内容存放的数据则重新算一遍还有没有会话引用得到。判定用的是宽松口径，宁可多留也不会误删；扫描中只要有一处读不出来，那一类就整体跳过。仍然建议清理前先创建备份。
+
+清理完还要点“压缩数据库”，磁盘占用才会真正回落。
+
+</details>
+
+<details>
+<summary>Cursor 的子会话为什么在列表里看不到？</summary>
+
+Cursor 的子会话由主会话持有引用，单独删掉会让主会话指向一个已经不存在的会话。所以它们不在列表里单独出现，只跟着主会话管理，删除主会话时一并删除。如果一个子会话同时被删除范围之外的另一个主会话引用，它会被保留。
+
+</details>
+
+<details>
+<summary>可以把 Claude Code 或 Codex 的会话转成 Cursor 会话吗？</summary>
+
+不可以，只能反过来。Cursor 编辑器内的会话没有命令行入口，就算写进它的数据库也没法从命令行打开继续聊。Cursor 会话可以转成 Claude Code 或 Codex 会话，转完用 `claude --resume` 或 `codex resume` 就能接着聊。
 
 </details>
 

--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -10,7 +10,7 @@ use crate::error::{AppError, AppResult};
 use crate::logs_db;
 use crate::models::{
     ArchiveOrigin, BackupDetail, BackupSummary, BundleExportTarget, Manifest, ManifestArtifact,
-    ManifestSession, RestoreResult, VerifyItem, VerifyReport,
+    ManifestSession, ProviderDirs, RestoreResult, VerifyItem, VerifyReport,
 };
 use crate::path_safety::{self, EntryKind};
 use crate::paths;
@@ -22,6 +22,7 @@ use restore_snapshot::{inject_restore_file_fault, restore_failure_message, Resto
 const PROVIDER_CODEX: &str = "codex";
 const PROVIDER_CLAUDE: &str = "claude";
 const PROVIDER_OPENCODE: &str = "opencode";
+const PROVIDER_CURSOR: &str = "cursor";
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RolloutPresence {
@@ -242,21 +243,60 @@ pub fn create_backup_with_opencode(
     name: Option<String>,
     note: Option<String>,
 ) -> AppResult<BackupSummary> {
+    create_backup_with_dirs(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            opencode_dir,
+            ..ProviderDirs::default()
+        },
+        backup_dir,
+        ids,
+        targets,
+        name,
+        note,
+    )
+}
+
+pub fn create_backup_with_dirs(
+    provider: Option<String>,
+    dirs: ProviderDirs,
+    backup_dir: String,
+    ids: Vec<String>,
+    targets: Option<Vec<BundleExportTarget>>,
+    name: Option<String>,
+    note: Option<String>,
+) -> AppResult<BackupSummary> {
+    let codex_dir = dirs.codex_dir.clone();
     let targets = normalize_backup_targets(&ids, targets)?;
     let provider_name = provider.as_deref().unwrap_or(PROVIDER_CODEX);
     if provider_name == PROVIDER_CLAUDE {
-        let claude = PathBuf::from(
-            claude_dir
-                .unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned()),
+        return create_claude_backup(
+            dirs.claude_path(),
+            PathBuf::from(backup_dir),
+            targets,
+            name,
+            note,
         );
-        return create_claude_backup(claude, PathBuf::from(backup_dir), targets, name, note);
     }
     if provider_name == PROVIDER_OPENCODE {
-        let data_dir = PathBuf::from(
-            opencode_dir
-                .unwrap_or_else(|| paths::default_opencode_dir().to_string_lossy().into_owned()),
+        return create_opencode_backup(
+            dirs.opencode_path(),
+            PathBuf::from(backup_dir),
+            targets,
+            name,
+            note,
         );
-        return create_opencode_backup(data_dir, PathBuf::from(backup_dir), targets, name, note);
+    }
+    if provider_name == PROVIDER_CURSOR {
+        return create_cursor_backup(
+            dirs.cursor_path(),
+            PathBuf::from(backup_dir),
+            targets,
+            name,
+            note,
+        );
     }
 
     let codex = PathBuf::from(&codex_dir);
@@ -753,6 +793,113 @@ fn create_opencode_backup(
     summarize_backup(&final_path)
 }
 
+/// Cursor 备份：每个会话一份自包含的 JSON 快照。
+///
+/// 不能拷 `state.vscdb`——那个文件里还有登录态和全部工作区状态，而且实测有 8 GB。
+fn create_cursor_backup(
+    cursor_dir: PathBuf,
+    backup_root: PathBuf,
+    targets: Vec<BundleExportTarget>,
+    name: Option<String>,
+    note: Option<String>,
+) -> AppResult<BackupSummary> {
+    fs::create_dir_all(&backup_root)?;
+    let final_name = name
+        .map(|n| n.trim().to_string())
+        .unwrap_or_else(|| format!("backup-{}", chrono::Utc::now().format("%Y-%m-%dT%H-%M-%S")));
+    validate_backup_name(&final_name)?;
+    let tmp = backup_root.join(format!(".{}.partial", final_name));
+    let final_path = backup_root.join(&final_name);
+    path_safety::validate_descendant(
+        &backup_root,
+        &tmp,
+        EntryKind::Directory,
+        true,
+        "备份临时目录",
+    )?;
+    path_safety::validate_descendant(
+        &backup_root,
+        &final_path,
+        EntryKind::Directory,
+        true,
+        "备份目标目录",
+    )?;
+    if final_path.exists() {
+        return Err(AppError::Other(format!("备份目录已存在: {final_name}")));
+    }
+    if tmp.exists() {
+        return Err(AppError::Other(format!(
+            "存在未完成的临时备份目录，请先检查或移除: {}",
+            tmp.to_string_lossy()
+        )));
+    }
+
+    let sessions = crate::cursor_sessions::list_sessions(
+        &cursor_dir,
+        &crate::paths::default_cursor_agent_dir(),
+    )?
+    .into_iter()
+    .map(|session| (session.id.clone(), session))
+    .collect::<HashMap<_, _>>();
+    let mut manifest = Manifest {
+        version: 5,
+        provider: Some(PROVIDER_CURSOR.to_string()),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        codex_dir: String::new(),
+        claude_dir: None,
+        opencode_dir: None,
+        note,
+        artifacts: Vec::new(),
+        sessions: Vec::new(),
+    };
+    for target in targets {
+        let summary = sessions
+            .get(&target.id)
+            .ok_or_else(|| AppError::NotFound(format!("Cursor 会话不存在: {}", target.id)))?;
+        if !summary.resume_command.is_empty() {
+            return Err(AppError::Other(format!(
+                "cursor-agent 会话暂不支持备份: {}",
+                target.id
+            )));
+        }
+        let snapshot = crate::cursor_transfer::export_snapshot(&cursor_dir, &target.id)?;
+        let relative = snapshot_relpath(PROVIDER_CURSOR, &target.id);
+        let destination = tmp.join(&relative);
+        crate::cursor_transfer::write_snapshot(&destination, &snapshot)?;
+        let sha = sha256_file(&destination)?;
+        let bytes = fs::metadata(&destination)?.len();
+        manifest.sessions.push(ManifestSession {
+            provider: Some(PROVIDER_CURSOR.to_string()),
+            id: target.id,
+            rollout_relpath: relative.to_string_lossy().replace('\\', "/"),
+            source_relpath: None,
+            sidecar_relpath: None,
+            sidecar_files: Vec::new(),
+            companions_relpath: None,
+            companion_files: Vec::new(),
+            tasks_relpath: None,
+            task_files: Vec::new(),
+            title: summary.title.clone(),
+            cwd: summary.cwd.clone(),
+            created_at: summary.created_at,
+            updated_at: summary.updated_at,
+            tokens_used: summary.tokens_used,
+            model: summary.model.clone(),
+            bytes_rollout: bytes,
+            logs_count: 0,
+            history_rows: 0,
+            sha256_rollout: sha,
+        });
+    }
+    fs::write(
+        tmp.join("manifest.json"),
+        serde_json::to_vec_pretty(&manifest)?,
+    )?;
+    fs::rename(&tmp, &final_path)?;
+    summarize_backup(&final_path)
+}
+
 fn normalize_backup_targets(
     ids: &[String],
     targets: Option<Vec<BundleExportTarget>>,
@@ -1040,16 +1187,29 @@ fn validate_claude_source_relpath(raw: &str, id: &str) -> AppResult<PathBuf> {
 }
 
 fn validate_opencode_snapshot_relpath(raw: &str, id: &str) -> AppResult<PathBuf> {
+    validate_snapshot_relpath(PROVIDER_OPENCODE, raw, id)
+}
+
+fn validate_cursor_snapshot_relpath(raw: &str, id: &str) -> AppResult<PathBuf> {
+    validate_snapshot_relpath(PROVIDER_CURSOR, raw, id)
+}
+
+/// 以会话快照 JSON 形式落盘的 provider 共用同一套路径约束。
+fn validate_snapshot_relpath(provider: &str, raw: &str, id: &str) -> AppResult<PathBuf> {
     let relative = paths::checked_relative_path(raw)?;
-    let expected = PathBuf::from(PROVIDER_OPENCODE)
-        .join("sessions")
-        .join(format!("{}.json", paths::sanitize_slug(id)));
+    let expected = snapshot_relpath(provider, id);
     if relative != expected {
         return Err(AppError::Path(format!(
-            "OpenCode 备份快照路径与会话 ID 不匹配: id={id} path={raw}"
+            "{provider} 备份快照路径与会话 ID 不匹配: id={id} path={raw}"
         )));
     }
     Ok(relative)
+}
+
+fn snapshot_relpath(provider: &str, id: &str) -> PathBuf {
+    PathBuf::from(provider)
+        .join("sessions")
+        .join(format!("{}.json", paths::sanitize_slug(id)))
 }
 
 fn validate_manifest_paths(manifest: &Manifest) -> AppResult<()> {
@@ -1083,7 +1243,7 @@ fn validate_manifest_paths(manifest: &Manifest) -> AppResult<()> {
         });
         let expected = match provider {
             PROVIDER_CLAUDE => ["history.jsonl"].into_iter().collect::<HashSet<_>>(),
-            PROVIDER_OPENCODE => HashSet::new(),
+            PROVIDER_OPENCODE | PROVIDER_CURSOR => HashSet::new(),
             _ => ["history.jsonl", "logs.ndjson", "threads.json"]
                 .into_iter()
                 .collect::<HashSet<_>>(),
@@ -1204,15 +1364,16 @@ fn validate_manifest_paths(manifest: &Manifest) -> AppResult<()> {
                     }
                 }
             }
-            PROVIDER_OPENCODE => {
-                validate_opencode_snapshot_relpath(&session.rollout_relpath, &session.id)?;
+            // 这两个 provider 都以单份 JSON 快照落盘，不该带任何文件型附属资产。
+            PROVIDER_OPENCODE | PROVIDER_CURSOR => {
+                validate_snapshot_relpath(provider, &session.rollout_relpath, &session.id)?;
                 if session.source_relpath.is_some()
                     || session.sidecar_relpath.is_some()
                     || session.companions_relpath.is_some()
                     || session.tasks_relpath.is_some()
                 {
                     return Err(AppError::Path(format!(
-                        "OpenCode 备份不应声明文件型附属资产: {}",
+                        "{provider} 备份不应声明文件型附属资产: {}",
                         session.id
                     )));
                 }
@@ -1228,6 +1389,9 @@ fn validate_manifest_paths(manifest: &Manifest) -> AppResult<()> {
 fn verify_rollout_identity(source: &Path, expected_id: &str, provider: &str) -> AppResult<()> {
     if provider == PROVIDER_OPENCODE {
         return crate::opencode_transfer::verify_snapshot_file(source, expected_id);
+    }
+    if provider == PROVIDER_CURSOR {
+        return crate::cursor_transfer::verify_snapshot_file(source, expected_id);
     }
     if provider == PROVIDER_CODEX {
         let brief = crate::repair::read_rollout_brief(source.parent().unwrap_or(source), source)?
@@ -1655,15 +1819,36 @@ pub fn restore_session_with_opencode(
     backup_rollout_relpath: Option<String>,
     overwrite: bool,
 ) -> AppResult<RestoreResult> {
+    restore_session_with_dirs(
+        provider,
+        backup_dir,
+        backup_path,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            opencode_dir,
+            ..ProviderDirs::default()
+        },
+        id,
+        backup_rollout_relpath,
+        overwrite,
+    )
+}
+
+pub fn restore_session_with_dirs(
+    provider: Option<String>,
+    backup_dir: String,
+    backup_path: String,
+    dirs: ProviderDirs,
+    id: String,
+    backup_rollout_relpath: Option<String>,
+    overwrite: bool,
+) -> AppResult<RestoreResult> {
     let backup = validated_backup_path(Path::new(&backup_dir), Path::new(&backup_path))?;
-    let codex = PathBuf::from(&codex_dir);
-    let claude = PathBuf::from(
-        claude_dir.unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned()),
-    );
-    let opencode = PathBuf::from(
-        opencode_dir
-            .unwrap_or_else(|| paths::default_opencode_dir().to_string_lossy().into_owned()),
-    );
+    let codex = dirs.codex_path();
+    let claude = dirs.claude_path();
+    let opencode = dirs.opencode_path();
+    let cursor = dirs.cursor_path();
     let manifest = load_backup_manifest(&backup)?;
     validate_backup_payload(&backup, &manifest, RolloutPresence::Required)?;
     let matches = manifest
@@ -1710,6 +1895,7 @@ pub fn restore_session_with_opencode(
     match provider {
         PROVIDER_CLAUDE => restore_one_claude(&backup, &claude, target, overwrite),
         PROVIDER_OPENCODE => restore_one_opencode(&backup, &opencode, target, overwrite),
+        PROVIDER_CURSOR => restore_one_cursor(&backup, &cursor, target, overwrite),
         _ => restore_one(&backup, &codex, target, overwrite),
     }
 }
@@ -1719,22 +1905,18 @@ pub fn restore_session_with_lock(
     provider: Option<String>,
     backup_dir: String,
     backup_path: String,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     id: String,
     backup_rollout_relpath: Option<String>,
     overwrite: bool,
     lock: &crate::family::FamilyLock,
 ) -> AppResult<RestoreResult> {
     crate::family::with_lock(lock, |_guard| {
-        restore_session_with_opencode(
+        restore_session_with_dirs(
             provider,
             backup_dir,
             backup_path,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            dirs,
             id,
             backup_rollout_relpath,
             overwrite,
@@ -1770,15 +1952,32 @@ pub fn restore_all_with_opencode(
     opencode_dir: Option<String>,
     overwrite: bool,
 ) -> AppResult<Vec<RestoreResult>> {
+    restore_all_with_dirs(
+        provider,
+        backup_dir,
+        backup_path,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            opencode_dir,
+            ..ProviderDirs::default()
+        },
+        overwrite,
+    )
+}
+
+pub fn restore_all_with_dirs(
+    provider: Option<String>,
+    backup_dir: String,
+    backup_path: String,
+    dirs: ProviderDirs,
+    overwrite: bool,
+) -> AppResult<Vec<RestoreResult>> {
     let backup = validated_backup_path(Path::new(&backup_dir), Path::new(&backup_path))?;
-    let codex = PathBuf::from(&codex_dir);
-    let claude = PathBuf::from(
-        claude_dir.unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned()),
-    );
-    let opencode = PathBuf::from(
-        opencode_dir
-            .unwrap_or_else(|| paths::default_opencode_dir().to_string_lossy().into_owned()),
-    );
+    let codex = dirs.codex_path();
+    let claude = dirs.claude_path();
+    let opencode = dirs.opencode_path();
+    let cursor = dirs.cursor_path();
     let manifest = load_backup_manifest(&backup)?;
     validate_backup_payload(&backup, &manifest, RolloutPresence::Required)?;
     if let Some(requested) = provider.as_deref() {
@@ -1801,6 +2000,7 @@ pub fn restore_all_with_opencode(
             (match session_provider {
                 PROVIDER_CLAUDE => restore_one_claude(&backup, &claude, s, overwrite),
                 PROVIDER_OPENCODE => restore_one_opencode(&backup, &opencode, s, overwrite),
+                PROVIDER_CURSOR => restore_one_cursor(&backup, &cursor, s, overwrite),
                 _ => restore_one(&backup, &codex, s, overwrite),
             })
             .unwrap_or_else(|e| RestoreResult {
@@ -1823,22 +2023,12 @@ pub fn restore_all_with_lock(
     provider: Option<String>,
     backup_dir: String,
     backup_path: String,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     overwrite: bool,
     lock: &crate::family::FamilyLock,
 ) -> AppResult<Vec<RestoreResult>> {
     crate::family::with_lock(lock, |_guard| {
-        restore_all_with_opencode(
-            provider,
-            backup_dir,
-            backup_path,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
-            overwrite,
-        )
+        restore_all_with_dirs(provider, backup_dir, backup_path, dirs, overwrite)
     })
 }
 
@@ -2023,6 +2213,37 @@ fn restore_one_opencode(
     if !outcome.written {
         result.conflict = true;
         result.error = outcome.skipped_reason;
+        return Ok(result);
+    }
+    result.rollout_copied = true;
+    result.threads_inserted = true;
+    result.ok = true;
+    Ok(result)
+}
+
+fn restore_one_cursor(
+    backup: &Path,
+    cursor_dir: &Path,
+    target: &ManifestSession,
+    overwrite: bool,
+) -> AppResult<RestoreResult> {
+    let mut result = RestoreResult {
+        id: target.id.clone(),
+        ok: false,
+        threads_inserted: false,
+        logs_inserted: 0,
+        history_appended: 0,
+        rollout_copied: false,
+        conflict: false,
+        error: None,
+    };
+    let relative = validate_cursor_snapshot_relpath(&target.rollout_relpath, &target.id)?;
+    let source = backup.join(relative);
+    verify_restore_source(backup, &source, target, PROVIDER_CURSOR)?;
+    let snapshot = crate::cursor_transfer::read_snapshot(&source, &target.id)?;
+    if !crate::cursor_transfer::import_snapshot(cursor_dir, &snapshot, overwrite)? {
+        result.conflict = true;
+        result.error = Some("目标库中已存在同 ID 会话".into());
         return Ok(result);
     }
     result.rollout_copied = true;
@@ -2619,9 +2840,7 @@ mod tests {
                 None,
                 "missing-backup-root".into(),
                 "missing-backup".into(),
-                "missing-codex".into(),
-                None,
-                None,
+                ProviderDirs::new("missing-codex".into()),
                 "missing-session".into(),
                 None,
                 false,
@@ -2633,9 +2852,7 @@ mod tests {
                 None,
                 "missing-backup-root".into(),
                 "missing-backup".into(),
-                "missing-codex".into(),
-                None,
-                None,
+                ProviderDirs::new("missing-codex".into()),
                 false,
                 &lock,
             )

--- a/src-tauri/src/bin/cc-sessions.rs
+++ b/src-tauri/src/bin/cc-sessions.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use cc_session_manager_lib::error::AppError;
 use cc_session_manager_lib::models::{
     BackupSummary, BundleExportTarget, BundleListItem, ConvertReport, ImportMode, ProjectGroup,
-    SessionSummary, Settings, SwitchStrategy,
+    ProviderDirs, SessionSummary, Settings, SwitchStrategy,
 };
 use cc_session_manager_lib::{
     backup, bundle, convert, family, fs_ops, paths, repair, rollout, sessions, settings, stats,
@@ -64,7 +64,21 @@ struct CliContext {
     claude_dir_explicit: bool,
     opencode_dir: String,
     opencode_dir_explicit: bool,
+    cursor_dir: String,
+    cursor_dir_explicit: bool,
     family_lock: family::FamilyLock,
+}
+
+impl CliContext {
+    fn dirs(&self) -> ProviderDirs {
+        ProviderDirs {
+            codex_dir: self.codex_dir.clone(),
+            claude_dir: Some(self.claude_dir.clone()),
+            opencode_dir: Some(self.opencode_dir.clone()),
+            cursor_dir: Some(self.cursor_dir.clone()),
+            cursor_agent_dir: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -118,6 +132,10 @@ fn run_cli() -> CliResult<()> {
     let opencode_dir_explicit = opencode_dir_arg.is_some();
     let opencode_dir = opencode_dir_arg
         .unwrap_or_else(|| paths::default_opencode_dir().to_string_lossy().into_owned());
+    let cursor_dir_arg = take_value(&mut args, "--cursor-dir")?;
+    let cursor_dir_explicit = cursor_dir_arg.is_some();
+    let cursor_dir = cursor_dir_arg
+        .unwrap_or_else(|| paths::default_cursor_dir().to_string_lossy().into_owned());
 
     if help {
         print_help();
@@ -133,6 +151,8 @@ fn run_cli() -> CliResult<()> {
         claude_dir_explicit,
         opencode_dir,
         opencode_dir_explicit,
+        cursor_dir,
+        cursor_dir_explicit,
         family_lock: family::FamilyLock::default(),
     };
 
@@ -142,6 +162,7 @@ fn run_cli() -> CliResult<()> {
             ctx.codex_dir.clone(),
             ctx.claude_dir.clone(),
             ctx.opencode_dir.clone(),
+            ctx.cursor_dir.clone(),
         )
         .map_err(CliError::message);
     };
@@ -154,6 +175,7 @@ fn run_cli() -> CliResult<()> {
                 ctx.codex_dir.clone(),
                 ctx.claude_dir.clone(),
                 ctx.opencode_dir.clone(),
+                ctx.cursor_dir.clone(),
             )
             .map_err(CliError::message)
         }
@@ -189,10 +211,11 @@ fn print_help() {
 
 全局选项:
   --json                    输出 JSON
-  --provider <codex|claude|opencode|all>  会话、统计与 webui 使用的 provider
+  --provider <codex|claude|opencode|cursor|all>  会话、统计与 webui 使用的 provider
   --codex-dir <路径>         默认读取 ~/.codex
   --claude-dir <路径>        默认读取 ~/.claude
   --opencode-dir <路径>      默认读取 ~/.local/share/opencode
+  --cursor-dir <路径>        Cursor 用户数据目录，默认 <配置目录>/Cursor/User
   -h, --help                显示帮助
 
 常用命令:
@@ -203,11 +226,11 @@ fn print_help() {
   webui [--host 127.0.0.1] [--port 17888]
   meta <rollout路径>
   resume-command <session-id>
-  convert <会话JSONL路径> [--mode simple|native]  # --provider 表示来源
+  convert <会话路径或定位符> [--mode simple|native] [--to claude|codex]  # --provider 表示来源
   stats <kpi|projects|models|timeseries|heatmap>
   backup <create|list|open|verify|delete|restore|restore-all>
   bundle <export|export-all|list|verify|import|pack|unpack>
-  repair <provider-info|project-configs|diagnose|index|threads|prune|claude-history|claude-gui|clone|batch-clone|fork>
+  repair <provider-info|project-configs|diagnose|index|threads|prune|claude-history|claude-gui|cursor-residue|clone|batch-clone|fork>
   family <store|verify|overlay|rollback|delete-branch|sync-states|sync-into-active|sync-active-into>
   settings <defaults|read|validate>
   menu
@@ -266,29 +289,17 @@ fn cmd_search(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
 
     let provider = session_provider(ctx)?;
     let mut hits = if provider == "all" {
-        let mut providers = vec!["codex", "claude"];
-        if Path::new(&ctx.opencode_dir).join("opencode.db").is_file() {
-            providers.push("opencode");
-        }
         let mut all_hits = Vec::new();
-        for current in providers {
-            all_hits.extend(sessions::search_sessions_with_opencode(
+        for current in installed_providers(ctx) {
+            all_hits.extend(sessions::search_sessions_with_dirs(
                 Some(current.to_string()),
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 query.clone(),
             )?);
         }
         all_hits
     } else {
-        sessions::search_sessions_with_opencode(
-            Some(provider),
-            ctx.codex_dir.clone(),
-            Some(ctx.claude_dir.clone()),
-            Some(ctx.opencode_dir.clone()),
-            query,
-        )?
+        sessions::search_sessions_with_dirs(Some(provider), ctx.dirs(), query)?
     };
     if !include_archived {
         hits.retain(|session| !session.archived);
@@ -339,7 +350,7 @@ fn cmd_webui(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
     webui::validate_host(&host)?;
     let default_provider = match ctx.provider.as_deref() {
         None => None,
-        Some("codex" | "claude" | "opencode") => ctx.provider.clone(),
+        Some("codex" | "claude" | "opencode" | "cursor") => ctx.provider.clone(),
         Some("all") => {
             return Err(CliError::message(
                 "webui 不支持 --provider all；请使用 codex、claude 或 opencode",
@@ -361,6 +372,8 @@ fn cmd_webui(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
         claude_dir_explicit: ctx.claude_dir_explicit,
         opencode_dir: ctx.opencode_dir.clone(),
         opencode_dir_explicit: ctx.opencode_dir_explicit,
+        cursor_dir: ctx.cursor_dir.clone(),
+        cursor_dir_explicit: ctx.cursor_dir_explicit,
     })?;
     Ok(())
 }
@@ -540,16 +553,28 @@ fn cmd_resume_command(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> 
 
 fn cmd_convert(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
     let conversion_mode = parse_conversion_mode(take_value(&mut args, "--mode")?)?;
+    let target_provider = take_value(&mut args, "--to")?;
     let rollout_path = conversion_path_arg(&mut args)?;
     ensure_no_args(&args)?;
     let source_provider = concrete_provider(ctx)?;
     if source_provider == "opencode" {
         return Err(CliError::message("OpenCode 会话暂不支持转换"));
     }
-    let report = convert::convert_session_with_lock(
-        ctx.codex_dir.clone(),
-        ctx.claude_dir.clone(),
+    if let Some(target) = target_provider.as_deref() {
+        if !matches!(target, "claude" | "codex") {
+            return Err(CliError::message(format!(
+                "--to 只支持 claude 或 codex，收到: {target}"
+            )));
+        }
+    } else if source_provider == "cursor" {
+        return Err(CliError::message(
+            "Cursor 会话可以转到 Claude 或 Codex，请用 --to 指定目标",
+        ));
+    }
+    let report = convert::convert_session_with_target(
+        ctx.dirs(),
         source_provider,
+        target_provider,
         rollout_path,
         conversion_mode,
         &ctx.family_lock,
@@ -572,9 +597,7 @@ fn cmd_stats(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
             ensure_no_args(&args)?;
             let data = stats::stats_kpi(
                 Some(provider),
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 from_ts,
                 to_ts,
                 cwd_filter,
@@ -592,9 +615,7 @@ fn cmd_stats(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
             ensure_no_args(&args)?;
             let data = stats::stats_by_project(
                 Some(provider),
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 from_ts,
                 to_ts,
                 limit,
@@ -618,9 +639,7 @@ fn cmd_stats(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
             ensure_no_args(&args)?;
             let data = stats::stats_by_model(
                 Some(provider),
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 from_ts,
                 to_ts,
                 cwd_filter,
@@ -645,9 +664,7 @@ fn cmd_stats(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
             ensure_no_args(&args)?;
             let data = stats::stats_timeseries(
                 Some(provider),
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 from_ts,
                 to_ts,
                 bucket,
@@ -665,9 +682,7 @@ fn cmd_stats(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
             ensure_no_args(&args)?;
             let data = stats::stats_heatmap(
                 Some(provider),
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 from_ts,
                 to_ts,
                 cwd_filter,
@@ -700,11 +715,9 @@ fn cmd_backup(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
             let name = take_value(&mut args, "--name")?;
             let note = take_value(&mut args, "--note")?;
             ensure_no_args(&args)?;
-            let summary = backup::create_backup_with_opencode(
+            let summary = backup::create_backup_with_dirs(
                 Some(concrete_provider(ctx)?),
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 backup_dir,
                 ids,
                 None,
@@ -773,9 +786,7 @@ fn cmd_backup(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
                 Some(concrete_provider(ctx)?),
                 backup_root,
                 backup_path,
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 id,
                 None,
                 overwrite,
@@ -800,9 +811,7 @@ fn cmd_backup(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
                 Some(concrete_provider(ctx)?),
                 backup_root,
                 backup_path,
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 overwrite,
                 &ctx.family_lock,
             )?;
@@ -855,11 +864,9 @@ fn cmd_bundle(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
                         .collect(),
                 )
             };
-            let reports = bundle::export_session_bundles_with_opencode(
+            let reports = bundle::export_session_bundles_with_dirs(
                 Some(concrete_provider(ctx)?),
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 out_dir,
                 ids,
                 targets,
@@ -877,11 +884,9 @@ fn cmd_bundle(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
             let export_group = take_value(&mut args, "--export-group")?;
             let active_only = take_flag(&mut args, "--active-only");
             ensure_no_args(&args)?;
-            let reports = bundle::export_all_bundles_with_opencode(
+            let reports = bundle::export_all_bundles_with_dirs(
                 Some(concrete_provider(ctx)?),
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 out_dir,
                 machine_label,
                 export_group,
@@ -910,9 +915,7 @@ fn cmd_bundle(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
             let reports = bundle::import_session_bundles_with_lock(
                 Some(concrete_provider(ctx)?),
                 src_dir,
-                ctx.codex_dir.clone(),
-                Some(ctx.claude_dir.clone()),
-                Some(ctx.opencode_dir.clone()),
+                ctx.dirs(),
                 mode,
                 make_visible,
                 strict,
@@ -1109,6 +1112,54 @@ fn cmd_repair(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
                 );
                 for family_id in &report.families_skipped {
                     println!("family_skipped\t{family_id}");
+                }
+            })
+        }
+        "cursor-residue" => {
+            let prune = take_flag(&mut args, "--prune");
+            let kinds = take_value(&mut args, "--kinds")?;
+            let dry_run = take_flag(&mut args, "--dry-run");
+            ensure_no_args(&args)?;
+            if !prune {
+                let report = cc_session_manager_lib::cursor_mutate::diagnose_residue(&ctx.dirs())?;
+                return output(ctx, &report, |report| {
+                    println!("database\t{}", report.database_path);
+                    println!(
+                        "headers\t{}\tvisible\t{}",
+                        report.header_rows, report.visible_sessions
+                    );
+                    for group in &report.groups {
+                        println!(
+                            "{}\t会话 {}\t行 {}\t字节 {}\t破坏性 {}\t{}",
+                            group.kind,
+                            group.sessions,
+                            group.rows,
+                            group.bytes,
+                            group.destructive,
+                            group.label
+                        );
+                    }
+                });
+            }
+            let kinds = kinds
+                .map(|value| {
+                    value
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|kind| !kind.is_empty())
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let report =
+                cc_session_manager_lib::cursor_mutate::prune_residue(&ctx.dirs(), &kinds, dry_run)?;
+            output(ctx, &report, |report| {
+                println!("dry_run\t{}", report.dry_run);
+                println!("removed_headers\t{}", report.removed_header_rows);
+                println!("removed_rows\t{}", report.removed_kv_rows);
+                println!("freed_bytes\t{}", report.freed_bytes);
+                if report.blob_scan_errors > 0 {
+                    println!("blob_scan_errors\t{}", report.blob_scan_errors);
                 }
             })
         }
@@ -1445,6 +1496,7 @@ fn cmd_settings(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
                 println!("codex_dir\t{}", settings.codex_dir);
                 println!("claude_dir\t{}", settings.claude_dir);
                 println!("opencode_dir\t{}", settings.opencode_dir);
+                println!("cursor_dir\t{}", settings.cursor_dir);
                 println!("backup_dir\t{}", settings.backup_dir);
                 println!("refresh_interval_ms\t{}", settings.refresh_interval_ms);
             })
@@ -1457,6 +1509,7 @@ fn cmd_settings(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
                 println!("codex_dir\t{}", settings.codex_dir);
                 println!("claude_dir\t{}", settings.claude_dir);
                 println!("opencode_dir\t{}", settings.opencode_dir);
+                println!("cursor_dir\t{}", settings.cursor_dir);
                 println!("backup_dir\t{}", settings.backup_dir);
                 println!("refresh_interval_ms\t{}", settings.refresh_interval_ms);
             })
@@ -1466,10 +1519,12 @@ fn cmd_settings(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
             let codex = settings::validate_codex_dir(ctx.codex_dir.clone())?;
             let claude = settings::validate_claude_dir(ctx.claude_dir.clone())?;
             let opencode = settings::validate_opencode_dir(ctx.opencode_dir.clone())?;
+            let cursor = settings::validate_cursor_dir(ctx.cursor_dir.clone())?;
             let report = HashMap::from([
                 ("codex", serde_json::to_value(codex)?),
                 ("claude", serde_json::to_value(claude)?),
                 ("opencode", serde_json::to_value(opencode)?),
+                ("cursor", serde_json::to_value(cursor)?),
             ]);
             output(ctx, &report, |report| {
                 for (name, value) in report {
@@ -1481,26 +1536,33 @@ fn cmd_settings(ctx: &CliContext, mut args: Vec<String>) -> CliResult<()> {
     }
 }
 
+/// `all` 只聚合本机确实装了的 Agent，缺一个不该让整条命令失败。
+fn installed_providers(ctx: &CliContext) -> Vec<&'static str> {
+    let mut providers = vec!["codex", "claude"];
+    if Path::new(&ctx.opencode_dir).join("opencode.db").is_file() {
+        providers.push("opencode");
+    }
+    let cursor_dir = PathBuf::from(&ctx.cursor_dir);
+    if cc_session_manager_lib::cursor_sessions::state_db_path(&cursor_dir).is_file()
+        || paths::cursor_agent_chats_dir(&paths::default_cursor_agent_dir()).is_dir()
+    {
+        providers.push("cursor");
+    }
+    providers
+}
+
 fn load_sessions(ctx: &CliContext, provider: String) -> CliResult<Vec<SessionSummary>> {
     match provider.as_str() {
-        "codex" | "claude" | "opencode" => Ok(sessions::list_sessions_with_opencode(
+        "codex" | "claude" | "opencode" | "cursor" => Ok(sessions::list_sessions_with_dirs(
             Some(provider),
-            ctx.codex_dir.clone(),
-            Some(ctx.claude_dir.clone()),
-            Some(ctx.opencode_dir.clone()),
+            ctx.dirs(),
         )?),
         "all" => {
-            let mut providers = vec!["codex", "claude"];
-            if Path::new(&ctx.opencode_dir).join("opencode.db").is_file() {
-                providers.push("opencode");
-            }
             let mut list = Vec::new();
-            for current in providers {
-                list.extend(sessions::list_sessions_with_opencode(
+            for current in installed_providers(ctx) {
+                list.extend(sessions::list_sessions_with_dirs(
                     Some(current.to_string()),
-                    ctx.codex_dir.clone(),
-                    Some(ctx.claude_dir.clone()),
-                    Some(ctx.opencode_dir.clone()),
+                    ctx.dirs(),
                 )?);
             }
             list.sort_by_key(|session| std::cmp::Reverse(session.updated_at));
@@ -1559,7 +1621,7 @@ fn group_projects(list: Vec<SessionSummary>, include_archived: bool) -> Vec<Proj
 fn session_provider(ctx: &CliContext) -> CliResult<String> {
     let provider = ctx.provider.clone().unwrap_or_else(|| "codex".to_string());
     match provider.as_str() {
-        "codex" | "claude" | "opencode" | "all" => Ok(provider),
+        "codex" | "claude" | "opencode" | "cursor" | "all" => Ok(provider),
         other => Err(CliError::message(format!("不支持的 provider: {other}"))),
     }
 }
@@ -1900,6 +1962,8 @@ mod tests {
             claude_dir_explicit: false,
             opencode_dir: "opencode".into(),
             opencode_dir_explicit: false,
+            cursor_dir: "cursor".into(),
+            cursor_dir_explicit: false,
             family_lock: family::FamilyLock::default(),
         }
     }

--- a/src-tauri/src/bundle.rs
+++ b/src-tauri/src/bundle.rs
@@ -33,7 +33,7 @@ use crate::error::{AppError, AppResult};
 use crate::family;
 use crate::models::{
     ArchiveOrigin, BundleExportTarget, BundleListItem, BundleManifest, ExportReport, ImportMode,
-    ImportReport, ManifestArtifact, ProjectPathMapping, SessionSummary,
+    ImportReport, ManifestArtifact, ProjectPathMapping, ProviderDirs, SessionSummary,
 };
 use crate::paths;
 use crate::state_db;
@@ -42,6 +42,7 @@ const BUNDLE_VERSION: u32 = 2;
 const PROVIDER_CODEX: &str = "codex";
 const PROVIDER_CLAUDE: &str = "claude";
 const PROVIDER_OPENCODE: &str = "opencode";
+const PROVIDER_CURSOR: &str = "cursor";
 const DEFAULT_SANDBOX_POLICY: &str = "read-only";
 const DEFAULT_APPROVAL_MODE: &str = "on-request";
 const DEFAULT_MEMORY_MODE: &str = "enabled";
@@ -578,6 +579,35 @@ pub fn export_session_bundles_with_opencode(
     machine_label: Option<String>,
     export_group: Option<String>,
 ) -> AppResult<Vec<ExportReport>> {
+    export_session_bundles_with_dirs(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            opencode_dir,
+            ..ProviderDirs::default()
+        },
+        out_dir,
+        ids,
+        targets,
+        machine_label,
+        export_group,
+    )
+}
+
+pub fn export_session_bundles_with_dirs(
+    provider: Option<String>,
+    dirs: ProviderDirs,
+    out_dir: String,
+    ids: Vec<String>,
+    targets: Option<Vec<BundleExportTarget>>,
+    machine_label: Option<String>,
+    export_group: Option<String>,
+) -> AppResult<Vec<ExportReport>> {
+    let codex_dir = dirs.codex_dir.clone();
+    let claude_dir = Some(dirs.claude_path().to_string_lossy().into_owned());
+    let opencode_dir = Some(dirs.opencode_path().to_string_lossy().into_owned());
+    let cursor_dir = Some(dirs.cursor_path().to_string_lossy().into_owned());
     let targets = normalize_bundle_export_targets(&ids, targets)?;
     let provider_name = provider.as_deref().unwrap_or(PROVIDER_CODEX);
     if provider_name == PROVIDER_CLAUDE {
@@ -600,6 +630,19 @@ pub fn export_session_bundles_with_opencode(
         );
         return export_opencode_session_bundles(
             &data_dir,
+            &PathBuf::from(out_dir),
+            &targets,
+            machine_label.as_deref(),
+            export_group.as_deref(),
+        );
+    }
+    if provider_name == PROVIDER_CURSOR {
+        let cursor = PathBuf::from(
+            cursor_dir
+                .unwrap_or_else(|| paths::default_cursor_dir().to_string_lossy().into_owned()),
+        );
+        return export_cursor_session_bundles(
+            &cursor,
             &PathBuf::from(out_dir),
             &targets,
             machine_label.as_deref(),
@@ -1289,6 +1332,33 @@ pub fn export_all_bundles_with_opencode(
     export_group: Option<String>,
     active_only: bool,
 ) -> AppResult<Vec<ExportReport>> {
+    export_all_bundles_with_dirs(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            opencode_dir,
+            ..ProviderDirs::default()
+        },
+        out_dir,
+        machine_label,
+        export_group,
+        active_only,
+    )
+}
+
+pub fn export_all_bundles_with_dirs(
+    provider: Option<String>,
+    dirs: ProviderDirs,
+    out_dir: String,
+    machine_label: Option<String>,
+    export_group: Option<String>,
+    active_only: bool,
+) -> AppResult<Vec<ExportReport>> {
+    let codex_dir = dirs.codex_dir.clone();
+    let claude_dir = Some(dirs.claude_path().to_string_lossy().into_owned());
+    let opencode_dir = Some(dirs.opencode_path().to_string_lossy().into_owned());
+    let cursor_dir = Some(dirs.cursor_path().to_string_lossy().into_owned());
     let provider_name = provider.as_deref().unwrap_or(PROVIDER_CODEX);
     if provider_name == PROVIDER_CLAUDE {
         let claude = PathBuf::from(
@@ -1327,6 +1397,30 @@ pub fn export_all_bundles_with_opencode(
             .collect::<Vec<_>>();
         return export_opencode_session_bundles(
             &data_dir,
+            &PathBuf::from(out_dir),
+            &targets,
+            machine_label.as_deref(),
+            export_group.as_deref(),
+        );
+    }
+    if provider_name == PROVIDER_CURSOR {
+        let cursor = PathBuf::from(
+            cursor_dir
+                .unwrap_or_else(|| paths::default_cursor_dir().to_string_lossy().into_owned()),
+        );
+        let targets =
+            crate::cursor_sessions::list_sessions(&cursor, &paths::default_cursor_agent_dir())?
+                .into_iter()
+                // cursor-agent 会话不落在 state.vscdb 里，导出格式另说，本期不导。
+                .filter(|session| session.resume_command.is_empty())
+                .filter(|session| !active_only || !session.archived)
+                .map(|session| BundleExportTarget {
+                    id: session.id,
+                    rollout_path: Some(session.rollout_path),
+                })
+                .collect::<Vec<_>>();
+        return export_cursor_session_bundles(
+            &cursor,
             &PathBuf::from(out_dir),
             &targets,
             machine_label.as_deref(),
@@ -1459,7 +1553,8 @@ pub fn verify_bundles(src_dir: String, provider: Option<String>) -> AppResult<Ve
                 validate_claude_bundle_rollout_relpath(source_rel, &it.manifest.session_id)?;
                 rel
             }
-            PROVIDER_OPENCODE => validate_opencode_bundle_rollout_relpath(
+            PROVIDER_OPENCODE | PROVIDER_CURSOR => validate_snapshot_bundle_relpath(
+                provider,
                 &it.manifest.rollout_relpath,
                 &it.manifest.session_id,
             )?,
@@ -1530,6 +1625,35 @@ pub fn import_session_bundles_with_opencode(
     strict: bool,
     project_mappings: Vec<ProjectPathMapping>,
 ) -> AppResult<Vec<ImportReport>> {
+    import_session_bundles_with_dirs(
+        provider,
+        src_dir,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            opencode_dir,
+            ..ProviderDirs::default()
+        },
+        mode,
+        make_visible,
+        strict,
+        project_mappings,
+    )
+}
+
+pub fn import_session_bundles_with_dirs(
+    provider: Option<String>,
+    src_dir: String,
+    dirs: ProviderDirs,
+    mode: ImportMode,
+    make_visible: bool,
+    strict: bool,
+    project_mappings: Vec<ProjectPathMapping>,
+) -> AppResult<Vec<ImportReport>> {
+    let codex_dir = dirs.codex_dir.clone();
+    let claude_dir = Some(dirs.claude_path().to_string_lossy().into_owned());
+    let opencode_dir = Some(dirs.opencode_path().to_string_lossy().into_owned());
+    let cursor = dirs.cursor_path();
     let codex = PathBuf::from(&codex_dir);
     let claude = PathBuf::from(
         claude_dir.unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned()),
@@ -1553,6 +1677,7 @@ pub fn import_session_bundles_with_opencode(
                 PROVIDER_OPENCODE => {
                     import_one_opencode(&opencode, &it, &mode, strict, &project_mappings)
                 }
+                PROVIDER_CURSOR => import_one_cursor(&cursor, &it, &mode, strict),
                 _ => import_one(&codex, &it, &mode, make_visible, strict, &project_mappings),
             })
             .unwrap_or_else(|e| ImportReport {
@@ -1576,9 +1701,7 @@ pub fn import_session_bundles_with_opencode(
 pub fn import_session_bundles_with_lock(
     provider: Option<String>,
     src_dir: String,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     mode: ImportMode,
     make_visible: bool,
     strict: bool,
@@ -1586,12 +1709,10 @@ pub fn import_session_bundles_with_lock(
     lock: &crate::family::FamilyLock,
 ) -> AppResult<Vec<ImportReport>> {
     crate::family::with_lock(lock, |_guard| {
-        import_session_bundles_with_opencode(
+        import_session_bundles_with_dirs(
             provider,
             src_dir,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            dirs,
             mode,
             make_visible,
             strict,
@@ -1835,12 +1956,21 @@ fn validate_claude_bundle_rollout_relpath(raw: &str, session_id: &str) -> AppRes
 }
 
 fn validate_opencode_bundle_rollout_relpath(raw: &str, session_id: &str) -> AppResult<PathBuf> {
+    validate_snapshot_bundle_relpath(PROVIDER_OPENCODE, raw, session_id)
+}
+
+/// 以会话快照 JSON 形式打包的 provider 共用同一套路径约束。
+fn validate_snapshot_bundle_relpath(
+    provider: &str,
+    raw: &str,
+    session_id: &str,
+) -> AppResult<PathBuf> {
     let relative = paths::checked_relative_path(raw)?;
     let expected =
         PathBuf::from("sessions").join(format!("{}.json", paths::sanitize_slug(session_id)));
     if relative != expected {
         return Err(AppError::Path(format!(
-            "OpenCode bundle 快照路径与会话 ID 不匹配: id={session_id} path={raw}"
+            "{provider} bundle 快照路径与会话 ID 不匹配: id={session_id} path={raw}"
         )));
     }
     Ok(relative)
@@ -2143,6 +2273,172 @@ fn import_one_opencode(
     report.rollout_written = outcome.written;
     report.threads_upserted = outcome.written;
     report.skipped_reason = outcome.skipped_reason;
+    report.ok = true;
+    Ok(report)
+}
+
+/// Cursor 会话包：与 OpenCode 一样，一个会话一份自包含的 JSON 快照。
+fn export_cursor_session_bundles(
+    cursor_dir: &Path,
+    out: &Path,
+    targets: &[BundleExportTarget],
+    machine_label: Option<&str>,
+    export_group: Option<&str>,
+) -> AppResult<Vec<ExportReport>> {
+    let machine = machine_label
+        .map(paths::sanitize_slug)
+        .unwrap_or_else(paths::machine_label);
+    let group = paths::sanitize_slug(export_group.unwrap_or("default"));
+    let sessions =
+        crate::cursor_sessions::list_sessions(cursor_dir, &paths::default_cursor_agent_dir())?
+            .into_iter()
+            .map(|session| (session.id.clone(), session))
+            .collect::<HashMap<_, _>>();
+    let (batch_root, final_batch_root) = create_export_batch(out, &machine, &group)?;
+    let mut reports = Vec::with_capacity(targets.len());
+    for target in targets {
+        let result = (|| -> AppResult<ExportReport> {
+            let session = sessions
+                .get(&target.id)
+                .ok_or_else(|| AppError::NotFound(format!("Cursor 会话不存在: {}", target.id)))?;
+            if !session.resume_command.is_empty() {
+                return Err(AppError::Other(format!(
+                    "cursor-agent 会话暂不支持导出会话包: {}",
+                    target.id
+                )));
+            }
+            let snapshot = crate::cursor_transfer::export_snapshot(cursor_dir, &target.id)?;
+            let bundle_dir = batch_root.join(paths::sanitize_slug(&target.id));
+            crate::path_safety::validate_descendant(
+                &batch_root,
+                &bundle_dir,
+                crate::path_safety::EntryKind::Directory,
+                true,
+                "Cursor Bundle 导出目录",
+            )?;
+            let relative = PathBuf::from("sessions")
+                .join(format!("{}.json", paths::sanitize_slug(&target.id)));
+            let destination = bundle_dir.join(PROVIDER_CURSOR).join(&relative);
+            crate::cursor_transfer::write_snapshot(&destination, &snapshot)?;
+            let sha = sha256_file(&destination)?;
+            let manifest = BundleManifest {
+                version: BUNDLE_VERSION,
+                provider: Some(PROVIDER_CURSOR.to_string()),
+                session_id: target.id.clone(),
+                rollout_relpath: relative.to_string_lossy().replace('\\', "/"),
+                source_relpath: None,
+                sidecar_relpath: None,
+                companions_relpath: None,
+                tasks_relpath: None,
+                exported_at: chrono::Utc::now().to_rfc3339(),
+                updated_at: session.updated_at,
+                thread_name: session.title.clone(),
+                session_cwd: session.cwd.clone(),
+                session_source: Some(PROVIDER_CURSOR.to_string()),
+                session_originator: Some("Cursor".to_string()),
+                model_provider: session.model.clone(),
+                export_machine: machine.clone(),
+                export_group: group.clone(),
+                sha256_rollout: sha,
+                rollout_line_count: snapshot.bubbles.len() as u64,
+                has_history: false,
+                artifacts: Vec::new(),
+            };
+            fs::write(
+                bundle_dir.join("manifest.json"),
+                serde_json::to_vec_pretty(&manifest)?,
+            )?;
+            Ok(ExportReport {
+                session_id: target.id.clone(),
+                ok: true,
+                bundle_path: Some(bundle_dir.to_string_lossy().into_owned()),
+                error: None,
+                skipped_reason: None,
+            })
+        })();
+        reports.push(result.unwrap_or_else(|error| ExportReport {
+            session_id: target.id.clone(),
+            ok: false,
+            bundle_path: None,
+            error: Some(error.to_string()),
+            skipped_reason: None,
+        }));
+    }
+    if reports.iter().any(|report| report.ok) {
+        if let Err(error) = publish_export_batch(&batch_root, &final_batch_root, &mut reports) {
+            return Err(match remove_path_recursive(&batch_root) {
+                Ok(()) => error,
+                Err(cleanup_error) => {
+                    AppError::Other(format!("{error}；清理临时导出目录失败: {cleanup_error}"))
+                }
+            });
+        }
+    } else {
+        remove_path_recursive(&batch_root)?;
+    }
+    Ok(reports)
+}
+
+fn import_one_cursor(
+    cursor_dir: &Path,
+    item: &BundleListItem,
+    mode: &ImportMode,
+    strict: bool,
+) -> AppResult<ImportReport> {
+    let mut report = ImportReport {
+        session_id: item.manifest.session_id.clone(),
+        ok: false,
+        rollout_written: false,
+        history_appended: 0,
+        threads_upserted: false,
+        index_appended: false,
+        skipped_reason: None,
+        error: None,
+        verified: false,
+        sha_mismatch: false,
+    };
+    let bundle_root = validate_bundle_item_root(item)?;
+    let relative = validate_snapshot_bundle_relpath(
+        PROVIDER_CURSOR,
+        &item.manifest.rollout_relpath,
+        &item.manifest.session_id,
+    )?;
+    let source = bundle_root.join(PROVIDER_CURSOR).join(relative);
+    if !crate::path_safety::validate_descendant(
+        &bundle_root,
+        &source,
+        crate::path_safety::EntryKind::File,
+        true,
+        "Cursor bundle 快照",
+    )? {
+        report.error = Some(format!(
+            "Cursor bundle 快照缺失: {}",
+            source.to_string_lossy()
+        ));
+        return Ok(report);
+    }
+    let actual = sha256_file(&source)?;
+    if actual != item.manifest.sha256_rollout {
+        report.sha_mismatch = true;
+        if strict {
+            report.error = Some("sha256 不一致，strict 模式跳过".into());
+            return Ok(report);
+        }
+    } else {
+        report.verified = true;
+    }
+    let snapshot = crate::cursor_transfer::read_snapshot(&source, &item.manifest.session_id)?;
+    // Cursor 的会话归属记在会话头里，跨机器改项目路径本期不做，因此不套用项目映射。
+    let overwrite = matches!(mode, ImportMode::Overwrite);
+    let written = crate::cursor_transfer::import_snapshot(cursor_dir, &snapshot, overwrite)?;
+    if !written {
+        report.skipped_reason = Some(match mode {
+            ImportMode::Skip => "目标库已存在同 ID 会话，按跳过处理".into(),
+            _ => "目标库已存在同 ID 会话，未覆盖".into(),
+        });
+    }
+    report.rollout_written = written;
+    report.threads_upserted = written;
     report.ok = true;
     Ok(report)
 }
@@ -3796,9 +4092,7 @@ mod tests {
             let result = import_session_bundles_with_lock(
                 None,
                 "missing-bundles".into(),
-                "missing-codex".into(),
-                None,
-                None,
+                ProviderDirs::new("missing-codex".into()),
                 ImportMode::Skip,
                 false,
                 false,

--- a/src-tauri/src/cli_menu.rs
+++ b/src-tauri/src/cli_menu.rs
@@ -3,7 +3,7 @@ use std::io::{self, Write};
 
 use cc_session_manager_lib::models::{
     BackupSummary, BundleExportTarget, BundleListItem, ConvertReport, DeleteTarget, ExportReport,
-    ImportMode, PreviewEvent, ProjectGroup, SessionSummary, SwitchStrategy,
+    ImportMode, PreviewEvent, ProjectGroup, ProviderDirs, SessionSummary, SwitchStrategy,
 };
 use cc_session_manager_lib::{
     backup, bundle, convert, family, paths, repair, rollout, sessions, settings, stats,
@@ -55,7 +55,20 @@ struct MenuContext {
     codex_dir: String,
     claude_dir: String,
     opencode_dir: String,
+    cursor_dir: String,
     family_lock: family::FamilyLock,
+}
+
+impl MenuContext {
+    fn dirs(&self) -> ProviderDirs {
+        ProviderDirs {
+            codex_dir: self.codex_dir.clone(),
+            claude_dir: Some(self.claude_dir.clone()),
+            opencode_dir: Some(self.opencode_dir.clone()),
+            cursor_dir: Some(self.cursor_dir.clone()),
+            cursor_agent_dir: None,
+        }
+    }
 }
 
 pub fn run(
@@ -63,12 +76,14 @@ pub fn run(
     codex_dir: String,
     claude_dir: String,
     opencode_dir: String,
+    cursor_dir: String,
 ) -> MenuResult<()> {
     let mut ctx = MenuContext {
         provider,
         codex_dir,
         claude_dir,
         opencode_dir,
+        cursor_dir,
         family_lock: family::FamilyLock::default(),
     };
 
@@ -87,29 +102,32 @@ fn main_menu(ctx: &mut MenuContext) -> MenuResult<Flow> {
             ("Codex 目录", ctx.codex_dir.as_str()),
             ("Claude 目录", ctx.claude_dir.as_str()),
             ("OpenCode 目录", ctx.opencode_dir.as_str()),
+            ("Cursor 目录", ctx.cursor_dir.as_str()),
         ],
     );
     println!("1. Codex 会话");
     println!("2. Claude 会话");
     println!("3. OpenCode 会话");
-    println!("4. 统计");
-    println!("5. 备份");
-    println!("6. 导入 / 导出 Bundle");
-    println!("7. 修复 / 诊断");
-    println!("8. 设置与路径检查");
-    println!("9. 帮助");
+    println!("4. Cursor 会话");
+    println!("5. 统计");
+    println!("6. 备份");
+    println!("7. 导入 / 导出 Bundle");
+    println!("8. 修复 / 诊断");
+    println!("9. 设置与路径检查");
+    println!("h. 帮助");
     println!("0. 退出");
 
     match prompt("请选择: ")?.as_str() {
         "1" => run_child(|| sessions_menu(ctx, "codex")),
         "2" => run_child(|| sessions_menu(ctx, "claude")),
         "3" => run_child(|| sessions_menu(ctx, "opencode")),
-        "4" => run_child(|| stats_menu(ctx)),
-        "5" => run_child(|| backup_menu(ctx)),
-        "6" => run_child(|| bundle_menu(ctx)),
-        "7" => run_child(|| repair_menu(ctx)),
-        "8" => run_child(|| settings_menu(ctx)),
-        "9" => {
+        "4" => run_child(|| sessions_menu(ctx, "cursor")),
+        "5" => run_child(|| stats_menu(ctx)),
+        "6" => run_child(|| backup_menu(ctx)),
+        "7" => run_child(|| bundle_menu(ctx)),
+        "8" => run_child(|| repair_menu(ctx)),
+        "9" => run_child(|| settings_menu(ctx)),
+        "h" | "H" => {
             show_interactive_help()?;
             Ok(Flow::Main)
         }
@@ -158,11 +176,9 @@ fn sessions_menu(ctx: &mut MenuContext, provider: &str) -> MenuResult<Flow> {
                 let query = prompt_required("请输入搜索关键词: ")?;
                 let include_archived = confirm_default_no("是否包含已归档会话？")?;
                 let scope = prompt_session_scope(provider)?;
-                let mut hits = sessions::search_sessions_with_opencode(
+                let mut hits = sessions::search_sessions_with_dirs(
                     Some(provider.to_string()),
-                    ctx.codex_dir.clone(),
-                    Some(ctx.claude_dir.clone()),
-                    Some(ctx.opencode_dir.clone()),
+                    ctx.dirs(),
                     query,
                 )
                 .map_err(to_string)?;
@@ -276,13 +292,8 @@ fn refresh_browsed_sessions(
     provider: &str,
     current: &[SessionSummary],
 ) -> MenuResult<Vec<SessionSummary>> {
-    let refreshed = sessions::list_sessions_with_opencode(
-        Some(provider.to_string()),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
-    )
-    .map_err(to_string)?;
+    let refreshed = sessions::list_sessions_with_dirs(Some(provider.to_string()), ctx.dirs())
+        .map_err(to_string)?;
     let mut refreshed_by_key = refreshed
         .into_iter()
         .map(|session| (session_selection_key(&session), session))
@@ -465,8 +476,8 @@ fn session_action_menu(
     provider: &str,
     session: SessionSummary,
 ) -> MenuResult<SessionActionResult> {
-    if provider == "opencode" {
-        return opencode_session_action_menu(ctx, session);
+    if matches!(provider, "opencode" | "cursor") {
+        return simple_session_action_menu(ctx, provider, session);
     }
     loop {
         let target_provider = conversion_target_provider(provider)?;
@@ -537,13 +548,17 @@ fn session_action_menu(
     }
 }
 
-fn opencode_session_action_menu(
+/// 不支持消息级编辑与格式转换的 provider 共用这一套动作菜单。
+fn simple_session_action_menu(
     ctx: &mut MenuContext,
+    provider: &str,
     session: SessionSummary,
 ) -> MenuResult<SessionActionResult> {
+    // Cursor 的会话记录在它自己的数据库里，改 cwd 需要重写工作区归属，本期不做。
+    let supports_move_cwd = provider != "cursor";
     loop {
         print_header(
-            "OpenCode 会话操作",
+            &format!("{} 会话操作", provider_label(provider)),
             &[
                 ("ID", session.id.as_str()),
                 ("标题", session.title.as_str()),
@@ -554,7 +569,9 @@ fn opencode_session_action_menu(
         println!("2. 查看元信息");
         println!("3. 显示 resume 命令");
         println!("4. 重命名会话");
-        println!("5. 移动会话目录");
+        if supports_move_cwd {
+            println!("5. 移动会话目录");
+        }
         println!("6. 创建备份");
         println!("7. 导出 Bundle");
         println!("8. 归档 / 取消归档");
@@ -564,25 +581,25 @@ fn opencode_session_action_menu(
         println!("0. 退出");
 
         match prompt("请选择: ")?.as_str() {
-            "1" => preview_session("opencode", &session)?,
-            "2" => show_session_meta("opencode", &session)?,
-            "3" => show_resume_command("opencode", &session)?,
+            "1" => preview_session(provider, &session)?,
+            "2" => show_session_meta(provider, &session)?,
+            "3" => show_resume_command(provider, &session)?,
             "4" => {
-                rename_session(ctx, "opencode", &session)?;
+                rename_session(ctx, provider, &session)?;
                 return Ok(SessionActionResult::Refresh);
             }
-            "5" => {
-                move_session_cwd(ctx, "opencode", &session)?;
+            "5" if supports_move_cwd => {
+                move_session_cwd(ctx, provider, &session)?;
                 return Ok(SessionActionResult::Refresh);
             }
-            "6" => create_backup_for_session(ctx, "opencode", &session)?,
-            "7" => export_bundle_for_session(ctx, "opencode", &session)?,
+            "6" => create_backup_for_session(ctx, provider, &session)?,
+            "7" => export_bundle_for_session(ctx, provider, &session)?,
             "8" => {
-                toggle_archived(ctx, "opencode", &session)?;
+                toggle_archived(ctx, provider, &session)?;
                 return Ok(SessionActionResult::Refresh);
             }
             "9" => {
-                delete_session(ctx, "opencode", &session)?;
+                delete_session(ctx, provider, &session)?;
                 return Ok(SessionActionResult::Refresh);
             }
             "10" => return Ok(SessionActionResult::Back),
@@ -602,11 +619,9 @@ fn rename_session(ctx: &MenuContext, provider: &str, session: &SessionSummary) -
         println!("标题未变化。");
         return pause().map(|_| ());
     }
-    sessions::rename_session_with_provider_dirs(
+    sessions::rename_session_with_dirs(
         Some(provider.to_string()),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         session.id.clone(),
         Some(session.rollout_path.clone()),
         title,
@@ -874,11 +889,9 @@ fn create_backup_for_session(
     let backup_dir = prompt_default("备份目录", &paths::default_backup_dir().to_string_lossy())?;
     let name = prompt_optional("备份名称（留空自动生成）: ")?;
     let note = prompt_optional("备注（可留空）: ")?;
-    let summary = backup::create_backup_with_opencode(
+    let summary = backup::create_backup_with_dirs(
         Some(provider.to_string()),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         backup_dir,
         vec![session.id.clone()],
         Some(vec![BundleExportTarget {
@@ -900,11 +913,9 @@ fn export_bundle_for_session(
     session: &SessionSummary,
 ) -> MenuResult<()> {
     let out_dir = prompt_required("导出目录: ")?;
-    let reports = bundle::export_session_bundles_with_opencode(
+    let reports = bundle::export_session_bundles_with_dirs(
         Some(provider.to_string()),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         out_dir,
         vec![session.id.clone()],
         Some(vec![BundleExportTarget {
@@ -1011,16 +1022,19 @@ fn toggle_archived(ctx: &MenuContext, provider: &str, session: &SessionSummary) 
         println!("Claude 会话不支持归档。");
         return pause().map(|_| ());
     }
+    if provider == "cursor" && !session.resume_command.is_empty() {
+        println!("cursor-agent 会话不支持归档（Cursor 本身没有这个状态）。");
+        return pause().map(|_| ());
+    }
     let target = !session.archived;
     let label = if target { "归档" } else { "取消归档" };
     if !confirm_yes(&format!("确认要{label}会话 {} 吗？", session.id))? {
         println!("已取消。");
         return pause().map(|_| ());
     }
-    sessions::set_archived_with_provider_dir(
+    sessions::set_archived_with_dirs(
         Some(provider.to_string()),
-        ctx.codex_dir.clone(),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         session.id.clone(),
         target,
         &ctx.family_lock,
@@ -1042,6 +1056,9 @@ fn delete_session(ctx: &MenuContext, provider: &str, session: &SessionSummary) -
         println!(
             "若这是最后一个同 ID 副本，还会清理 history.jsonl、tasks/<id> 与 file-history/<id>；否则保留这些共享数据。"
         );
+    } else if provider == "cursor" {
+        println!("将从 Cursor 的 state.vscdb 删除该会话的会话头、气泡索引与全部气泡。");
+        println!("注意：删除只释放库内页面，磁盘占用需要单独执行“压缩数据库”才会回收。");
     } else {
         println!("将从 opencode.db 删除该会话、全部子会话及其消息、片段和关联事件。");
     }
@@ -1050,11 +1067,9 @@ fn delete_session(ctx: &MenuContext, provider: &str, session: &SessionSummary) -
         pause()?;
         return Ok(());
     }
-    let result = sessions::delete_session_with_provider_dir(
+    let result = sessions::delete_session_with_dirs(
         Some(provider.to_string()),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         session.id.clone(),
         Some(DeleteTarget {
             id: session.id.clone(),
@@ -1135,11 +1150,9 @@ fn delete_selected_sessions(
             rollout_path: Some(session.rollout_path.clone()),
         })
         .collect::<Vec<_>>();
-    let results = sessions::delete_sessions_with_provider_dir(
+    let results = sessions::delete_sessions_with_dirs(
         Some(provider.to_string()),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         ids,
         Some(targets),
         &ctx.family_lock,
@@ -1222,17 +1235,8 @@ fn stats_provider(ctx: &MenuContext) -> MenuResult<String> {
 
 fn stats_kpi(ctx: &MenuContext) -> MenuResult<()> {
     let provider = stats_provider(ctx)?;
-    let data = stats::stats_kpi(
-        Some(provider),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
-        None,
-        None,
-        Vec::new(),
-        false,
-    )
-    .map_err(to_string)?;
+    let data = stats::stats_kpi(Some(provider), ctx.dirs(), None, None, Vec::new(), false)
+        .map_err(to_string)?;
     println!("sessions_total           {}", data.sessions_total);
     println!("tokens_total             {}", data.tokens_total);
     println!("active_projects          {}", data.active_projects);
@@ -1249,9 +1253,7 @@ fn stats_projects(ctx: &MenuContext) -> MenuResult<()> {
     let limit = prompt_usize("显示数量", 20)?;
     let data = stats::stats_by_project(
         Some(provider),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         None,
         None,
         limit,
@@ -1275,17 +1277,8 @@ fn stats_projects(ctx: &MenuContext) -> MenuResult<()> {
 
 fn stats_models(ctx: &MenuContext) -> MenuResult<()> {
     let provider = stats_provider(ctx)?;
-    let data = stats::stats_by_model(
-        Some(provider),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
-        None,
-        None,
-        Vec::new(),
-        false,
-    )
-    .map_err(to_string)?;
+    let data = stats::stats_by_model(Some(provider), ctx.dirs(), None, None, Vec::new(), false)
+        .map_err(to_string)?;
     println!("provider  sessions  tokens  model");
     for item in data {
         println!(
@@ -1306,9 +1299,7 @@ fn stats_timeseries(ctx: &MenuContext) -> MenuResult<()> {
     let bucket = prompt_default("时间粒度 day/week", "day")?;
     let data = stats::stats_timeseries(
         Some(provider),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         None,
         None,
         bucket,
@@ -1331,17 +1322,8 @@ fn stats_timeseries(ctx: &MenuContext) -> MenuResult<()> {
 
 fn stats_heatmap(ctx: &MenuContext) -> MenuResult<()> {
     let provider = stats_provider(ctx)?;
-    let data = stats::stats_heatmap(
-        Some(provider),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
-        None,
-        None,
-        Vec::new(),
-        false,
-    )
-    .map_err(to_string)?;
+    let data = stats::stats_heatmap(Some(provider), ctx.dirs(), None, None, Vec::new(), false)
+        .map_err(to_string)?;
     println!("每行从周日到周六，每列为 0-23 点。");
     for row in data {
         println!(
@@ -1407,11 +1389,9 @@ fn backup_create_by_id(ctx: &MenuContext) -> MenuResult<()> {
     let ids = prompt_ids()?;
     let name = prompt_optional("备份名称（留空自动生成）: ")?;
     let note = prompt_optional("备注（可留空）: ")?;
-    let summary = backup::create_backup_with_opencode(
+    let summary = backup::create_backup_with_dirs(
         Some(provider),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         backup_dir,
         ids,
         None,
@@ -1478,9 +1458,7 @@ fn backup_restore_one(ctx: &MenuContext) -> MenuResult<()> {
         Some(provider),
         backup_root,
         path,
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         id,
         None,
         overwrite,
@@ -1508,9 +1486,7 @@ fn backup_restore_all(ctx: &MenuContext) -> MenuResult<()> {
         Some(provider),
         backup_root,
         path,
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         overwrite,
         &ctx.family_lock,
     )
@@ -1584,11 +1560,9 @@ fn bundle_export(ctx: &MenuContext) -> MenuResult<()> {
     let out_dir = prompt_required("导出目录: ")?;
     let ids = prompt_ids()?;
     let targets = resolve_bundle_export_targets(ctx, &provider, &ids)?;
-    let reports = bundle::export_session_bundles_with_opencode(
+    let reports = bundle::export_session_bundles_with_dirs(
         Some(provider),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         out_dir,
         ids,
         targets,
@@ -1611,11 +1585,9 @@ fn bundle_export_all(ctx: &MenuContext) -> MenuResult<()> {
     } else {
         confirm_default_no("是否只导出 active 会话？")?
     };
-    let reports = bundle::export_all_bundles_with_opencode(
+    let reports = bundle::export_all_bundles_with_dirs(
         Some(provider),
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         out_dir,
         None,
         None,
@@ -1653,9 +1625,7 @@ fn bundle_import(ctx: &MenuContext) -> MenuResult<()> {
     let reports = bundle::import_session_bundles_with_lock(
         Some(provider),
         src_dir,
-        ctx.codex_dir.clone(),
-        Some(ctx.claude_dir.clone()),
-        Some(ctx.opencode_dir.clone()),
+        ctx.dirs(),
         mode,
         make_visible,
         strict,
@@ -2552,6 +2522,7 @@ fn provider_label(provider: &str) -> &'static str {
         "codex" => "Codex",
         "claude" => "Claude",
         "opencode" => "OpenCode",
+        "cursor" => "Cursor",
         _ => "未知",
     }
 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -31,19 +31,60 @@ where
 pub fn start_content_search(
     provider: String,
     codex_dir: String,
-    claude_dir: String,
-    opencode_dir: String,
+    claude_dir: Option<String>,
+    opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     query: String,
     rollout_paths: Vec<String>,
 ) -> AppResult<ContentSearchStart> {
     crate::content_search::start_content_search(
         provider,
-        codex_dir,
-        claude_dir,
-        opencode_dir,
+        provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
         query,
         rollout_paths,
     )
+}
+
+/// 回收 Cursor 数据库中删除留下的空页。库可能有数 GB，单独成命令并放在设置里。
+#[tauri::command]
+pub async fn compact_cursor_database(
+    codex_dir: String,
+    cursor_dir: Option<String>,
+) -> AppResult<crate::cursor_mutate::CursorCompactReport> {
+    run_blocking(move || {
+        crate::cursor_mutate::compact_database(&provider_dirs(codex_dir, None, None, cursor_dir))
+    })
+    .await
+}
+
+/// 扫描 Cursor 数据库里的空会话、孤儿记录与项目目录已消失的会话。
+#[tauri::command]
+pub async fn diagnose_cursor_residue(
+    codex_dir: String,
+    cursor_dir: Option<String>,
+) -> AppResult<CursorResidueReport> {
+    run_blocking(move || {
+        crate::cursor_mutate::diagnose_residue(&provider_dirs(codex_dir, None, None, cursor_dir))
+    })
+    .await
+}
+
+/// 按选定类别清理残留。`kinds` 必须显式给出，删除有内容的会话不会被默认包含。
+#[tauri::command]
+pub async fn prune_cursor_residue(
+    codex_dir: String,
+    cursor_dir: Option<String>,
+    kinds: Vec<String>,
+    dry_run: bool,
+) -> AppResult<CursorPruneReport> {
+    run_blocking(move || {
+        crate::cursor_mutate::prune_residue(
+            &provider_dirs(codex_dir, None, None, cursor_dir),
+            &kinds,
+            dry_run,
+        )
+    })
+    .await
 }
 
 #[tauri::command]
@@ -120,6 +161,7 @@ pub async fn restore_session(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     id: String,
     backup_rollout_relpath: Option<String>,
     overwrite: bool,
@@ -131,9 +173,7 @@ pub async fn restore_session(
             provider,
             backup_dir,
             backup_path,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             id,
             backup_rollout_relpath,
             overwrite,
@@ -151,6 +191,7 @@ pub async fn restore_all(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     overwrite: bool,
     lock: SharedLock<'_>,
 ) -> AppResult<Vec<RestoreResult>> {
@@ -160,9 +201,7 @@ pub async fn restore_all(
             provider,
             backup_dir,
             backup_path,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             overwrite,
             &lock,
         )
@@ -176,6 +215,7 @@ pub async fn export_session_bundles(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     out_dir: String,
     ids: Vec<String>,
     targets: Option<Vec<BundleExportTarget>>,
@@ -183,11 +223,9 @@ pub async fn export_session_bundles(
     export_group: Option<String>,
 ) -> AppResult<Vec<ExportReport>> {
     run_blocking(move || {
-        crate::bundle::export_session_bundles_with_opencode(
+        crate::bundle::export_session_bundles_with_dirs(
             provider,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             out_dir,
             ids,
             targets,
@@ -204,17 +242,16 @@ pub async fn export_all_bundles(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     out_dir: String,
     machine_label: Option<String>,
     export_group: Option<String>,
     active_only: bool,
 ) -> AppResult<Vec<ExportReport>> {
     run_blocking(move || {
-        crate::bundle::export_all_bundles_with_opencode(
+        crate::bundle::export_all_bundles_with_dirs(
             provider,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             out_dir,
             machine_label,
             export_group,
@@ -247,6 +284,7 @@ pub async fn import_session_bundles(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     mode: ImportMode,
     make_visible: bool,
     strict: bool,
@@ -258,9 +296,7 @@ pub async fn import_session_bundles(
         crate::bundle::import_session_bundles_with_lock(
             provider,
             src_dir,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             mode,
             make_visible,
             strict,
@@ -633,18 +669,21 @@ pub async fn duplicate_session(
 #[tauri::command]
 pub async fn convert_session_provider(
     codex_dir: String,
-    claude_dir: String,
+    claude_dir: Option<String>,
+    opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     source_provider: String,
+    target_provider: Option<String>,
     rollout_path: String,
     conversion_mode: Option<String>,
     lock: SharedLock<'_>,
 ) -> AppResult<ConvertReport> {
     let lock = lock.inner().clone();
     run_blocking(move || {
-        crate::convert::convert_session_with_lock(
-            codex_dir,
-            claude_dir,
+        crate::convert::convert_session_with_target(
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             source_provider,
+            target_provider,
             rollout_path,
             conversion_mode,
             &lock,
@@ -920,15 +959,38 @@ pub async fn delete_claude_memory_file(
     .await
 }
 
+/// 把前端传来的扁平目录参数收成一个 `ProviderDirs`。
+///
+/// 命令签名保持扁平是为了让 Tauri 与 Web UI 两条通道的入参形状完全一致；
+/// 收口只发生在这一层之后。
+fn provider_dirs(
+    codex_dir: String,
+    claude_dir: Option<String>,
+    opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
+) -> ProviderDirs {
+    ProviderDirs {
+        codex_dir,
+        claude_dir,
+        opencode_dir,
+        cursor_dir,
+        cursor_agent_dir: None,
+    }
+}
+
 #[tauri::command]
 pub async fn list_sessions(
     provider: Option<String>,
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
 ) -> AppResult<Vec<SessionSummary>> {
     run_blocking(move || {
-        crate::sessions::list_sessions_with_opencode(provider, codex_dir, claude_dir, opencode_dir)
+        crate::sessions::list_sessions_with_dirs(
+            provider,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
+        )
     })
     .await
 }
@@ -939,13 +1001,12 @@ pub async fn group_sessions_by_project(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
 ) -> AppResult<Vec<ProjectGroup>> {
     run_blocking(move || {
-        crate::sessions::group_sessions_by_project_with_opencode(
+        crate::sessions::group_sessions_by_project_with_dirs(
             provider,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
         )
     })
     .await
@@ -957,14 +1018,13 @@ pub async fn search_sessions(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     query: String,
 ) -> AppResult<Vec<SessionSummary>> {
     run_blocking(move || {
-        crate::sessions::search_sessions_with_opencode(
+        crate::sessions::search_sessions_with_dirs(
             provider,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             query,
         )
     })
@@ -975,17 +1035,18 @@ pub async fn search_sessions(
 pub async fn set_archived(
     provider: Option<String>,
     codex_dir: String,
+    claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     id: String,
     v: bool,
     lock: SharedLock<'_>,
 ) -> AppResult<()> {
     let lock = lock.inner().clone();
     run_blocking(move || {
-        crate::sessions::set_archived_with_provider_dir(
+        crate::sessions::set_archived_with_dirs(
             provider,
-            codex_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             id,
             v,
             &lock,
@@ -1000,17 +1061,16 @@ pub async fn delete_session(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     id: String,
     target: Option<DeleteTarget>,
     lock: SharedLock<'_>,
 ) -> AppResult<DeleteResult> {
     let lock = lock.inner().clone();
     run_blocking(move || {
-        crate::sessions::delete_session_with_provider_dir(
+        crate::sessions::delete_session_with_dirs(
             provider,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             id,
             target,
             &lock,
@@ -1025,17 +1085,16 @@ pub async fn delete_sessions(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     ids: Vec<String>,
     targets: Option<Vec<DeleteTarget>>,
     lock: SharedLock<'_>,
 ) -> AppResult<Vec<DeleteResult>> {
     let lock = lock.inner().clone();
     run_blocking(move || {
-        crate::sessions::delete_sessions_with_provider_dir(
+        crate::sessions::delete_sessions_with_dirs(
             provider,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             ids,
             targets,
             &lock,
@@ -1050,6 +1109,7 @@ pub async fn rename_session(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     id: String,
     rollout_path: Option<String>,
     title: String,
@@ -1057,11 +1117,9 @@ pub async fn rename_session(
 ) -> AppResult<u32> {
     let lock = lock.inner().clone();
     run_blocking(move || {
-        crate::sessions::rename_session_with_provider_dirs(
+        crate::sessions::rename_session_with_dirs(
             provider,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             id,
             rollout_path,
             title,
@@ -1106,6 +1164,7 @@ pub async fn stats_snapshot(
     codex_dir: String,
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
+    cursor_dir: Option<String>,
     from_ts: Option<i64>,
     to_ts: Option<i64>,
     bucket: String,
@@ -1116,9 +1175,7 @@ pub async fn stats_snapshot(
     run_blocking(move || {
         crate::stats::stats_snapshot(
             provider,
-            codex_dir,
-            claude_dir,
-            opencode_dir,
+            provider_dirs(codex_dir, claude_dir, opencode_dir, cursor_dir),
             from_ts,
             to_ts,
             bucket,

--- a/src-tauri/src/content_search.rs
+++ b/src-tauri/src/content_search.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 
 use crate::error::{AppError, AppResult};
 use crate::models::{
-    ContentSearchMatch, ContentSearchResult, ContentSearchStart, ContentSearchStatus,
+    ContentSearchMatch, ContentSearchResult, ContentSearchStart, ContentSearchStatus, ProviderDirs,
     SessionSummary,
 };
 use crate::{rollout, sessions};
@@ -43,9 +43,7 @@ struct SearchManager {
 
 struct SearchRequest {
     provider: String,
-    codex_dir: String,
-    claude_dir: String,
-    opencode_dir: String,
+    dirs: ProviderDirs,
     query: String,
     rollout_paths: Vec<String>,
 }
@@ -159,17 +157,13 @@ fn manager() -> &'static SearchManager {
 
 pub fn start_content_search(
     provider: String,
-    codex_dir: String,
-    claude_dir: String,
-    opencode_dir: String,
+    dirs: ProviderDirs,
     query: String,
     rollout_paths: Vec<String>,
 ) -> AppResult<ContentSearchStart> {
     manager().start(SearchRequest {
         provider,
-        codex_dir,
-        claude_dir,
-        opencode_dir,
+        dirs,
         query: query.trim().to_string(),
         rollout_paths,
     })
@@ -188,7 +182,10 @@ pub fn cancel_content_search(job_id: u64) -> AppResult<()> {
 }
 
 fn validate_request(request: &SearchRequest) -> AppResult<()> {
-    if !matches!(request.provider.as_str(), "codex" | "claude" | "opencode") {
+    if !matches!(
+        request.provider.as_str(),
+        "codex" | "claude" | "opencode" | "cursor"
+    ) {
         return Err(AppError::Other(format!(
             "不支持的 provider: {}",
             request.provider
@@ -204,14 +201,9 @@ fn validate_request(request: &SearchRequest) -> AppResult<()> {
             "全文搜索关键词不能超过 {MAX_QUERY_CHARS} 个字符"
         )));
     }
-    if request.provider == "codex" && request.codex_dir.trim().is_empty() {
+    // 目录为空时后端会退回默认值，只有 Codex 没有可用默认目录，必须显式给出。
+    if request.provider == "codex" && request.dirs.codex_dir.trim().is_empty() {
         return Err(AppError::Other("Codex 目录不能为空".to_string()));
-    }
-    if request.provider == "claude" && request.claude_dir.trim().is_empty() {
-        return Err(AppError::Other("Claude 目录不能为空".to_string()));
-    }
-    if request.provider == "opencode" && request.opencode_dir.trim().is_empty() {
-        return Err(AppError::Other("OpenCode 目录不能为空".to_string()));
     }
     if request.query.chars().any(char::is_control) {
         return Err(AppError::Other(
@@ -247,11 +239,9 @@ fn execute_search(job: &SearchJob, request: &SearchRequest) -> AppResult<()> {
         .iter()
         .map(String::as_str)
         .collect::<HashSet<_>>();
-    let sessions = sessions::list_sessions_cancellable_with_opencode(
+    let sessions = sessions::list_sessions_cancellable_with_dirs(
         Some(request.provider.clone()),
-        request.codex_dir.clone(),
-        Some(request.claude_dir.clone()),
-        Some(request.opencode_dir.clone()),
+        request.dirs.clone(),
         &job.cancel,
     )?
     .into_iter()
@@ -262,7 +252,12 @@ fn execute_search(job: &SearchJob, request: &SearchRequest) -> AppResult<()> {
         return Ok(());
     }
 
-    let total_bytes = sessions.iter().map(|session| session.rollout_bytes).sum();
+    // Cursor 的 Composer 会话拿不到便宜的体积估计（`rollout_bytes` 为 0），
+    // 每个会话至少记 1，进度条就退化成"扫到第几个会话"而不是原地不动。
+    let total_bytes = sessions
+        .iter()
+        .map(|session| session.rollout_bytes.max(1))
+        .sum();
     {
         let mut status = job.status.lock().unwrap_or_else(|error| error.into_inner());
         status.total_files = sessions.len();
@@ -278,11 +273,14 @@ fn execute_search(job: &SearchJob, request: &SearchRequest) -> AppResult<()> {
         if outcome.cancelled {
             return Ok(());
         }
-        completed_bytes = completed_bytes.saturating_add(if outcome.missing {
-            session.rollout_bytes
-        } else {
-            outcome.bytes_read
-        });
+        completed_bytes = completed_bytes.saturating_add(
+            if outcome.missing {
+                session.rollout_bytes
+            } else {
+                outcome.bytes_read
+            }
+            .max(1),
+        );
 
         let mut status = job.status.lock().unwrap_or_else(|error| error.into_inner());
         status.scanned_files += 1;
@@ -315,8 +313,19 @@ fn scan_session(
     query: &str,
     completed_bytes: u64,
 ) -> AppResult<FileScanOutcome> {
-    if session.provider == "opencode" {
-        return scan_opencode_session(job, session, query, completed_bytes);
+    // 这两个 provider 的会话不是可逐行扫描的文件，先还原成事件序列再匹配。
+    match session.provider.as_str() {
+        "opencode" => {
+            let events =
+                crate::opencode_sessions::load_preview_events_from_locator(&session.rollout_path)?;
+            return scan_event_sequence(job, session, query, completed_bytes, events);
+        }
+        "cursor" => {
+            let events =
+                crate::cursor_sessions::load_preview_events_from_locator(&session.rollout_path)?;
+            return scan_event_sequence(job, session, query, completed_bytes, events);
+        }
+        _ => {}
     }
     let file = match File::open(&session.rollout_path) {
         Ok(file) => file,
@@ -410,13 +419,14 @@ fn scan_session(
     })
 }
 
-fn scan_opencode_session(
+/// 在已经展开好的事件序列上做匹配，供没有行式存储的 provider 复用。
+fn scan_event_sequence(
     job: &SearchJob,
     session: &SessionSummary,
     query: &str,
     completed_bytes: u64,
+    events: Vec<crate::models::PreviewEvent>,
 ) -> AppResult<FileScanOutcome> {
-    let events = crate::opencode_sessions::load_preview_events_from_locator(&session.rollout_path)?;
     let total_events = events.len().max(1);
     let mut matches = Vec::new();
 
@@ -472,7 +482,8 @@ fn scan_opencode_session(
 fn classify_event(provider: &str, index: usize, raw: Value) -> Option<crate::models::PreviewEvent> {
     match provider {
         "codex" => Some(rollout::classify_preview(index, raw)),
-        "claude" => crate::claude_sessions::classify_preview(index, raw),
+        // Cursor 与 OpenCode 都会先合成 Claude 形状的记录再分类。
+        "claude" | "cursor" => crate::claude_sessions::classify_preview(index, raw),
         _ => None,
     }
 }
@@ -808,9 +819,13 @@ mod tests {
         job.cancel.store(true, Ordering::Release);
         let request = SearchRequest {
             provider: "claude".to_string(),
-            codex_dir: root.join("codex").to_string_lossy().into_owned(),
-            claude_dir: claude_dir.to_string_lossy().into_owned(),
-            opencode_dir: root.join("opencode").to_string_lossy().into_owned(),
+            dirs: ProviderDirs {
+                codex_dir: root.join("codex").to_string_lossy().into_owned(),
+                claude_dir: Some(claude_dir.to_string_lossy().into_owned()),
+                opencode_dir: Some(root.join("opencode").to_string_lossy().into_owned()),
+                cursor_dir: Some(root.join("cursor").to_string_lossy().into_owned()),
+                cursor_agent_dir: Some(root.join("cursor-agent").to_string_lossy().into_owned()),
+            },
             query: "needle".to_string(),
             rollout_paths: Vec::new(),
         };

--- a/src-tauri/src/convert.rs
+++ b/src-tauri/src/convert.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
 use crate::error::{AppError, AppResult};
-use crate::models::ConvertReport;
+use crate::models::{ConvertReport, ProviderDirs};
 use crate::{
     atomic_file, family, fs_ops, mutation_journal, paths, provenance, repair, sessions, state_db,
 };
@@ -27,6 +27,8 @@ const TOOL_RESULT_TAG: &str = "tool_result";
 const NOTE_MAX_LEN: usize = 2_000;
 const TOOL_RESULT_MAX_LEN: usize = 4_000;
 const NATIVE_TOOL_RESULT_MAX_LEN: usize = 30_000;
+pub(crate) mod cursor;
+
 const LEGACY_IMPORTED_MARKER: &str = "<EXTERNAL SESSION IMPORTED>";
 /// Codex 要求 `SessionMeta.cli_version` 为字符串。没有样本时写入占位版本。
 const FALLBACK_CODEX_CLI_VERSION: &str = "0.0.0";
@@ -151,6 +153,32 @@ pub fn convert_session_with_lock(
     conversion_mode: Option<String>,
     lock: &family::FamilyLock,
 ) -> AppResult<ConvertReport> {
+    convert_session_with_target(
+        ProviderDirs {
+            codex_dir,
+            claude_dir: Some(claude_dir),
+            ..ProviderDirs::default()
+        },
+        source_provider,
+        None,
+        rollout_path,
+        conversion_mode,
+        lock,
+    )
+}
+
+/// Claude 与 Codex 各自只有一个可能的目标，`target_provider` 留空即可；
+/// Cursor 两个方向都能去，必须显式指定。
+pub fn convert_session_with_target(
+    dirs: ProviderDirs,
+    source_provider: String,
+    target_provider: Option<String>,
+    rollout_path: String,
+    conversion_mode: Option<String>,
+    lock: &family::FamilyLock,
+) -> AppResult<ConvertReport> {
+    let codex_dir = dirs.codex_dir.clone();
+    let claude_dir = dirs.claude_path().to_string_lossy().into_owned();
     family::with_lock(lock, |_g| match source_provider.as_str() {
         "claude" => convert_claude_to_codex(
             &codex_dir,
@@ -163,6 +191,35 @@ pub fn convert_session_with_lock(
             &rollout_path,
             ClaudeImportMode::parse(conversion_mode.as_deref())?,
         ),
+        "cursor" => {
+            let parsed = cursor::parse(
+                &dirs.cursor_path(),
+                &dirs.cursor_agent_path(),
+                &rollout_path,
+            )?;
+            match target_provider.as_deref() {
+                Some("claude") => write_claude_session(
+                    &codex_dir,
+                    &claude_dir,
+                    "cursor",
+                    &parsed.source_id.clone(),
+                    &cursor::as_codex(&parsed),
+                    ClaudeImportMode::parse(conversion_mode.as_deref())?,
+                    Vec::new(),
+                ),
+                Some("codex") => write_codex_session(
+                    &codex_dir,
+                    "cursor",
+                    &parsed.source_id.clone(),
+                    &cursor::as_claude(&parsed),
+                    CodexImportMode::parse(conversion_mode.as_deref())?,
+                ),
+                Some(other) => Err(AppError::Other(format!("Cursor 会话不支持转换到 {other}"))),
+                None => Err(AppError::Other(
+                    "Cursor 会话可以转到 Claude 或 Codex，请指定目标".into(),
+                )),
+            }
+        }
         other => Err(AppError::Other(format!(
             "不支持的转换来源 provider: {other}"
         ))),
@@ -178,9 +235,29 @@ fn convert_claude_to_codex(
     source_path: &str,
     mode: CodexImportMode,
 ) -> AppResult<ConvertReport> {
-    let codex = PathBuf::from(codex_dir);
     let source = PathBuf::from(source_path);
     let parsed = parse_claude_session(&source)?;
+    let source_id = parsed.source_id.clone().unwrap_or_else(|| {
+        source
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    });
+    write_codex_session(codex_dir, "claude", &source_id, &parsed, mode)
+}
+
+/// 把已经解析成 Claude 事件流的会话写成一个新的 Codex 会话。
+///
+/// rollout、threads、session_index 与 Desktop 项目归属必须一起提交，所以这段可补偿
+/// 事务由 Claude 与 Cursor 两个来源共用，绝不复制第二份。
+fn write_codex_session(
+    codex_dir: &str,
+    source_provider: &str,
+    source_id: &str,
+    parsed: &ParsedClaudeSession,
+    mode: CodexImportMode,
+) -> AppResult<ConvertReport> {
+    let codex = PathBuf::from(codex_dir);
     let Some(source_cwd) = parsed.cwd.as_deref() else {
         return Err(AppError::Other(
             "源会话缺少 cwd，无法确定 Codex 项目目录".into(),
@@ -199,14 +276,8 @@ fn convert_claude_to_codex(
     repair::validate_rollout_filename(&new_abs)?;
     let provider = repair::effective_current_provider(&codex)?;
     let identity = detect_codex_identity(&codex);
-    let built = build_codex_lines(&new_id, &cwd, &provider, &parsed, &identity, &now, mode);
+    let built = build_codex_lines(&new_id, &cwd, &provider, parsed, &identity, &now, mode);
     let imported_messages = parsed.messages.len() as u32;
-    let source_id = parsed.source_id.clone().unwrap_or_else(|| {
-        source
-            .file_stem()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_default()
-    });
     let title = conversion_title(parsed.title.as_deref(), &parsed.messages);
     let desktop_cwd = desktop_project_cwd(&codex, &cwd);
 
@@ -305,16 +376,16 @@ fn convert_claude_to_codex(
         &codex,
         "codex",
         &new_id,
-        "claude",
-        &source_id,
+        source_provider,
+        source_id,
         Some(mode.as_str()),
     ) {
         warnings.push(format!("记录转换来源失败（不影响会话使用）: {error}"));
     }
 
     Ok(ConvertReport {
-        source_id,
-        source_provider: "claude".into(),
+        source_id: source_id.to_string(),
+        source_provider: source_provider.to_string(),
         target_provider: "codex".into(),
         conversion_mode: Some(mode.as_str().into()),
         new_id: new_id.clone(),
@@ -1352,12 +1423,45 @@ fn convert_codex_to_claude(
     mode: ClaudeImportMode,
 ) -> AppResult<ConvertReport> {
     let codex = PathBuf::from(codex_dir);
-    let claude = PathBuf::from(claude_dir);
     let source = PathBuf::from(rollout_path);
     let mut parsed = parse_codex_rollout(&source)?;
+    let source_id = parsed.source_id.clone().unwrap_or_else(|| {
+        source
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    });
+    let mut warnings = Vec::new();
+    // Codex App 可能已经给会话起了短标题，比首条消息更适合作为新会话的名字。
+    if !codex.as_os_str().is_empty() && !source_id.is_empty() {
+        match sessions::codex_display_title(&codex, &source_id) {
+            Ok(title) => parsed.title = title,
+            Err(error) => warnings.push(format!("读取 Codex 标题失败，已保留内容转换: {error}")),
+        }
+    }
+    write_claude_session(
+        codex_dir, claude_dir, "codex", &source_id, &parsed, mode, warnings,
+    )
+}
+
+/// 把已经解析成 Codex 事件流的会话写成一个新的 Claude 会话。
+///
+/// Codex 与 Cursor 两个来源共用这段写入，避免 parentUuid 链、custom-title 与来源登记
+/// 出现两份实现。
+fn write_claude_session(
+    codex_dir: &str,
+    claude_dir: &str,
+    source_provider: &str,
+    source_id: &str,
+    parsed: &ParsedCodexRollout,
+    mode: ClaudeImportMode,
+    mut warnings: Vec<String>,
+) -> AppResult<ConvertReport> {
+    let codex = PathBuf::from(codex_dir);
+    let claude = PathBuf::from(claude_dir);
     let Some(cwd) = parsed.cwd.clone() else {
         return Err(AppError::Other(
-            "源 rollout 缺少 cwd（session_meta/turn_context 均未提供）".into(),
+            "源会话缺少 cwd，无法确定 Claude 项目目录".into(),
         ));
     };
     if parsed.messages.iter().all(|m| m.role != Role::User) {
@@ -1366,27 +1470,13 @@ fn convert_codex_to_claude(
         ));
     }
 
-    let source_id = parsed.source_id.clone().unwrap_or_else(|| {
-        source
-            .file_stem()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_default()
-    });
-    let mut warnings = Vec::new();
-    if !codex.as_os_str().is_empty() && !source_id.is_empty() {
-        match sessions::codex_display_title(&codex, &source_id) {
-            Ok(title) => parsed.title = title,
-            Err(error) => warnings.push(format!("读取 Codex 标题失败，已保留内容转换: {error}")),
-        }
-    }
-
     let projects = paths::claude_projects_dir(&claude);
     let project_dir = projects.join(encode_claude_project_dir(&cwd));
     fs::create_dir_all(&project_dir)?;
     let new_id = repair::new_session_id();
     let new_abs = project_dir.join(format!("{new_id}.jsonl"));
     let identity = detect_claude_identity(&projects);
-    let mut built = build_claude_lines(&new_id, &cwd, &parsed, &identity, mode);
+    let mut built = build_claude_lines(&new_id, &cwd, parsed, &identity, mode);
     let imported_messages = built.lines.len() as u32;
     if let Some(title) = parsed
         .title
@@ -1427,8 +1517,8 @@ fn convert_codex_to_claude(
             &codex,
             "claude",
             &new_id,
-            "codex",
-            &source_id,
+            source_provider,
+            source_id,
             Some(mode.as_str()),
         ) {
             warnings.push(format!("记录转换来源失败（不影响会话使用）: {error}"));
@@ -1436,8 +1526,8 @@ fn convert_codex_to_claude(
     }
 
     Ok(ConvertReport {
-        source_id,
-        source_provider: "codex".into(),
+        source_id: source_id.to_string(),
+        source_provider: source_provider.to_string(),
         target_provider: "claude".into(),
         conversion_mode: Some(mode.as_str().into()),
         new_id: new_id.clone(),

--- a/src-tauri/src/convert/cursor.rs
+++ b/src-tauri/src/convert/cursor.rs
@@ -1,0 +1,728 @@
+//! Cursor 会话到 Claude / Codex 两种写入形态的适配。
+//!
+//! Cursor 的会话不是行式文件，先由 [`crate::cursor_sessions`] 展开成 `PreviewEvent`，
+//! 这里再归一成一份中立的会话表示，最后按目标各自包装：
+//!
+//! - 目标 Codex：包装成 [`ParsedClaudeSession`]，由 `native_codex_tool_call` 把
+//!   Claude 工具名映射成 Codex 的 `shell_command` / `apply_patch` 等；
+//! - 目标 Claude：包装成 [`ParsedCodexRollout`]，`native_tool_call` 认得 `Bash`
+//!   `Read` `Edit` 这些名字（大小写不敏感），会原样保留。
+//!
+//! 也就是说 Cursor 侧只需要维护**一张**到 Claude 工具名的映射表，两个方向共用。
+//!
+//! 与既有的两个转换方向一致：thinking 一律丢弃并计入 `dropped_reasoning`，
+//! 不重放工具，只搬运已经完成的调用与其输出。
+
+use serde_json::{json, Value};
+
+use super::*;
+
+/// Cursor 会话的中立表示。
+pub(super) struct ParsedCursorSession {
+    pub source_id: String,
+    pub cwd: Option<String>,
+    pub title: Option<String>,
+    pub model: Option<String>,
+    pub git_branch: Option<String>,
+    pub messages: Vec<ConvMessage>,
+    pub items: Vec<CursorItem>,
+    pub stats: ExtractStats,
+}
+
+pub(super) enum CursorItem {
+    Message(ConvMessage),
+    Tool(CursorTool),
+}
+
+pub(super) struct CursorTool {
+    /// 已经映射成 Claude 工具名。
+    name: String,
+    input: Value,
+    /// 调用与输出在 Cursor 里同属一个气泡，所以这里一定是配对好的。
+    output: String,
+    is_error: bool,
+    timestamp: Option<String>,
+}
+
+/// 读取一个 Cursor 会话并归一化。
+pub(super) fn parse(
+    cursor_dir: &Path,
+    agent_dir: &Path,
+    locator: &str,
+) -> AppResult<ParsedCursorSession> {
+    let summary = crate::cursor_sessions::list_sessions(cursor_dir, agent_dir)?
+        .into_iter()
+        .find(|session| session.rollout_path == locator)
+        .ok_or_else(|| AppError::NotFound("Cursor 会话不存在或已被删除".into()))?;
+
+    let mut out = ParsedCursorSession {
+        source_id: summary.id.clone(),
+        cwd: Some(summary.cwd.clone()).filter(|cwd| !cwd.trim().is_empty()),
+        title: Some(summary.title.clone()).filter(|title| !title.trim().is_empty()),
+        model: crate::cursor_sessions::preview_meta(locator)
+            .ok()
+            .and_then(|meta| meta.model_provider),
+        git_branch: summary.git_branch.clone(),
+        messages: Vec::new(),
+        items: Vec::new(),
+        stats: ExtractStats::default(),
+    };
+
+    absorb(
+        &mut out,
+        crate::cursor_sessions::load_preview_events_from_locator(locator)?,
+    );
+    Ok(out)
+}
+
+/// 把展开好的事件序列归一成中立形态。
+fn absorb(out: &mut ParsedCursorSession, events: Vec<crate::models::PreviewEvent>) {
+    // 工具调用先攒着：Cursor 的输出跟调用相邻，但中间可能夹着别的事件。
+    let mut pending: Option<(String, String, Value, Option<String>)> = None;
+    for event in events {
+        let timestamp = Some(event.timestamp.clone()).filter(|value| !value.is_empty());
+        match event.role.as_str() {
+            "user" | "assistant" => {
+                flush_unpaired(out, &mut pending);
+                let text = event_text(&event.raw);
+                if text.trim().is_empty() {
+                    continue;
+                }
+                let role = if event.role == "user" {
+                    Role::User
+                } else {
+                    Role::Assistant
+                };
+                let message = ConvMessage {
+                    role,
+                    text,
+                    timestamp,
+                    phase: None,
+                    images: Vec::new(),
+                };
+                out.messages.push(message.clone());
+                out.items.push(CursorItem::Message(message));
+            }
+            // 与 Claude→Codex、Codex→Claude 两个方向保持一致：推理内容不迁移。
+            "reasoning" => {
+                flush_unpaired(out, &mut pending);
+                out.stats.dropped_reasoning += 1;
+            }
+            "tool_call" => {
+                flush_unpaired(out, &mut pending);
+                let Some(block) = content_block(&event.raw) else {
+                    continue;
+                };
+                let raw_name = block.get("name").and_then(Value::as_str).unwrap_or("");
+                let id = block
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                pending = Some((
+                    id,
+                    claude_tool_name(raw_name),
+                    block.get("input").cloned().unwrap_or_else(|| json!({})),
+                    timestamp,
+                ));
+            }
+            "tool_result" => {
+                let Some(block) = content_block(&event.raw) else {
+                    continue;
+                };
+                let Some((id, name, input, call_ts)) = pending.take() else {
+                    // 没有配对调用的输出无法还原成工具对，只能丢弃。
+                    out.stats.tool_notes += 1;
+                    continue;
+                };
+                let result_id = block
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if !id.is_empty() && !result_id.is_empty() && id != result_id {
+                    // 顺序被打乱时宁可丢掉这一对，也不要把输出接到别的调用上。
+                    out.stats.tool_notes += 1;
+                    continue;
+                }
+                out.stats.tool_notes += 1;
+                out.items.push(CursorItem::Tool(CursorTool {
+                    name,
+                    input,
+                    output: block
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    is_error: block.get("is_error").and_then(Value::as_bool) == Some(true),
+                    timestamp: call_ts.or(timestamp),
+                }));
+            }
+            _ => {}
+        }
+    }
+    flush_unpaired(out, &mut pending);
+
+    // 首条用户消息之前的内容不构成一轮对话，与另外两个方向的处理一致。
+    if let Some(first) = out.messages.iter().position(|m| m.role == Role::User) {
+        out.messages.drain(..first);
+    }
+    if let Some(first) = out
+        .items
+        .iter()
+        .position(|item| matches!(item, CursorItem::Message(message) if message.role == Role::User))
+    {
+        out.items.drain(..first);
+    }
+}
+
+/// 调用没等到输出（会话被中断）时只保留调用本身，输出留空。
+fn flush_unpaired(
+    out: &mut ParsedCursorSession,
+    pending: &mut Option<(String, String, Value, Option<String>)>,
+) {
+    let Some((_, name, input, timestamp)) = pending.take() else {
+        return;
+    };
+    out.stats.tool_notes += 1;
+    out.items.push(CursorItem::Tool(CursorTool {
+        name,
+        input,
+        output: String::new(),
+        is_error: false,
+        timestamp,
+    }));
+}
+
+fn content_block(raw: &Value) -> Option<&Value> {
+    raw.get("message")?.get("content")?.as_array()?.first()
+}
+
+fn event_text(raw: &Value) -> String {
+    let Some(blocks) = raw.get("message").and_then(|m| m.get("content")) else {
+        return String::new();
+    };
+    blocks
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|block| block.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Cursor 工具名 → Claude 工具名。
+///
+/// 两个目标方向共用这一张表：写 Codex 时由 `native_codex_tool_call` 继续映射成
+/// Codex 名字，写 Claude 时 `native_tool_call` 会原样保留这些名字。
+/// 表里没有的（含 `mcp_*` 这类 MCP 工具）原样透传，由下游做字符清洗。
+fn claude_tool_name(raw: &str) -> String {
+    let name = match raw {
+        // Ⓐ IDE Composer 的工具集
+        "run_terminal_command_v2" | "run_terminal_cmd" => "Bash",
+        "edit_file_v2" | "StrReplace" => "Edit",
+        "read_file_v2" => "Read",
+        "ripgrep_raw_search" => "Grep",
+        "glob_file_search" => "Glob",
+        "todo_write" => "TodoWrite",
+        "web_search" => "WebSearch",
+        "ask_question" => "AskUserQuestion",
+        "task_v2" => "Task",
+        "await" => "TaskOutput",
+        // Ⓒ cursor-agent 已经在用 Claude 的名字，只有少数几个不同
+        "Shell" => "Bash",
+        "Delete" => "Bash",
+        other => other,
+    };
+    if name.trim().is_empty() {
+        "unknown".to_string()
+    } else {
+        name.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 目标形态包装
+// ---------------------------------------------------------------------------
+
+/// 工具调用 id 的种子。带上会话 id 与序号，保证同一会话内互不相同、跨会话也不撞。
+fn tool_seed(parsed: &ParsedCursorSession, index: usize, tool: &CursorTool) -> String {
+    format!("{}:{index}:{}", parsed.source_id, tool.name)
+}
+
+/// 包装成 Claude 事件流，供 `write_codex_session` 使用。
+pub(super) fn as_claude(parsed: &ParsedCursorSession) -> ParsedClaudeSession {
+    let mut events = Vec::new();
+    // 种子里带上序号：同一个会话里重复执行同一条命令是常态，只用名字和输出做种
+    // 会让两次调用拿到同一个 id，配对时就会张冠李戴。
+    for (index, item) in parsed.items.iter().enumerate() {
+        match item {
+            CursorItem::Message(message) => events.push(ClaudeEvent::Message(message.clone())),
+            CursorItem::Tool(tool) => {
+                let id = claude_native_id("toolu_", &tool_seed(parsed, index, tool));
+                events.push(ClaudeEvent::ToolCall(ClaudeToolEvent {
+                    tool_use_id: Some(id.clone()),
+                    payload: json!({
+                        "type": "tool_use",
+                        "id": id,
+                        "name": tool.name,
+                        "input": tool.input,
+                    }),
+                    timestamp: tool.timestamp.clone(),
+                }));
+                events.push(ClaudeEvent::ToolResult(ClaudeToolEvent {
+                    tool_use_id: Some(id.clone()),
+                    payload: json!({
+                        "type": "tool_result",
+                        "tool_use_id": id,
+                        "content": truncate_chars(&tool.output, NATIVE_TOOL_RESULT_MAX_LEN),
+                        "is_error": tool.is_error,
+                    }),
+                    timestamp: tool.timestamp.clone(),
+                }));
+            }
+        }
+    }
+    classify_claude_assistant_phases(&mut events);
+    ParsedClaudeSession {
+        source_id: Some(parsed.source_id.clone()),
+        cwd: parsed.cwd.clone(),
+        title: parsed.title.clone(),
+        messages: parsed.messages.clone(),
+        events,
+        stats: ExtractStats {
+            dropped_reasoning: parsed.stats.dropped_reasoning,
+            tool_notes: parsed.stats.tool_notes,
+        },
+    }
+}
+
+/// 包装成 Codex 事件流，供 `write_claude_session` 使用。
+///
+/// 工具名保持 Claude 侧的取值：`native_tool_call` 对 `bash` / `read` / `edit` 等
+/// 是大小写不敏感匹配，未收录的名字也会原样透传，因此不需要再绕一次 Codex 名字。
+pub(super) fn as_codex(parsed: &ParsedCursorSession) -> ParsedCodexRollout {
+    let mut events = Vec::new();
+    let mut messages = Vec::new();
+    for (index, item) in parsed.items.iter().enumerate() {
+        match item {
+            CursorItem::Message(message) => {
+                messages.push(message.clone());
+                events.push(CodexEvent::Message(message.clone()));
+            }
+            CursorItem::Tool(tool) => {
+                let call_id = codex_native_id("call_", &tool_seed(parsed, index, tool));
+                // 工具事件在简洁模式下不参与对话，与 Codex 侧一样标成 commentary。
+                let note = ConvMessage {
+                    role: Role::Assistant,
+                    text: format!("[tool_call: {}]", tool.name),
+                    timestamp: tool.timestamp.clone(),
+                    phase: Some("commentary".into()),
+                    images: Vec::new(),
+                };
+                messages.push(note);
+                events.push(CodexEvent::ToolCall(CodexToolEvent {
+                    call_id: Some(call_id.clone()),
+                    payload: json!({
+                        "type": "function_call",
+                        "name": tool.name,
+                        "arguments": tool.input.to_string(),
+                        "call_id": call_id,
+                    }),
+                    timestamp: tool.timestamp.clone(),
+                }));
+                events.push(CodexEvent::ToolResult(CodexToolEvent {
+                    call_id: Some(call_id.clone()),
+                    payload: json!({
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": truncate_chars(&tool.output, NATIVE_TOOL_RESULT_MAX_LEN),
+                        "is_error": tool.is_error,
+                    }),
+                    timestamp: tool.timestamp.clone(),
+                }));
+            }
+        }
+    }
+    classify_codex_turn_phases(&mut messages);
+    ParsedCodexRollout {
+        source_id: Some(parsed.source_id.clone()),
+        cwd: parsed.cwd.clone(),
+        git_branch: parsed.git_branch.clone(),
+        model: parsed.model.clone(),
+        title: parsed.title.clone(),
+        messages,
+        events,
+        stats: ExtractStats {
+            dropped_reasoning: parsed.stats.dropped_reasoning,
+            tool_notes: parsed.stats.tool_notes,
+        },
+    }
+}
+
+/// 一轮里最后一条 assistant 是最终答复，其余是过程回复。
+///
+/// Claude 的简洁模式只保留用户提问和每轮的 `final_answer`，没有这一步的话
+/// 整个会话会退化成只剩提问。
+fn classify_codex_turn_phases(messages: &mut [ConvMessage]) {
+    let mut last_assistant: Option<usize> = None;
+    for index in 0..messages.len() {
+        match messages[index].role {
+            Role::User => {
+                if let Some(previous) = last_assistant.take() {
+                    messages[previous].phase = Some("final_answer".into());
+                }
+            }
+            Role::Assistant => {
+                if messages[index].phase.is_none() {
+                    messages[index].phase = Some("commentary".into());
+                    last_assistant = Some(index);
+                }
+            }
+        }
+    }
+    if let Some(previous) = last_assistant {
+        messages[previous].phase = Some("final_answer".into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::PreviewEvent;
+
+    fn event(index: usize, role: &str, message: Value) -> PreviewEvent {
+        PreviewEvent {
+            index,
+            timestamp: format!("2026-08-01T00:00:{:02}.000Z", index),
+            role: role.into(),
+            kind: role.into(),
+            text_summary: String::new(),
+            raw: json!({ "message": message }),
+        }
+    }
+
+    /// 事件序列 → 中立形态。直接复用 `cursor_sessions` 产出的事件形状。
+    fn normalize(events: Vec<PreviewEvent>) -> ParsedCursorSession {
+        let mut out = ParsedCursorSession {
+            source_id: "cursor-src".into(),
+            cwd: Some("/work/demo".into()),
+            title: Some("演示会话".into()),
+            model: Some("claude-opus-5".into()),
+            git_branch: Some("main".into()),
+            messages: Vec::new(),
+            items: Vec::new(),
+            stats: ExtractStats::default(),
+        };
+        absorb(&mut out, events);
+        out
+    }
+
+    #[test]
+    fn cursor_tool_names_map_to_claude_and_pass_unknown_ones_through() {
+        assert_eq!(claude_tool_name("run_terminal_command_v2"), "Bash");
+        assert_eq!(claude_tool_name("edit_file_v2"), "Edit");
+        assert_eq!(claude_tool_name("read_file_v2"), "Read");
+        assert_eq!(claude_tool_name("ripgrep_raw_search"), "Grep");
+        assert_eq!(claude_tool_name("glob_file_search"), "Glob");
+        assert_eq!(claude_tool_name("todo_write"), "TodoWrite");
+        assert_eq!(claude_tool_name("ask_question"), "AskUserQuestion");
+        assert_eq!(claude_tool_name("await"), "TaskOutput");
+        // cursor-agent 侧已经在用 Claude 的名字。
+        assert_eq!(claude_tool_name("Shell"), "Bash");
+        assert_eq!(claude_tool_name("Read"), "Read");
+        // MCP 工具原样透传。
+        assert_eq!(
+            claude_tool_name("mcp_cloudfirewall_get_alerts"),
+            "mcp_cloudfirewall_get_alerts"
+        );
+        assert_eq!(claude_tool_name(""), "unknown");
+    }
+
+    #[test]
+    fn tool_calls_and_their_output_are_normalized_into_one_item() {
+        let parsed = normalize(vec![
+            event(
+                0,
+                "user",
+                json!({"role": "user", "content": [{"type": "text", "text": "看下目录"}]}),
+            ),
+            event(
+                1,
+                "reasoning",
+                json!({"role": "assistant", "content": [{"type": "thinking", "thinking": "先列目录"}]}),
+            ),
+            event(
+                2,
+                "assistant",
+                json!({"role": "assistant", "content": [{"type": "text", "text": "好的"}]}),
+            ),
+            event(
+                3,
+                "tool_call",
+                json!({"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "t1", "name": "run_terminal_command_v2", "input": {"command": "ls"}}
+                ]}),
+            ),
+            event(
+                4,
+                "tool_result",
+                json!({"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "a.txt", "is_error": false}
+                ]}),
+            ),
+        ]);
+
+        // 推理不迁移，但要如实计数。
+        assert_eq!(parsed.stats.dropped_reasoning, 1);
+        assert_eq!(parsed.messages.len(), 2);
+        assert_eq!(parsed.items.len(), 3);
+        let CursorItem::Tool(tool) = &parsed.items[2] else {
+            panic!("第三项应当是工具调用");
+        };
+        assert_eq!(tool.name, "Bash");
+        assert_eq!(tool.output, "a.txt");
+        assert!(!tool.is_error);
+    }
+
+    /// 会话被中断时只有调用没有输出，仍要保留调用本身。
+    #[test]
+    fn an_unfinished_tool_call_is_kept_without_output() {
+        let parsed = normalize(vec![
+            event(
+                0,
+                "user",
+                json!({"role": "user", "content": [{"type": "text", "text": "跑一下"}]}),
+            ),
+            event(
+                1,
+                "tool_call",
+                json!({"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "t1", "name": "read_file_v2", "input": {"target_file": "a.rs"}}
+                ]}),
+            ),
+        ]);
+        let CursorItem::Tool(tool) = parsed.items.last().unwrap() else {
+            panic!("末项应当是工具调用");
+        };
+        assert_eq!(tool.name, "Read");
+        assert!(tool.output.is_empty());
+    }
+
+    /// 输出的 id 对不上调用时宁可丢弃，也不能把结果接到别的调用上。
+    #[test]
+    fn a_mismatched_tool_result_is_dropped_instead_of_being_attached() {
+        let parsed = normalize(vec![
+            event(
+                0,
+                "user",
+                json!({"role": "user", "content": [{"type": "text", "text": "跑一下"}]}),
+            ),
+            event(
+                1,
+                "tool_call",
+                json!({"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "t1", "name": "Grep", "input": {}}
+                ]}),
+            ),
+            event(
+                2,
+                "tool_result",
+                json!({"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "OTHER", "content": "x"}
+                ]}),
+            ),
+        ]);
+        assert!(parsed
+            .items
+            .iter()
+            .all(|item| !matches!(item, CursorItem::Tool(tool) if !tool.output.is_empty())));
+    }
+
+    #[test]
+    fn the_claude_shape_emits_paired_tool_use_and_tool_result_blocks() {
+        let parsed = normalize(vec![
+            event(
+                0,
+                "user",
+                json!({"role": "user", "content": [{"type": "text", "text": "看下目录"}]}),
+            ),
+            event(
+                1,
+                "tool_call",
+                json!({"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "t1", "name": "run_terminal_command_v2", "input": {"command": "ls"}}
+                ]}),
+            ),
+            event(
+                2,
+                "tool_result",
+                json!({"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "a.txt"}
+                ]}),
+            ),
+        ]);
+        let claude = as_claude(&parsed);
+        let mut call_id = None;
+        let mut result_id = None;
+        for e in &claude.events {
+            match e {
+                ClaudeEvent::ToolCall(call) => {
+                    assert_eq!(call.payload["name"], "Bash");
+                    call_id = call.tool_use_id.clone();
+                }
+                ClaudeEvent::ToolResult(result) => result_id = result.tool_use_id.clone(),
+                ClaudeEvent::Message(_) => {}
+            }
+        }
+        assert!(call_id.is_some());
+        assert_eq!(call_id, result_id, "工具调用与输出必须共用同一个 id");
+    }
+
+    #[test]
+    fn the_codex_shape_emits_paired_function_call_items() {
+        let parsed = normalize(vec![
+            event(
+                0,
+                "user",
+                json!({"role": "user", "content": [{"type": "text", "text": "看下目录"}]}),
+            ),
+            event(
+                1,
+                "tool_call",
+                json!({"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "t1", "name": "run_terminal_command_v2", "input": {"command": "ls"}}
+                ]}),
+            ),
+            event(
+                2,
+                "tool_result",
+                json!({"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "t1", "content": "a.txt"}
+                ]}),
+            ),
+        ]);
+        let codex = as_codex(&parsed);
+        assert_eq!(codex.git_branch.as_deref(), Some("main"));
+        assert_eq!(codex.model.as_deref(), Some("claude-opus-5"));
+        let calls = codex
+            .events
+            .iter()
+            .filter_map(|e| match e {
+                CodexEvent::ToolCall(call) => Some(call),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].payload["type"], "function_call");
+        // 工具名保持 Claude 侧取值，native_tool_call 会原样识别。
+        assert_eq!(calls[0].payload["name"], "Bash");
+        let outputs = codex
+            .events
+            .iter()
+            .filter_map(|e| match e {
+                CodexEvent::ToolResult(result) => result.call_id.clone(),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(outputs, vec![calls[0].call_id.clone().unwrap()]);
+    }
+
+    /// 同一条命令跑两次不能拿到同一个工具 id，否则配对会张冠李戴。
+    #[test]
+    fn repeated_identical_tool_calls_get_distinct_ids() {
+        let repeat = |index: usize| {
+            vec![
+                event(
+                    index,
+                    "tool_call",
+                    json!({"role": "assistant", "content": [
+                        {"type": "tool_use", "id": format!("t{index}"), "name": "Shell", "input": {"command": "ls"}}
+                    ]}),
+                ),
+                event(
+                    index + 1,
+                    "tool_result",
+                    json!({"role": "user", "content": [
+                        {"type": "tool_result", "tool_use_id": format!("t{index}"), "content": "same"}
+                    ]}),
+                ),
+            ]
+        };
+        let mut events = vec![event(
+            0,
+            "user",
+            json!({"role": "user", "content": [{"type": "text", "text": "跑两次"}]}),
+        )];
+        events.extend(repeat(1));
+        events.extend(repeat(3));
+
+        let claude = as_claude(&normalize(events));
+        let ids = claude
+            .events
+            .iter()
+            .filter_map(|e| match e {
+                ClaudeEvent::ToolCall(call) => call.tool_use_id.clone(),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(ids.len(), 2);
+        assert_ne!(ids[0], ids[1]);
+    }
+
+    #[test]
+    fn turn_phases_mark_the_last_assistant_of_each_turn_as_the_final_answer() {
+        let mut messages = vec![
+            ConvMessage {
+                role: Role::User,
+                text: "问题一".into(),
+                timestamp: None,
+                phase: None,
+                images: Vec::new(),
+            },
+            ConvMessage {
+                role: Role::Assistant,
+                text: "过程".into(),
+                timestamp: None,
+                phase: None,
+                images: Vec::new(),
+            },
+            ConvMessage {
+                role: Role::Assistant,
+                text: "答复一".into(),
+                timestamp: None,
+                phase: None,
+                images: Vec::new(),
+            },
+            ConvMessage {
+                role: Role::User,
+                text: "问题二".into(),
+                timestamp: None,
+                phase: None,
+                images: Vec::new(),
+            },
+            ConvMessage {
+                role: Role::Assistant,
+                text: "答复二".into(),
+                timestamp: None,
+                phase: None,
+                images: Vec::new(),
+            },
+        ];
+        classify_codex_turn_phases(&mut messages);
+        let phases = messages
+            .iter()
+            .map(|m| m.phase.as_deref())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            phases,
+            vec![
+                None,
+                Some("commentary"),
+                Some("final_answer"),
+                None,
+                Some("final_answer")
+            ]
+        );
+    }
+}

--- a/src-tauri/src/cursor_agent_store.rs
+++ b/src-tauri/src/cursor_agent_store.rs
@@ -1,0 +1,690 @@
+//! cursor-agent CLI 会话（`~/.cursor/chats`）的只读解析。
+//!
+//! 目录布局是 `chats/<md5(cwd)>/<agentId>/`，每个会话目录里：
+//! - `meta.json`（并非总是存在）：`cwd` / `createdAtMs` / `updatedAtMs` / `hasConversation`
+//! - `prompt_history.json`（可选）：用户提问的纯文本列表
+//! - `store.db`：`meta` 表存 hex 编码的 JSON 会话头，`blobs` 表是内容寻址的消息体
+//!
+//! `blobs` 只是一个哈希到字节的映射，对话顺序记在 root blob 这个私有 protobuf 报文里。
+//! 本模块只依赖一条最小假设：**root blob 中字段 1、wire type 2、长度 32 的取值，是按
+//! 对话顺序排列的子 blob 摘要**。其余字段（上下文窗口分区、token 统计）一律跳过。
+//! Cursor 调整报文结构时，最坏结果是这个会话读不出来，而不会拼出一段错误的对话。
+//!
+//! 子 blob 本身是纯 JSON 的 AI-SDK 消息，不需要再解 protobuf。
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OpenFlags};
+use serde_json::{json, Value};
+
+use crate::error::{AppError, AppResult};
+use crate::models::{PreviewEvent, SessionMetaBrief, SessionSummary, UserPromptList};
+use crate::paths;
+
+/// blob 摘要是 32 字节的 SHA-256。
+const BLOB_ID_LEN: usize = 32;
+
+/// 一个会话目录解析出来的原始信息，`SessionSummary` 与预览都由它派生。
+#[derive(Debug, Clone, Default)]
+pub(crate) struct AgentSessionMeta {
+    pub id: String,
+    pub name: String,
+    pub cwd: String,
+    pub model: Option<String>,
+    pub mode: Option<String>,
+    pub created_at_ms: i64,
+    pub updated_at_ms: i64,
+    pub first_prompt: String,
+    pub bytes: u64,
+}
+
+pub fn store_path(session_dir: &Path) -> PathBuf {
+    session_dir.join("store.db")
+}
+
+/// 扫描 `<agent_dir>/chats` 下的全部会话。
+///
+/// 目录不存在时返回空列表而不是报错：用户可能只用 Cursor IDE、从没装过 CLI。
+pub fn list_sessions(agent_dir: &Path) -> AppResult<Vec<SessionSummary>> {
+    let chats = paths::cursor_agent_chats_dir(agent_dir);
+    if !chats.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for workspace in read_dirs(&chats)? {
+        // 目录名是 md5(cwd)，不可逆。但同一目录下的会话共享同一个 cwd，
+        // 所以只要组内任何一个会话留下了 meta.json 就能补全其余会话。
+        let sessions = read_dirs(&workspace)?;
+        let shared_cwd = sessions
+            .iter()
+            .find_map(|dir| read_meta_json(dir).and_then(|meta| meta.cwd));
+        for dir in sessions {
+            match read_session_meta(&dir, shared_cwd.as_deref()) {
+                Ok(Some(meta)) => out.push(summary_from_meta(&dir, meta)?),
+                // 单个会话损坏不应该让整个列表不可用。
+                Ok(None) | Err(_) => continue,
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn summary_from_meta(session_dir: &Path, meta: AgentSessionMeta) -> AppResult<SessionSummary> {
+    let title = if meta.name.trim().is_empty() {
+        if meta.first_prompt.trim().is_empty() {
+            paths::basename_display(&session_dir.to_string_lossy())
+        } else {
+            crate::cursor_sessions::truncate_title(&meta.first_prompt)
+        }
+    } else {
+        meta.name.clone()
+    };
+    let cwd = paths::strip_verbatim(&meta.cwd);
+    Ok(SessionSummary {
+        provider: crate::cursor_sessions::PROVIDER.into(),
+        id: meta.id.clone(),
+        rollout_path: crate::cursor_sessions::encode_agent_locator(session_dir, &meta.id)?,
+        cwd_display: paths::basename_display(&cwd),
+        cwd,
+        title,
+        first_user_message: meta.first_prompt,
+        model: meta.model,
+        reasoning_effort: None,
+        source: meta.mode,
+        agent_nickname: None,
+        agent_role: None,
+        conversion_origin: None,
+        // Cursor 全程不记录 token 用量，写 0 而不是拿上下文窗口占用冒充累计消耗。
+        tokens_used: 0,
+        created_at: meta.created_at_ms / 1000,
+        updated_at: meta.updated_at_ms / 1000,
+        // cursor-agent 没有归档概念。
+        archived: false,
+        git_branch: None,
+        rollout_bytes: meta.bytes,
+        logs_count: 0,
+        has_backup: false,
+        resume_command: format!("cursor-agent --resume {}", meta.id),
+    })
+}
+
+/// 读取单个会话目录的元信息；不含 `store.db` 时返回 `None`。
+pub(crate) fn read_session_meta(
+    session_dir: &Path,
+    shared_cwd: Option<&str>,
+) -> AppResult<Option<AgentSessionMeta>> {
+    let store = store_path(session_dir);
+    if !store.is_file() {
+        return Ok(None);
+    }
+    let file_meta = fs::metadata(&store)?;
+    let mtime_ms = file_meta
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|delta| delta.as_millis() as i64)
+        .unwrap_or(0);
+
+    let header = read_store_header(&store).unwrap_or(Value::Null);
+    let json_meta = read_meta_json(session_dir);
+
+    let id = header
+        .get("agentId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| paths::basename_display(&session_dir.to_string_lossy()));
+    let created_at_ms = json_meta
+        .as_ref()
+        .and_then(|meta| meta.created_at_ms)
+        .or_else(|| header.get("createdAt").and_then(Value::as_i64))
+        .filter(|value| *value > 0)
+        .unwrap_or(mtime_ms);
+    let updated_at_ms = json_meta
+        .as_ref()
+        .and_then(|meta| meta.updated_at_ms)
+        .filter(|value| *value > 0)
+        .unwrap_or(mtime_ms)
+        .max(created_at_ms);
+
+    Ok(Some(AgentSessionMeta {
+        id,
+        name: header
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        cwd: json_meta
+            .as_ref()
+            .and_then(|meta| meta.cwd.clone())
+            .or_else(|| shared_cwd.map(str::to_string))
+            .unwrap_or_default(),
+        model: header
+            .get("lastUsedModel")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string),
+        mode: header
+            .get("mode")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .map(str::to_string),
+        created_at_ms,
+        updated_at_ms,
+        first_prompt: read_first_prompt(session_dir),
+        bytes: file_meta.len(),
+    }))
+}
+
+pub(crate) fn preview_meta(session_dir: &Path) -> AppResult<SessionMetaBrief> {
+    let meta = read_session_meta(session_dir, None)?
+        .ok_or_else(|| AppError::NotFound("Cursor CLI 会话不存在".into()))?;
+    Ok(SessionMetaBrief {
+        id: Some(meta.id),
+        timestamp: crate::cursor_sessions::timestamp_from_millis(meta.created_at_ms),
+        cwd: Some(meta.cwd).filter(|value| !value.is_empty()),
+        originator: Some("cursor-agent".into()),
+        cli_version: None,
+        source: Some("store.db".into()),
+        model_provider: meta.model,
+    })
+}
+
+/// 按 root blob 记录的顺序还原整段对话。
+pub(crate) fn load_preview_events(session_dir: &Path) -> AppResult<Vec<PreviewEvent>> {
+    let store = store_path(session_dir);
+    let connection = open_readonly(&store)?;
+    let header = read_store_header(&store)?;
+    let Some(root) = header.get("latestRootBlobId").and_then(Value::as_str) else {
+        return Ok(Vec::new());
+    };
+
+    let mut blobs: HashMap<String, Vec<u8>> = HashMap::new();
+    let mut statement = connection.prepare("SELECT id, data FROM blobs")?;
+    let rows = statement.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?))
+    })?;
+    for row in rows {
+        let (id, data) = row?;
+        blobs.insert(id, data);
+    }
+
+    let Some(root_blob) = blobs.get(root) else {
+        return Ok(Vec::new());
+    };
+    let mut events = Vec::new();
+    for id in child_blob_ids(root_blob) {
+        let Some(data) = blobs.get(&id) else {
+            continue;
+        };
+        let Ok(message) = serde_json::from_slice::<Value>(data) else {
+            continue;
+        };
+        push_message_events(&mut events, &id, &message);
+    }
+    Ok(events)
+}
+
+/// 把一条 AI-SDK 消息拆成若干 `PreviewEvent`。
+///
+/// 合成的 `raw` 刻意做成 Claude 记录的形状，直接复用
+/// `claude_sessions::classify_preview` 的角色判定，前端也就不必为 Cursor 再写渲染分支。
+fn push_message_events(events: &mut Vec<PreviewEvent>, blob_id: &str, message: &Value) {
+    let role = message.get("role").and_then(Value::as_str).unwrap_or("");
+    let content = message.get("content");
+    let origin = json!({ "blob_id": blob_id, "store": "agent" });
+
+    // 系统提示词与 <user_info> 这类注入上下文不是对话内容，标成 meta 让预览默认折叠。
+    if role == "system" {
+        push(events, meta_raw("system_prompt", content, &origin));
+        return;
+    }
+    let Some(blocks) = content.and_then(Value::as_array) else {
+        let text = content.and_then(Value::as_str).unwrap_or("");
+        if role == "user" && crate::cursor_sessions::is_injected_context(text) {
+            push(events, meta_raw("environment_context", content, &origin));
+        } else {
+            push(
+                events,
+                message_raw(role, json!([text_block(text)]), &origin),
+            );
+        }
+        return;
+    };
+
+    let mut texts = Vec::new();
+    for block in blocks {
+        match block.get("type").and_then(Value::as_str).unwrap_or("") {
+            "text" => {
+                let text = block.get("text").and_then(Value::as_str).unwrap_or("");
+                if role == "user" && crate::cursor_sessions::is_injected_context(text) {
+                    push(events, meta_raw("environment_context", content, &origin));
+                } else {
+                    texts.push(text_block(text));
+                }
+            }
+            "tool-call" => {
+                // 工具调用单独成事件，与 Ⓐ 侧和 Claude 侧的时间线粒度保持一致。
+                // 先把此前攒下的正文冲出去，否则同一条消息里 text 会排到工具后面。
+                flush_texts(events, role, &mut texts, &origin);
+                push(
+                    events,
+                    message_raw(
+                        "assistant",
+                        json!([{
+                            "type": "tool_use",
+                            "id": block.get("toolCallId").cloned().unwrap_or(Value::Null),
+                            "name": block.get("toolName").cloned().unwrap_or(Value::Null),
+                            "input": block.get("args").cloned().unwrap_or(Value::Null),
+                        }]),
+                        &origin,
+                    ),
+                );
+            }
+            "tool-result" => {
+                flush_texts(events, role, &mut texts, &origin);
+                push(
+                    events,
+                    message_raw(
+                        "user",
+                        json!([{
+                            "type": "tool_result",
+                            "tool_use_id": block.get("toolCallId").cloned().unwrap_or(Value::Null),
+                            "content": crate::cursor_sessions::tool_result_content(block.get("result")),
+                        }]),
+                        &origin,
+                    ),
+                );
+            }
+            _ => {}
+        }
+    }
+    flush_texts(events, role, &mut texts, &origin);
+}
+
+/// 把攒下的连续 text 块合成一条消息事件。相邻的正文属于同一次发言，不该拆开。
+fn flush_texts(events: &mut Vec<PreviewEvent>, role: &str, texts: &mut Vec<Value>, origin: &Value) {
+    if texts.is_empty() {
+        return;
+    }
+    push(
+        events,
+        message_raw(role, Value::Array(std::mem::take(texts)), origin),
+    );
+}
+
+fn push(events: &mut Vec<PreviewEvent>, raw: Value) {
+    if let Some(event) = crate::claude_sessions::classify_preview(events.len(), raw) {
+        events.push(event);
+    }
+}
+
+fn text_block(text: &str) -> Value {
+    json!({ "type": "text", "text": crate::cursor_sessions::unwrap_user_query(text) })
+}
+
+/// cursor-agent 不给每条消息记时间戳，`timestamp` 留空表示"未知"而不是编一个。
+fn message_raw(role: &str, content: Value, origin: &Value) -> Value {
+    json!({
+        "type": role,
+        "timestamp": "",
+        "message": { "role": role, "content": content },
+        "cursor": origin,
+    })
+}
+
+fn meta_raw(kind: &str, content: Option<&Value>, origin: &Value) -> Value {
+    json!({
+        "type": kind,
+        "timestamp": "",
+        "isMeta": true,
+        "content": content.and_then(Value::as_str).unwrap_or(""),
+        "cursor": origin,
+    })
+}
+
+pub(crate) fn preview_user_prompts(session_dir: &Path) -> AppResult<UserPromptList> {
+    let events = load_preview_events(session_dir)?;
+    Ok(crate::rollout::user_prompts_from_events(events, |event| {
+        matches!(event.role.as_str(), "assistant" | "reasoning" | "tool_call")
+    }))
+}
+
+// ---------------------------------------------------------------------------
+// root blob 的最小 protobuf 解析
+// ---------------------------------------------------------------------------
+
+/// 按报文顺序取出字段 1 中长度为 32 的取值，即对话中各条消息的 blob 摘要。
+fn child_blob_ids(data: &[u8]) -> Vec<String> {
+    let mut cursor = 0usize;
+    let mut out = Vec::new();
+    while cursor < data.len() {
+        let Some(key) = read_varint(data, &mut cursor) else {
+            break;
+        };
+        let field = key >> 3;
+        match key & 7 {
+            // varint
+            0 => {
+                if read_varint(data, &mut cursor).is_none() {
+                    break;
+                }
+            }
+            // 64 位定长
+            1 => match cursor.checked_add(8).filter(|end| *end <= data.len()) {
+                Some(end) => cursor = end,
+                None => break,
+            },
+            // 长度前缀
+            2 => {
+                let Some(len) = read_varint(data, &mut cursor) else {
+                    break;
+                };
+                let Ok(len) = usize::try_from(len) else {
+                    break;
+                };
+                let Some(end) = cursor.checked_add(len).filter(|end| *end <= data.len()) else {
+                    break;
+                };
+                if field == 1 && len == BLOB_ID_LEN {
+                    out.push(hex::encode(&data[cursor..end]));
+                }
+                cursor = end;
+            }
+            // 32 位定长
+            5 => match cursor.checked_add(4).filter(|end| *end <= data.len()) {
+                Some(end) => cursor = end,
+                None => break,
+            },
+            // 3/4 是已废弃的 group 编码，遇到直接停止而不是猜测长度。
+            _ => break,
+        }
+    }
+    out
+}
+
+fn read_varint(data: &[u8], cursor: &mut usize) -> Option<u64> {
+    let mut result = 0u64;
+    let mut shift = 0u32;
+    loop {
+        let byte = *data.get(*cursor)?;
+        *cursor += 1;
+        result |= u64::from(byte & 0x7f).checked_shl(shift)?;
+        if byte & 0x80 == 0 {
+            return Some(result);
+        }
+        shift += 7;
+        if shift >= 64 {
+            return None;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 文件与数据库读取
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Default)]
+struct MetaJson {
+    cwd: Option<String>,
+    created_at_ms: Option<i64>,
+    updated_at_ms: Option<i64>,
+}
+
+fn read_meta_json(session_dir: &Path) -> Option<MetaJson> {
+    let raw = fs::read_to_string(session_dir.join("meta.json")).ok()?;
+    let value: Value = serde_json::from_str(&raw).ok()?;
+    Some(MetaJson {
+        cwd: value
+            .get("cwd")
+            .and_then(Value::as_str)
+            .filter(|cwd| !cwd.trim().is_empty())
+            .map(str::to_string),
+        created_at_ms: value.get("createdAtMs").and_then(Value::as_i64),
+        updated_at_ms: value.get("updatedAtMs").and_then(Value::as_i64),
+    })
+}
+
+/// `prompt_history.json` 是用户提问的纯文本列表，用来在列表页免去解析 blob。
+fn read_first_prompt(session_dir: &Path) -> String {
+    let Ok(raw) = fs::read_to_string(session_dir.join("prompt_history.json")) else {
+        return String::new();
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+        return String::new();
+    };
+    value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        // 开头的斜杠命令是客户端指令，不能代表这个会话在聊什么。
+        .find(|prompt| !prompt.is_empty() && !prompt.starts_with('/'))
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// `store.db` 的 `meta` 表把会话头存成 hex 编码的 JSON。
+fn read_store_header(store: &Path) -> AppResult<Value> {
+    let connection = open_readonly(store)?;
+    let mut statement = connection.prepare("SELECT value FROM meta ORDER BY key ASC")?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
+    for row in rows {
+        let encoded = row?;
+        let Ok(bytes) = hex::decode(encoded.trim()) else {
+            continue;
+        };
+        let Ok(text) = String::from_utf8(bytes) else {
+            continue;
+        };
+        if let Ok(value) = serde_json::from_str::<Value>(&text) {
+            if value.get("agentId").is_some() || value.get("latestRootBlobId").is_some() {
+                return Ok(value);
+            }
+        }
+    }
+    Ok(Value::Null)
+}
+
+fn read_dirs(root: &Path) -> AppResult<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            out.push(entry.path());
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+fn open_readonly(path: &Path) -> AppResult<Connection> {
+    if !path.is_file() {
+        return Err(AppError::NotFound(format!(
+            "Cursor CLI 会话数据库不存在: {}",
+            path.to_string_lossy()
+        )));
+    }
+    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_root(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "cc-sessions-cursor-agent-{name}-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    /// 按 protobuf 的 `field 1, wire type 2` 编码一串 32 字节摘要。
+    fn encode_root(children: &[[u8; BLOB_ID_LEN]]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for child in children {
+            out.push((1 << 3) | 2);
+            out.push(BLOB_ID_LEN as u8);
+            out.extend_from_slice(child);
+        }
+        out
+    }
+
+    fn blob_id(seed: u8) -> [u8; BLOB_ID_LEN] {
+        [seed; BLOB_ID_LEN]
+    }
+
+    fn write_store(dir: &Path, messages: &[Value]) -> AppResult<()> {
+        fs::create_dir_all(dir)?;
+        let connection = Connection::open(store_path(dir))?;
+        connection.execute_batch(
+            "CREATE TABLE blobs (id TEXT PRIMARY KEY, data BLOB);
+             CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT);",
+        )?;
+        let mut ids = Vec::new();
+        for (index, message) in messages.iter().enumerate() {
+            let id = blob_id(index as u8 + 1);
+            ids.push(id);
+            connection.execute(
+                "INSERT INTO blobs VALUES (?1, ?2)",
+                rusqlite::params![hex::encode(id), serde_json::to_vec(message)?],
+            )?;
+        }
+        let root = blob_id(0xff);
+        connection.execute(
+            "INSERT INTO blobs VALUES (?1, ?2)",
+            rusqlite::params![hex::encode(root), encode_root(&ids)],
+        )?;
+        let header = json!({
+            "agentId": "agent-1",
+            "latestRootBlobId": hex::encode(root),
+            "name": "示例会话",
+            "mode": "default",
+            "lastUsedModel": "composer-2.5",
+            "createdAt": 1_700_000_000_000i64,
+        });
+        connection.execute(
+            "INSERT INTO meta VALUES ('0', ?1)",
+            [hex::encode(header.to_string())],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn child_blob_ids_follows_root_order_and_ignores_other_fields() {
+        let mut data = Vec::new();
+        // 字段 2 的 varint 与字段 3 的字符串都应被跳过。
+        data.push((2 << 3) | 0);
+        data.push(0x7f);
+        data.push((1 << 3) | 2);
+        data.push(BLOB_ID_LEN as u8);
+        data.extend_from_slice(&blob_id(0xaa));
+        data.push((3 << 3) | 2);
+        data.push(3);
+        data.extend_from_slice(b"cli");
+        data.push((1 << 3) | 2);
+        data.push(BLOB_ID_LEN as u8);
+        data.extend_from_slice(&blob_id(0xbb));
+
+        let ids = child_blob_ids(&data);
+        assert_eq!(
+            ids,
+            vec![hex::encode(blob_id(0xaa)), hex::encode(blob_id(0xbb))]
+        );
+    }
+
+    #[test]
+    fn child_blob_ids_stops_on_truncated_payload_instead_of_panicking() {
+        // 长度前缀声明 32 字节但只剩 3 字节，必须安全停止。
+        let data = vec![(1 << 3) | 2, BLOB_ID_LEN as u8, 1, 2, 3];
+        assert!(child_blob_ids(&data).is_empty());
+    }
+
+    #[test]
+    fn load_preview_events_splits_tool_calls_and_results() -> AppResult<()> {
+        let dir = temp_root("preview").join("agent-1");
+        write_store(
+            &dir,
+            &[
+                json!({"role": "system", "content": "system prompt"}),
+                json!({"role": "user", "content": "<user_info>OS darwin</user_info>"}),
+                json!({"role": "user", "content": [{"type": "text", "text": "<user_query>\n查一下日志\n</user_query>"}]}),
+                json!({"role": "assistant", "content": [
+                    {"type": "text", "text": "好的"},
+                    {"type": "tool-call", "toolCallId": "tool_1", "toolName": "Shell", "args": {"command": "ls"}}
+                ]}),
+                json!({"role": "tool", "content": [
+                    {"type": "tool-result", "toolCallId": "tool_1", "toolName": "Shell", "result": "a.txt"}
+                ]}),
+            ],
+        )?;
+
+        let events = load_preview_events(&dir)?;
+        let roles = events.iter().map(|e| e.role.as_str()).collect::<Vec<_>>();
+        // 同一条 assistant 消息里，正文必须排在它触发的工具调用之前。
+        assert_eq!(
+            roles,
+            vec![
+                "meta",
+                "meta",
+                "user",
+                "assistant",
+                "tool_call",
+                "tool_result"
+            ]
+        );
+        assert_eq!(events[2].text_summary, "查一下日志");
+        assert_eq!(events[3].text_summary, "好的");
+        fs::remove_dir_all(dir.parent().unwrap())?;
+        Ok(())
+    }
+
+    #[test]
+    fn list_sessions_borrows_cwd_from_a_sibling_meta_json() -> AppResult<()> {
+        let root = temp_root("list");
+        let workspace =
+            paths::cursor_agent_chats_dir(&root).join("d41d8cd98f00b204e9800998ecf8427e");
+        let with_meta = workspace.join("agent-with-meta");
+        let without_meta = workspace.join("agent-without-meta");
+        write_store(&with_meta, &[json!({"role": "user", "content": "hi"})])?;
+        write_store(&without_meta, &[json!({"role": "user", "content": "hi"})])?;
+        fs::write(
+            with_meta.join("meta.json"),
+            json!({"cwd": "/tmp/demo", "createdAtMs": 1_700_000_000_000i64, "updatedAtMs": 1_700_000_100_000i64})
+                .to_string(),
+        )?;
+        fs::write(
+            with_meta.join("prompt_history.json"),
+            json!(["/status", "第一句提问"]).to_string(),
+        )?;
+
+        let sessions = list_sessions(&root)?;
+        assert_eq!(sessions.len(), 2);
+        // 没有 meta.json 的会话应当借用同组兄弟的 cwd。
+        assert!(sessions.iter().all(|s| s.cwd == "/tmp/demo"));
+        assert!(sessions.iter().all(|s| s.provider == "cursor"));
+        let with_prompt = sessions
+            .iter()
+            .find(|s| !s.first_user_message.is_empty())
+            .expect("prompt_history 应该被读到");
+        // 斜杠命令不能当作首条提问。
+        assert_eq!(with_prompt.first_user_message, "第一句提问");
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn list_sessions_returns_empty_when_cli_was_never_used() -> AppResult<()> {
+        let root = temp_root("absent");
+        fs::create_dir_all(&root)?;
+        assert!(list_sessions(&root)?.is_empty());
+        fs::remove_dir_all(&root)?;
+        Ok(())
+    }
+}

--- a/src-tauri/src/cursor_blobs.rs
+++ b/src-tauri/src/cursor_blobs.rs
@@ -1,0 +1,540 @@
+//! `agentKv:blob:` 与 `composer.content.` 两个内容寻址存储的无引用回收。
+//!
+//! 这两个空间的键是内容的 sha256，不带会话 id，没法像 `bubbleId:<会话>:…` 那样直接判断
+//! 归属，只能做可达性分析。Cursor 自己对 `agentKv` 有同样的机制（命令面板里的
+//! `GC Agent KV Blobs`，实现见 bundle 里的 `AgentKvGC`），对 `composer.content` 则完全没有
+//! 回收路径——所以后者只会一直涨。
+//!
+//! # 引用是怎么存的
+//!
+//! `composerData:<会话>` 和 `bubbleId:<会话>:<气泡>` 的 JSON 里有个 `conversationState`
+//! 字段，值是 base64（`~` 开头的要先去掉这个前缀）编码的二进制，blob id 以**原始 32 字节**
+//! 出现在里面。按十六进制去搜是搜不到的。
+//!
+//! `composer.content.<sha256>` 则相反，以十六进制字面量出现在气泡的
+//! `toolFormerData.result` 里（`beforeContentId` / `afterContentId`）。
+//!
+//! # 判定策略：宁可留下，不可误删
+//!
+//! blob 引用不做协议解析，而是**在字节流里找任何一段等于已知 blob id 的 32 字节窗口**。
+//! 这是"按 protobuf 字段解析"的严格超集：字段号、嵌套层数、编码方式怎么变都不影响，
+//! 代价只是可能多留几个块，不会少留。blob 之间还会互相引用（实测 376 万条边），
+//! 所以要一路做闭包。
+//!
+//! 与 Cursor 一致的一条安全阀：**只要遍历过程中出现任何一次解码失败就整体放弃删除**，
+//! 因为读不出来的那部分可能正引用着别的块。
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use base64::engine::general_purpose::{STANDARD, URL_SAFE};
+use base64::Engine;
+use rusqlite::Connection;
+use serde_json::Value;
+
+use crate::error::AppResult;
+
+const BLOB_PREFIX: &str = "agentKv:blob:";
+const CHECKPOINT_PREFIX: &str = "agentKv:checkpoint:";
+const BUBBLE_CHECKPOINT_PREFIX: &str = "agentKv:bubbleCheckpoint:";
+const CONTENT_PREFIX: &str = "composer.content.";
+
+/// 一次可达性扫描的结果。
+#[derive(Debug, Default)]
+pub struct ContentSweep {
+    pub blobs_total: u32,
+    pub blobs_live: u32,
+    pub blob_orphan_rows: u32,
+    pub blob_orphan_bytes: u64,
+    pub content_total: u32,
+    pub content_live: u32,
+    pub content_orphan_rows: u32,
+    pub content_orphan_bytes: u64,
+    /// 遍历过程中读不动的行数。不为 0 时禁止删除。
+    pub errors: u32,
+    /// 可以删除的完整键。
+    pub orphan_keys: Vec<String>,
+}
+
+impl ContentSweep {
+    pub fn orphan_rows(&self) -> u32 {
+        self.blob_orphan_rows
+            .saturating_add(self.content_orphan_rows)
+    }
+
+    pub fn orphan_bytes(&self) -> u64 {
+        self.blob_orphan_bytes
+            .saturating_add(self.content_orphan_bytes)
+    }
+}
+
+type Id = [u8; 32];
+
+/// 已知 id 的集合，外挂一张 2 MiB 的前 3 字节位图做粗筛。
+///
+/// 逐字节滑窗要做上亿次查询，先过位图能把绝大多数位置在一次内存访问里排掉。
+struct Index {
+    sizes: HashMap<Id, u32>,
+    prefix: Vec<u64>,
+}
+
+impl Index {
+    fn new() -> Self {
+        Self {
+            sizes: HashMap::new(),
+            prefix: vec![0u64; 1 << 18],
+        }
+    }
+
+    fn insert(&mut self, id: Id, bytes: u32) {
+        let slot = prefix_slot(&id);
+        self.prefix[slot >> 6] |= 1u64 << (slot & 63);
+        self.sizes.insert(id, bytes);
+    }
+
+    fn prefix_hit(&self, window: &[u8]) -> bool {
+        let slot = prefix_slot(window);
+        self.prefix[slot >> 6] >> (slot & 63) & 1 == 1
+    }
+
+    fn is_empty(&self) -> bool {
+        self.sizes.is_empty()
+    }
+}
+
+fn prefix_slot(bytes: &[u8]) -> usize {
+    ((bytes[0] as usize) << 16) | ((bytes[1] as usize) << 8) | bytes[2] as usize
+}
+
+/// 扫描整库，算出两个内容存储里没有任何引用的行。
+pub fn sweep(connection: &Connection) -> AppResult<ContentSweep> {
+    let blobs = load_index(connection, BLOB_PREFIX)?;
+    let contents = load_index(connection, CONTENT_PREFIX)?;
+    let mut sweep = ContentSweep {
+        blobs_total: blobs.sizes.len() as u32,
+        content_total: contents.sizes.len() as u32,
+        ..Default::default()
+    };
+    if blobs.is_empty() && contents.is_empty() {
+        return Ok(sweep);
+    }
+
+    let mut live_blobs: HashSet<Id> = HashSet::new();
+    let mut live_contents: HashSet<Id> = HashSet::new();
+    let mut queue: VecDeque<Id> = VecDeque::new();
+
+    collect_roots(
+        connection,
+        &blobs,
+        &contents,
+        &mut live_blobs,
+        &mut live_contents,
+        &mut queue,
+        &mut sweep.errors,
+    )?;
+    close_over_blobs(connection, &blobs, &mut live_blobs, &mut queue, &mut sweep)?;
+
+    sweep.blobs_live = live_blobs.len() as u32;
+    sweep.content_live = live_contents.len() as u32;
+    for (id, bytes) in &blobs.sizes {
+        if !live_blobs.contains(id) {
+            sweep.blob_orphan_rows = sweep.blob_orphan_rows.saturating_add(1);
+            sweep.blob_orphan_bytes = sweep.blob_orphan_bytes.saturating_add(*bytes as u64);
+            sweep
+                .orphan_keys
+                .push(format!("{BLOB_PREFIX}{}", hex::encode(id)));
+        }
+    }
+    for (id, bytes) in &contents.sizes {
+        if !live_contents.contains(id) {
+            sweep.content_orphan_rows = sweep.content_orphan_rows.saturating_add(1);
+            sweep.content_orphan_bytes = sweep.content_orphan_bytes.saturating_add(*bytes as u64);
+            sweep
+                .orphan_keys
+                .push(format!("{CONTENT_PREFIX}{}", hex::encode(id)));
+        }
+    }
+    Ok(sweep)
+}
+
+/// 删除扫描出来的孤儿行。扫描期间出过错就拒绝执行。
+pub fn delete_orphans(connection: &Connection, sweep: &ContentSweep) -> AppResult<u32> {
+    if sweep.errors > 0 {
+        return Err(crate::error::AppError::Other(format!(
+            "有 {} 行内容块读不出来，无法确认剩下的是否还被引用，已放弃删除",
+            sweep.errors
+        )));
+    }
+    let mut statement = connection.prepare("DELETE FROM cursorDiskKV WHERE key = ?1")?;
+    let mut removed = 0u32;
+    for key in &sweep.orphan_keys {
+        removed = removed.saturating_add(statement.execute([key])? as u32);
+    }
+    Ok(removed)
+}
+
+fn load_index(connection: &Connection, prefix: &str) -> AppResult<Index> {
+    let mut index = Index::new();
+    let mut statement = connection.prepare(
+        "SELECT key, octet_length(value) FROM cursorDiskKV WHERE key >= ?1 AND key < ?2",
+    )?;
+    let rows = statement.query_map([prefix, &range_end(prefix)], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?))
+    })?;
+    for row in rows {
+        let (key, bytes) = row?;
+        let Some(id) = key.strip_prefix(prefix).and_then(parse_id) else {
+            continue;
+        };
+        index.insert(id, bytes.unwrap_or(0).max(0) as u32);
+    }
+    Ok(index)
+}
+
+/// 从会话数据里找出根引用。
+///
+/// 覆盖 `agentKv:blob:` 之外的**全部**行：blob 引用只可能出现在 `conversationState` 里，
+/// 但 `composer.content.` 的十六进制字面量出现在哪一类行里没法先验排除，索性全扫。
+fn collect_roots(
+    connection: &Connection,
+    blobs: &Index,
+    contents: &Index,
+    live_blobs: &mut HashSet<Id>,
+    live_contents: &mut HashSet<Id>,
+    queue: &mut VecDeque<Id>,
+    errors: &mut u32,
+) -> AppResult<()> {
+    let end = range_end(BLOB_PREFIX);
+    let mut statement = connection.prepare(
+        "SELECT key, value FROM cursorDiskKV WHERE key < ?1
+         UNION ALL
+         SELECT key, value FROM cursorDiskKV WHERE key >= ?2",
+    )?;
+    let rows = statement.query_map([BLOB_PREFIX, end.as_str()], |row| {
+        Ok((
+            row.get::<_, Option<String>>(0)?,
+            row.get::<_, rusqlite::types::Value>(1)?,
+        ))
+    })?;
+    for row in rows {
+        let (key, value) = row?;
+        let Some(key) = key else { continue };
+        let Some(raw) = as_bytes(value) else { continue };
+
+        // `composer.content.<十六进制>` 在任何行里都算引用。
+        for id in scan_content_refs(&raw, contents) {
+            live_contents.insert(id);
+        }
+
+        if let Some(pointer) = checkpoint_pointer(&key, &raw, errors) {
+            if blobs.sizes.contains_key(&pointer) && live_blobs.insert(pointer) {
+                queue.push_back(pointer);
+            }
+            continue;
+        }
+        if !(key.starts_with("composerData:") || key.starts_with("bubbleId:")) {
+            continue;
+        }
+        let Ok(json) = serde_json::from_slice::<Value>(&raw) else {
+            continue;
+        };
+        let Some(state) = json.get("conversationState").and_then(Value::as_str) else {
+            continue;
+        };
+        if state.is_empty() {
+            continue;
+        }
+        let Some(decoded) = decode_base64(state) else {
+            // 有这个字段却解不开，说明这一行的引用没能算进来。
+            *errors = errors.saturating_add(1);
+            continue;
+        };
+        for id in scan_blob_refs(&decoded, blobs) {
+            if live_blobs.insert(id) {
+                queue.push_back(id);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// 顺着 blob 之间的引用做闭包。
+fn close_over_blobs(
+    connection: &Connection,
+    blobs: &Index,
+    live_blobs: &mut HashSet<Id>,
+    queue: &mut VecDeque<Id>,
+    sweep: &mut ContentSweep,
+) -> AppResult<()> {
+    let mut statement = connection.prepare("SELECT value FROM cursorDiskKV WHERE key = ?1")?;
+    while let Some(current) = queue.pop_front() {
+        let key = format!("{BLOB_PREFIX}{}", hex::encode(current));
+        let value = statement
+            .query_row([&key], |row| row.get::<_, rusqlite::types::Value>(0))
+            .ok();
+        let Some(raw) = value.and_then(as_bytes) else {
+            // 键在索引里却读不出内容，剩下的可达性无从判断。
+            sweep.errors = sweep.errors.saturating_add(1);
+            continue;
+        };
+        for id in scan_blob_refs(&raw, blobs) {
+            if live_blobs.insert(id) {
+                queue.push_back(id);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// `agentKv:checkpoint:<会话>` / `agentKv:bubbleCheckpoint:<会话>:<气泡>` 存的是
+/// base64 后的 32 字节根指针。本机库里这两类键已经被 Cursor 清空，但别的安装上可能还有。
+fn checkpoint_pointer(key: &str, raw: &[u8], errors: &mut u32) -> Option<Id> {
+    if !(key.starts_with(CHECKPOINT_PREFIX) || key.starts_with(BUBBLE_CHECKPOINT_PREFIX)) {
+        return None;
+    }
+    let text = std::str::from_utf8(raw).ok()?.trim();
+    match decode_base64(text).and_then(|bytes| bytes.try_into().ok()) {
+        Some(id) => Some(id),
+        None => {
+            *errors = errors.saturating_add(1);
+            None
+        }
+    }
+}
+
+/// 找出字节流里任何一段等于已知 blob id 的 32 字节窗口。
+fn scan_blob_refs(buf: &[u8], index: &Index) -> Vec<Id> {
+    let mut out = Vec::new();
+    if buf.len() < 32 || index.is_empty() {
+        return out;
+    }
+    for start in 0..=buf.len() - 32 {
+        if !index.prefix_hit(&buf[start..start + 3]) {
+            continue;
+        }
+        let mut id = [0u8; 32];
+        id.copy_from_slice(&buf[start..start + 32]);
+        if index.sizes.contains_key(&id) {
+            out.push(id);
+        }
+    }
+    out
+}
+
+/// 找出 `composer.content.<64 位十六进制>` 字面量。
+fn scan_content_refs(buf: &[u8], index: &Index) -> Vec<Id> {
+    let mut out = Vec::new();
+    if index.is_empty() {
+        return out;
+    }
+    let needle = CONTENT_PREFIX.as_bytes();
+    let span = needle.len() + 64;
+    if buf.len() < span {
+        return out;
+    }
+    for start in 0..=buf.len() - span {
+        if buf[start] != needle[0] || &buf[start..start + needle.len()] != needle {
+            continue;
+        }
+        let digits = &buf[start + needle.len()..start + span];
+        let Ok(text) = std::str::from_utf8(digits) else {
+            continue;
+        };
+        if let Some(id) = parse_id(text) {
+            if index.sizes.contains_key(&id) {
+                out.push(id);
+            }
+        }
+    }
+    out
+}
+
+fn parse_id(hex_text: &str) -> Option<Id> {
+    if hex_text.len() != 64 || !hex_text.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    hex::decode(hex_text).ok()?.try_into().ok()
+}
+
+fn decode_base64(text: &str) -> Option<Vec<u8>> {
+    let body = text.strip_prefix('~').unwrap_or(text);
+    STANDARD
+        .decode(body)
+        .or_else(|_| URL_SAFE.decode(body))
+        .ok()
+}
+
+fn as_bytes(value: rusqlite::types::Value) -> Option<Vec<u8>> {
+    match value {
+        rusqlite::types::Value::Text(text) => Some(text.into_bytes()),
+        rusqlite::types::Value::Blob(bytes) => Some(bytes),
+        _ => None,
+    }
+}
+
+/// 前缀区间的右端。`:` 的下一个字符是 `;`，`.` 的下一个是 `/`。
+fn range_end(prefix: &str) -> String {
+    let mut end = prefix.to_string();
+    let last = end.pop().unwrap_or(':');
+    end.push((last as u8 + 1) as char);
+    end
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use serde_json::json;
+
+    fn memory_db() -> AppResult<Connection> {
+        let connection = Connection::open_in_memory()?;
+        connection.execute_batch(
+            "CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);",
+        )?;
+        Ok(connection)
+    }
+
+    fn put_blob(connection: &Connection, body: &[u8]) -> AppResult<Id> {
+        use sha2::{Digest, Sha256};
+        let id: Id = Sha256::digest(body).into();
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES (?1, ?2)",
+            rusqlite::params![format!("{BLOB_PREFIX}{}", hex::encode(id)), body],
+        )?;
+        Ok(id)
+    }
+
+    fn put_content(connection: &Connection, body: &str) -> AppResult<Id> {
+        use sha2::{Digest, Sha256};
+        let id: Id = Sha256::digest(body.as_bytes()).into();
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES (?1, ?2)",
+            rusqlite::params![format!("{CONTENT_PREFIX}{}", hex::encode(id)), body],
+        )?;
+        Ok(id)
+    }
+
+    fn conversation_state(ids: &[Id]) -> String {
+        // 真实数据是 protobuf，这里只关心"原始 32 字节出现在里面"这一点。
+        let mut raw = Vec::new();
+        for id in ids {
+            raw.push(0x0a);
+            raw.push(0x20);
+            raw.extend_from_slice(id);
+        }
+        format!("~{}", STANDARD.encode(raw))
+    }
+
+    #[test]
+    fn blobs_reachable_through_the_reference_chain_survive() -> AppResult<()> {
+        let connection = memory_db()?;
+        let leaf = put_blob(&connection, b"leaf payload")?;
+        // 中间节点把叶子的 id 以原始字节嵌进去。
+        let mut middle_body = b"header".to_vec();
+        middle_body.push(0x12);
+        middle_body.push(0x20);
+        middle_body.extend_from_slice(&leaf);
+        let middle = put_blob(&connection, &middle_body)?;
+        let unreachable = put_blob(&connection, b"nobody points at me")?;
+
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES ('composerData:s1', ?1)",
+            [json!({ "conversationState": conversation_state(&[middle]) }).to_string()],
+        )?;
+
+        let sweep = sweep(&connection)?;
+        assert_eq!(sweep.errors, 0);
+        assert_eq!(sweep.blobs_total, 3);
+        assert_eq!(sweep.blobs_live, 2, "叶子必须跟着中间节点一起活下来");
+        assert_eq!(sweep.blob_orphan_rows, 1);
+        assert_eq!(
+            sweep.orphan_keys,
+            vec![format!("{BLOB_PREFIX}{}", hex::encode(unreachable))]
+        );
+
+        delete_orphans(&connection, &sweep)?;
+        let left: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key LIKE 'agentKv:blob:%'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(left, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn bubbles_keep_the_file_snapshots_they_mention() -> AppResult<()> {
+        let connection = memory_db()?;
+        let kept = put_content(&connection, "kept file body")?;
+        let dropped = put_content(&connection, "stale file body")?;
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES ('bubbleId:s1:b1', ?1)",
+            [json!({
+                "toolFormerData": {
+                    "result": format!(
+                        "{{\"beforeContentId\":\"{CONTENT_PREFIX}{}\"}}",
+                        hex::encode(kept)
+                    )
+                }
+            })
+            .to_string()],
+        )?;
+
+        let sweep = sweep(&connection)?;
+        assert_eq!(sweep.content_total, 2);
+        assert_eq!(sweep.content_live, 1);
+        assert_eq!(sweep.content_orphan_rows, 1);
+        assert_eq!(
+            sweep.orphan_keys,
+            vec![format!("{CONTENT_PREFIX}{}", hex::encode(dropped))]
+        );
+        Ok(())
+    }
+
+    /// 遗留的 `agentKv:checkpoint:` 指针也算根。
+    #[test]
+    fn legacy_checkpoint_pointers_are_roots() -> AppResult<()> {
+        let connection = memory_db()?;
+        let pinned = put_blob(&connection, b"pinned by a legacy pointer")?;
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES (?1, ?2)",
+            rusqlite::params![format!("{CHECKPOINT_PREFIX}s1"), STANDARD.encode(pinned)],
+        )?;
+        let sweep = sweep(&connection)?;
+        assert_eq!(sweep.errors, 0);
+        assert_eq!(sweep.blobs_live, 1);
+        assert_eq!(sweep.blob_orphan_rows, 0);
+        Ok(())
+    }
+
+    /// 解不开的 `conversationState` 意味着这一行的引用没算进来，必须整体放弃删除。
+    #[test]
+    fn an_undecodable_state_blocks_deletion() -> AppResult<()> {
+        let connection = memory_db()?;
+        put_blob(&connection, b"payload")?;
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES ('composerData:s1', ?1)",
+            [json!({ "conversationState": "~这不是 base64" }).to_string()],
+        )?;
+        let sweep = sweep(&connection)?;
+        assert_eq!(sweep.errors, 1);
+        assert_eq!(sweep.blob_orphan_rows, 1);
+        assert!(delete_orphans(&connection, &sweep).is_err());
+        let left: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key LIKE 'agentKv:blob:%'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(left, 1, "出错时一行都不许删");
+        Ok(())
+    }
+
+    #[test]
+    fn an_empty_store_is_not_an_error() -> AppResult<()> {
+        let connection = memory_db()?;
+        let sweep = sweep(&connection)?;
+        assert_eq!(sweep.blobs_total, 0);
+        assert_eq!(sweep.orphan_rows(), 0);
+        assert!(sweep.orphan_keys.is_empty());
+        Ok(())
+    }
+}

--- a/src-tauri/src/cursor_mutate.rs
+++ b/src-tauri/src/cursor_mutate.rs
@@ -11,6 +11,7 @@
 //! 会让两份数据以新的方式互相矛盾。
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -138,12 +139,9 @@ pub fn rename_session(dirs: &ProviderDirs, id: &str, title: &str) -> AppResult<u
             // 会话正文里也存了一份名字，两处不同步的话 Cursor 打开会话时会显示旧名。
             let key = format!("composerData:{id}");
             if let Some(raw) = read_kv(&transaction, &key)? {
-                let data = merge_header(
-                    serde_json::from_slice::<Value>(&raw).unwrap_or(Value::Null),
-                    |value| {
-                        value.insert("name".into(), Value::String(title.to_string()));
-                    },
-                );
+                let data = merge_header(parse_mutable_object(&raw, "会话正文")?, |value| {
+                    value.insert("name".into(), Value::String(title.to_string()));
+                });
                 transaction.execute(
                     "UPDATE cursorDiskKV SET value = ?1 WHERE key = ?2",
                     params![data.to_string(), key],
@@ -256,11 +254,40 @@ fn subagent_children(connection: &Connection, id: &str) -> AppResult<Vec<String>
 }
 
 /// 在删除范围之外，还有哪些会话引用着这批子代理。
+///
+/// 只要有一条 `composerData` 读不出来，"没有别人引用它"这个结论就不成立——那条记录
+/// 完全可能正引用着我们准备删的子会话。这种情况下把范围内的子会话全部当成共享保留，
+/// 只删根会话；留下来的子会话之后会在残留诊断里以"无主子会话"出现，由用户自己决定。
 fn shared_children(
     connection: &Connection,
     scope: &BTreeSet<String>,
 ) -> AppResult<BTreeSet<String>> {
-    let mut shared = BTreeSet::new();
+    let scan = scan_child_references(connection, Some(scope))?;
+    if !scan.complete {
+        return Ok(scope.clone());
+    }
+    Ok(scan.referenced)
+}
+
+/// 一次 `composerData` 全扫的结果。
+struct ChildReferences {
+    /// 被别的会话引用的子会话 id。
+    referenced: BTreeSet<String>,
+    /// 是否每条记录都成功解析。为 false 时不能反过来断言"某个 id 没有被引用"。
+    complete: bool,
+}
+
+/// 扫描所有 `composerData`，收集其中登记的子会话 id。
+///
+/// `skip` 里的会话不计入（级联删除时，删除范围内部的引用不算"共享"）。
+fn scan_child_references(
+    connection: &Connection,
+    skip: Option<&BTreeSet<String>>,
+) -> AppResult<ChildReferences> {
+    let mut out = ChildReferences {
+        referenced: BTreeSet::new(),
+        complete: true,
+    };
     let mut statement = connection.prepare(
         "SELECT key, value FROM cursorDiskKV
          WHERE key >= 'composerData:' AND key < 'composerData;'",
@@ -276,22 +303,27 @@ fn shared_children(
         let Some(owner) = key.strip_prefix("composerData:") else {
             continue;
         };
-        if scope.contains(owner) {
+        if skip.is_some_and(|skip| skip.contains(owner)) {
             continue;
         }
         let raw = match value {
             rusqlite::types::Value::Text(text) => text.into_bytes(),
             rusqlite::types::Value::Blob(bytes) => bytes,
-            _ => continue,
-        };
-        let data = serde_json::from_slice::<Value>(&raw).unwrap_or(Value::Null);
-        for child in child_ids(&data) {
-            if scope.contains(child) {
-                shared.insert(child.to_string());
+            // 既不是文本也不是二进制，内容无从判断。
+            _ => {
+                out.complete = false;
+                continue;
             }
+        };
+        let Ok(data) = serde_json::from_slice::<Value>(&raw) else {
+            out.complete = false;
+            continue;
+        };
+        for child in child_ids(&data) {
+            out.referenced.insert(child.to_string());
         }
     }
-    Ok(shared)
+    Ok(out)
 }
 
 /// 回收删除后空出的页。
@@ -338,16 +370,43 @@ fn locate(dirs: &ProviderDirs, id: &str) -> AppResult<Target> {
         }
     }
     // cursor-agent 的会话目录名就是 agentId。
+    //
+    // 这里**不能**把 id 拼进路径：`Path::join` 遇到绝对路径会直接把前面整段丢掉，
+    // 传进来一个绝对路径就能逃出 chats 目录，然后被 delete_session 的 remove_dir_all
+    // 删掉。改成逐个比对目录名，用户输入永远不会变成路径的一段。
+    if !is_plain_path_component(id) {
+        return Err(AppError::NotFound(format!("Cursor 会话不存在: {id}")));
+    }
     let chats = paths::cursor_agent_chats_dir(&dirs.cursor_agent_path());
     if chats.is_dir() {
-        for entry in fs::read_dir(&chats)? {
-            let candidate = entry?.path().join(id);
-            if candidate.is_dir() {
-                return Ok(Target::Agent { dir: candidate });
+        for project in fs::read_dir(&chats)? {
+            let project = project?.path();
+            if !project.is_dir() {
+                continue;
+            }
+            for session in fs::read_dir(&project)? {
+                let session = session?;
+                if session.file_name() == OsStr::new(id) && session.path().is_dir() {
+                    return Ok(Target::Agent {
+                        dir: session.path(),
+                    });
+                }
             }
         }
     }
     Err(AppError::NotFound(format!("Cursor 会话不存在: {id}")))
+}
+
+/// id 必须是单独一段普通目录名，不能带路径分隔符、盘符或 `.` / `..`。
+fn is_plain_path_component(id: &str) -> bool {
+    !id.is_empty()
+        && id != "."
+        && id != ".."
+        && !id.contains('/')
+        && !id.contains('\\')
+        && !id.contains('\0')
+        // Windows 上 "C:foo" 这类带盘符的相对路径同样会改变解析结果。
+        && !id.contains(':')
 }
 
 /// 拒绝在旧版 Cursor 上写入。
@@ -386,12 +445,31 @@ fn header_value(connection: &Connection, id: &str) -> AppResult<Value> {
         )
         .optional()?
         .flatten();
-    Ok(raw
-        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
-        .unwrap_or(Value::Null))
+    match raw {
+        Some(raw) => parse_mutable_object(raw.as_bytes(), "会话头"),
+        // 列本身是 NULL，没有内容会被覆盖掉。
+        None => Ok(Value::Null),
+    }
+}
+
+/// 解析一段准备"读出来改几个字段再写回去"的 JSON。
+///
+/// 这里绝对不能把解析失败降级成空对象：后面 [`merge_header`] 会把非对象当成新的空
+/// 对象，写回去就等于把原记录整行替换成只剩本次写入的字段。宁可拒绝这次修改，
+/// 也不能让一条读不懂的记录被悄悄清空。
+fn parse_mutable_object(raw: &[u8], what: &str) -> AppResult<Value> {
+    match serde_json::from_slice::<Value>(raw) {
+        Ok(value @ Value::Object(_)) => Ok(value),
+        _ => Err(AppError::Other(format!(
+            "{what}的内容不是合法 JSON 对象，继续写入会覆盖掉原有数据，已放弃本次修改"
+        ))),
+    }
 }
 
 /// 只改动指定字段，其余原样保留——会话头里还有几十个 Cursor 自己用的字段。
+///
+/// 传入非对象只在"原本就没有内容"时才是合法的，调用方必须先用
+/// [`parse_mutable_object`] 把损坏的记录拦下来。
 fn merge_header(header: Value, edit: impl FnOnce(&mut serde_json::Map<String, Value>)) -> Value {
     let mut object = match header {
         Value::Object(object) => object,
@@ -433,7 +511,7 @@ fn rename_agent_session(dir: &Path, title: &str) -> AppResult<()> {
     let text = String::from_utf8(bytes)
         .map_err(|error| AppError::Other(format!("Cursor CLI 会话头不是合法 UTF-8: {error}")))?;
     let header = merge_header(
-        serde_json::from_str::<Value>(&text).unwrap_or(Value::Null),
+        parse_mutable_object(text.as_bytes(), "Cursor CLI 会话头")?,
         |value| {
             value.insert("name".into(), Value::String(title.to_string()));
         },
@@ -506,7 +584,7 @@ pub fn diagnose_residue(dirs: &ProviderDirs) -> AppResult<CursorResidueReport> {
     let headers = read_headers(&connection)?;
     let counts = cursor_sessions::bubble_counts(&connection, headers.keys().map(String::as_str))?;
 
-    let referenced = referenced_subagents(&connection)?;
+    let references = scan_child_references(&connection, None)?;
     let mut empty = Vec::new();
     let mut missing_project = Vec::new();
     let mut orphan_subagents = Vec::new();
@@ -518,7 +596,8 @@ pub fn diagnose_residue(dirs: &ProviderDirs) -> AppResult<CursorResidueReport> {
         }
         if header.is_subagent {
             // 子代理不进列表，只随父会话管理；没有父引用的就再也访问不到了。
-            if !referenced.contains(id) {
+            // 扫描不完整时不能断言"没有父引用"，这一类整体不报，避免误删。
+            if references.complete && !references.referenced.contains(id) {
                 orphan_subagents.push(id.clone());
             }
             continue;
@@ -602,8 +681,12 @@ pub fn diagnose_residue(dirs: &ProviderDirs) -> AppResult<CursorResidueReport> {
         CursorResidueGroup {
             kind: RESIDUE_ORPHAN_SUBAGENTS.into(),
             label: "无主子会话".into(),
-            description: "子会话只跟着父会话管理，但这些的父会话已经不在了，界面上再也访问不到。"
-                .into(),
+            description: if references.complete {
+                "子会话只跟着父会话管理，但这些的父会话已经不在了，界面上再也访问不到。".into()
+            } else {
+                "有会话记录读不出来，无法确认这些子会话是否还被引用，这一类已锁定不可清理。"
+                    .to_string()
+            },
             sessions: orphan_subagents.len() as u32,
             rows: orphan_subagents.len() as u32,
             bytes: 0,
@@ -705,12 +788,18 @@ pub fn prune_residue(
         }
     }
     if kinds.iter().any(|kind| kind == RESIDUE_ORPHAN_SUBAGENTS) {
-        let referenced = referenced_subagents(&connection)?;
+        let references = scan_child_references(&connection, None)?;
+        // 有记录读不出来就没法证明这些子会话真的没人引用了，这一类整体不删。
+        if !references.complete {
+            return Err(AppError::Other(
+                "有会话记录读不出来，无法确认哪些子会话仍被引用，已放弃清理无主子会话".into(),
+            ));
+        }
         for (id, header) in &headers {
             if counts.get(id).copied().unwrap_or(0) == 0 || !header.is_subagent {
                 continue;
             }
-            if !referenced.contains(id) {
+            if !references.referenced.contains(id) {
                 sessions_to_drop.push(id.clone());
             }
         }
@@ -928,26 +1017,6 @@ fn read_headers(connection: &Connection) -> AppResult<BTreeMap<String, HeaderRow
 }
 
 /// 库里所有被某个父会话引用着的子代理 id。
-fn referenced_subagents(connection: &Connection) -> AppResult<BTreeSet<String>> {
-    let mut out = BTreeSet::new();
-    let mut statement = connection.prepare(
-        "SELECT value FROM cursorDiskKV
-         WHERE key >= 'composerData:' AND key < 'composerData;'",
-    )?;
-    let rows = statement.query_map([], |row| row.get::<_, rusqlite::types::Value>(0))?;
-    for row in rows {
-        let raw = match row? {
-            rusqlite::types::Value::Text(text) => text.into_bytes(),
-            rusqlite::types::Value::Blob(bytes) => bytes,
-            _ => continue,
-        };
-        let data = serde_json::from_slice::<Value>(&raw).unwrap_or(Value::Null);
-        for child in child_ids(&data) {
-            out.insert(child.to_string());
-        }
-    }
-    Ok(out)
-}
 
 fn header_cwd(header: &Value) -> String {
     header
@@ -1714,6 +1783,178 @@ mod tests {
         let _probe = CursorRunningProbe::not_running();
         let error = set_archived(&fixture.dirs, "s1", true).unwrap_err();
         assert!(error.to_string().contains("已拒绝写入"));
+        Ok(())
+    }
+
+    /// 会话 id 绝不能被当成路径的一段。
+    ///
+    /// `Path::join` 遇到绝对路径会把前面整段丢掉，早先的实现因此可以用一个绝对路径
+    /// 逃出 chats 目录，再被 `remove_dir_all` 整个删掉。
+    #[test]
+    fn an_agent_id_can_not_escape_the_chats_directory() -> AppResult<()> {
+        let fixture = fixture("agent-escape")?;
+        // chats 目录必须存在，否则查找会提前结束，测不到逃逸路径。
+        let chats = paths::cursor_agent_chats_dir(Path::new(
+            fixture.dirs.cursor_agent_dir.as_deref().unwrap(),
+        ));
+        fs::create_dir_all(chats.join("project"))?;
+
+        let outsider = fixture.root.join("outside");
+        fs::create_dir_all(outsider.join("payload"))?;
+
+        let _probe = CursorRunningProbe::not_running();
+        for id in [
+            outsider.to_string_lossy().into_owned(),
+            "../../outside".to_string(),
+            "..".to_string(),
+            "project/../../outside".to_string(),
+        ] {
+            let error = delete_session(&fixture.dirs, &id).unwrap_err();
+            assert!(
+                matches!(error, AppError::NotFound(_)),
+                "id={id} 应当直接判定为不存在，实际是 {error}"
+            );
+            assert!(outsider.is_dir(), "id={id} 把 chats 之外的目录删掉了");
+        }
+        Ok(())
+    }
+
+    /// 正文解析不了的时候宁可不改，也不能把整条记录覆盖成只剩一个 name。
+    #[test]
+    fn renaming_refuses_to_overwrite_a_record_it_can_not_parse() -> AppResult<()> {
+        let fixture = fixture("rename-corrupt")?;
+        let connection = connect(&fixture)?;
+        connection.execute(
+            "UPDATE cursorDiskKV SET value = ?1 WHERE key = 'composerData:s1'",
+            ["{ 这不是 JSON"],
+        )?;
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        let error = rename_session(&fixture.dirs, "s1", "新名字").unwrap_err();
+        assert!(error.to_string().contains("已放弃本次修改"));
+
+        let connection = connect(&fixture)?;
+        let body: String = connection.query_row(
+            "SELECT value FROM cursorDiskKV WHERE key = 'composerData:s1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(body, "{ 这不是 JSON", "损坏的正文被覆盖了");
+        // 会话头也要跟着回滚，不能只改了一半。
+        let header: String = connection.query_row(
+            "SELECT value FROM composerHeaders WHERE composerId = 's1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(header.contains("原名"));
+        Ok(())
+    }
+
+    /// 会话头损坏时同样不能改名——头里还存着项目路径、创建时间等一堆字段。
+    #[test]
+    fn renaming_refuses_when_the_header_json_is_broken() -> AppResult<()> {
+        let fixture = fixture("rename-broken-header")?;
+        let connection = connect(&fixture)?;
+        connection.execute(
+            "UPDATE composerHeaders SET value = '[]' WHERE composerId = 's1'",
+            [],
+        )?;
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        assert!(rename_session(&fixture.dirs, "s1", "新名字").is_err());
+        assert!(set_archived(&fixture.dirs, "s1", true).is_err());
+        Ok(())
+    }
+
+    /// 有父会话记录读不出来时，不能反过来断定某个子会话没人引用。
+    #[test]
+    fn an_unreadable_parent_keeps_shared_subagents_alive() -> AppResult<()> {
+        let fixture = fixture("shared-unreadable-parent")?;
+        let connection = connect(&fixture)?;
+        for id in ["parent", "other", "kid"] {
+            insert_header(&connection, id, 0, i64::from(id == "kid"), json!({}))?;
+            insert_kv(
+                &connection,
+                &format!("bubbleId:{id}:b1"),
+                json!({"type": 1}),
+            )?;
+        }
+        insert_kv(
+            &connection,
+            "composerData:parent",
+            json!({
+                "fullConversationHeadersOnly": [{"bubbleId": "b1"}],
+                "subagentComposerIds": ["kid"],
+            }),
+        )?;
+        insert_kv(
+            &connection,
+            "composerData:kid",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}]}),
+        )?;
+        // other 也引用着 kid，但它的记录坏了，解析不出这条引用。
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES ('composerData:other', ?1)",
+            ["{ 坏掉的记录，其实写着 subagentComposerIds: [kid]"],
+        )?;
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        delete_session(&fixture.dirs, "parent")?;
+
+        let connection = connect(&fixture)?;
+        let kid: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM composerHeaders WHERE composerId = 'kid'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(kid, 1, "读不出 other 的引用时把共享子会话删掉了");
+        let parent: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM composerHeaders WHERE composerId = 'parent'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(parent, 0, "根会话本身还是要删掉");
+        Ok(())
+    }
+
+    /// 同样的道理：扫描不完整时不能把子会话报成"无主"，更不能清理。
+    #[test]
+    fn an_unreadable_parent_locks_the_orphan_subagent_kind() -> AppResult<()> {
+        let fixture = fixture("orphan-subagent-unreadable")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "lonely", 0, 1, json!({}))?;
+        insert_kv(
+            &connection,
+            "composerData:lonely",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}]}),
+        )?;
+        insert_kv(&connection, "bubbleId:lonely:b1", json!({"type": 1}))?;
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES ('composerData:broken', ?1)",
+            ["{ 坏掉的记录"],
+        )?;
+        drop(connection);
+
+        let report = diagnose_residue(&fixture.dirs)?;
+        let group = report
+            .groups
+            .iter()
+            .find(|g| g.kind == RESIDUE_ORPHAN_SUBAGENTS)
+            .expect("无主子会话分组");
+        assert_eq!(group.sessions, 0, "扫描不完整时不该报无主子会话");
+        assert!(group.description.contains("锁定"));
+
+        let _probe = CursorRunningProbe::not_running();
+        let error = prune_residue(
+            &fixture.dirs,
+            &[RESIDUE_ORPHAN_SUBAGENTS.to_string()],
+            false,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("已放弃清理无主子会话"));
         Ok(())
     }
 

--- a/src-tauri/src/cursor_mutate.rs
+++ b/src-tauri/src/cursor_mutate.rs
@@ -1,0 +1,1963 @@
+//! Cursor 会话的写操作：归档、重命名、删除、压缩数据库。
+//!
+//! 所有写入都先确认 Cursor 已经完全退出。Cursor 会把会话状态缓存在内存里，运行期间
+//! 改库有很大概率被它按旧状态覆盖回去，这和 Codex 桌面端的处理是同一个道理。
+//!
+//! IDE Composer 会话全部改在 `state.vscdb` 的一个事务里，跨存储补偿（`mutation_journal`）
+//! 用不上；cursor-agent 会话各自独占一个目录，删除即删目录。
+//!
+//! **不碰 `ItemTable` 里的遗留键 `composer.composerHeaders`**：实测本机该数组只有 622 条
+//! 而表里有 837 条，且已有 7 条时间戳对不上——新版 Cursor 已经不再维护它，跟着写反而
+//! 会让两份数据以新的方式互相矛盾。
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::cursor_blobs;
+use crate::cursor_sessions;
+use crate::error::{AppError, AppResult};
+use crate::models::{
+    CursorPruneReport, CursorResidueGroup, CursorResidueReport, CursorResidueSample, DeleteResult,
+    ProviderDirs,
+};
+use crate::paths;
+
+const CURSOR_RUNNING_ERROR: &str =
+    "Cursor 正在运行；为避免它用内存中的旧会话状态覆盖本次修改，请完全退出 Cursor（包括后台进程）后重试";
+
+/// 会话头改用独立表之后，Cursor 用这个开关决定读表还是读 `ItemTable` 里的遗留数组。
+const HEADER_TABLE_GATE_KEY: &str = "composer.composerHeaders.tableGateEnabled";
+
+const TITLE_MAX_CHARS: usize = 120;
+
+/// `cursorDiskKV` 里按会话 id 归属的全部键空间。
+///
+/// 前六项抄自 Cursor 自己的 `deleteComposer`（`clearComposerCheckpoints` /
+/// `clearComposerDiffs` / `clearComposerMessages` / `clearComposerPartialInlineDiffFates`
+/// / `composerDataHandleManager.deleteComposer`，最后一个同时清 `composerData` 与
+/// `ofsContent`）。后两项是 Cursor 自己漏掉的：`messageRequestContext` 在当前版本的代码里
+/// 已经完全不存在，只剩历史数据；`composerVirtualRowHeights` 只有"整体清空"没有按会话清。
+///
+/// 键形状有两种，`composerData:<id>` / `composerVirtualRowHeights:<id>` 是精确键，
+/// 其余是 `<空间>:<id>:<子 id>`。两种都按 `= ns:id` 或 `ns:id:` 前缀段匹配，
+/// 冒号边界保证不会串到别的会话（`bubbleId:task-x:` 不会命中 `bubbleId:x:`）。
+const SESSION_NAMESPACES: [&str; 8] = [
+    "bubbleId",
+    "composerData",
+    "checkpointId",
+    "codeBlockDiff",
+    "codeBlockPartialInlineDiffFates",
+    "ofsContent",
+    "messageRequestContext",
+    "composerVirtualRowHeights",
+];
+
+/// 落在会话键空间里、但其实是全局键的例外。
+///
+/// `composerVirtualRowHeights:_recentIds` 存的是最近会话 id 列表，不属于任何会话；
+/// 不排除掉会被当成"没有会话头的孤儿"删掉。
+const NON_SESSION_KEYS: [&str; 1] = ["composerVirtualRowHeights:_recentIds"];
+
+/// 一个会话落在哪套存储里。
+enum Target {
+    Composer { db: PathBuf },
+    Agent { dir: PathBuf },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CursorCompactReport {
+    pub bytes_before: u64,
+    pub bytes_after: u64,
+    pub bytes_reclaimed: u64,
+}
+
+// ---------------------------------------------------------------------------
+// 对外操作
+// ---------------------------------------------------------------------------
+
+pub fn set_archived(dirs: &ProviderDirs, id: &str, archived: bool) -> AppResult<()> {
+    ensure_cursor_not_running()?;
+    match locate(dirs, id)? {
+        Target::Composer { db } => {
+            let mut connection = open_writable(&db)?;
+            ensure_header_table_is_authoritative(&connection)?;
+            let transaction = connection.transaction()?;
+            let header = header_value(&transaction, id)?;
+            let updated = merge_header(header, |value| {
+                value.insert("isArchived".into(), Value::Bool(archived));
+            });
+            let changed = transaction.execute(
+                "UPDATE composerHeaders SET isArchived = ?1, value = ?2 WHERE composerId = ?3",
+                params![i64::from(archived), updated.to_string(), id],
+            )?;
+            if changed == 0 {
+                return Err(AppError::NotFound(format!("Cursor 会话不存在: {id}")));
+            }
+            transaction.commit()?;
+            Ok(())
+        }
+        // cursor-agent 没有归档这个概念，与其伪造一个本地标记，不如直说。
+        Target::Agent { .. } => Err(AppError::Other(
+            "cursor-agent 会话不支持归档（Cursor 本身没有这个状态）".into(),
+        )),
+    }
+}
+
+pub fn rename_session(dirs: &ProviderDirs, id: &str, title: &str) -> AppResult<u32> {
+    let title = title.trim();
+    if title.is_empty() {
+        return Err(AppError::Other("会话名称不能为空".into()));
+    }
+    if title.chars().count() > TITLE_MAX_CHARS {
+        return Err(AppError::Other(format!(
+            "会话名称过长（最多 {TITLE_MAX_CHARS} 个字符）"
+        )));
+    }
+    ensure_cursor_not_running()?;
+    match locate(dirs, id)? {
+        Target::Composer { db } => {
+            let mut connection = open_writable(&db)?;
+            ensure_header_table_is_authoritative(&connection)?;
+            let transaction = connection.transaction()?;
+            let header = header_value(&transaction, id)?;
+            let updated = merge_header(header, |value| {
+                value.insert("name".into(), Value::String(title.to_string()));
+            });
+            let changed = transaction.execute(
+                "UPDATE composerHeaders SET value = ?1 WHERE composerId = ?2",
+                params![updated.to_string(), id],
+            )?;
+            if changed == 0 {
+                return Err(AppError::NotFound(format!("Cursor 会话不存在: {id}")));
+            }
+            // 会话正文里也存了一份名字，两处不同步的话 Cursor 打开会话时会显示旧名。
+            let key = format!("composerData:{id}");
+            if let Some(raw) = read_kv(&transaction, &key)? {
+                let data = merge_header(
+                    serde_json::from_slice::<Value>(&raw).unwrap_or(Value::Null),
+                    |value| {
+                        value.insert("name".into(), Value::String(title.to_string()));
+                    },
+                );
+                transaction.execute(
+                    "UPDATE cursorDiskKV SET value = ?1 WHERE key = ?2",
+                    params![data.to_string(), key],
+                )?;
+            }
+            transaction.commit()?;
+            Ok(changed as u32)
+        }
+        Target::Agent { dir } => {
+            rename_agent_session(&dir, title)?;
+            Ok(1)
+        }
+    }
+}
+
+pub fn delete_session(dirs: &ProviderDirs, id: &str) -> AppResult<DeleteResult> {
+    ensure_cursor_not_running()?;
+    match locate(dirs, id)? {
+        Target::Composer { db } => delete_composer_session(&db, id),
+        Target::Agent { dir } => {
+            fs::remove_dir_all(&dir)?;
+            Ok(delete_result(
+                id,
+                Some(dir.to_string_lossy().into_owned()),
+                0,
+                true,
+            ))
+        }
+    }
+}
+
+fn delete_composer_session(db: &Path, id: &str) -> AppResult<DeleteResult> {
+    let mut connection = open_writable(db)?;
+    ensure_header_table_is_authoritative(&connection)?;
+    let targets = cascade_targets(&connection, id)?;
+    let transaction = connection.transaction()?;
+
+    let mut removed = 0u32;
+    for target in &targets {
+        removed = removed.saturating_add(delete_session_rows(&transaction, target)?);
+    }
+    let mut header_rows = 0usize;
+    for target in &targets {
+        header_rows += transaction.execute(
+            "DELETE FROM composerHeaders WHERE composerId = ?1",
+            [target],
+        )?;
+    }
+    transaction.commit()?;
+
+    if header_rows == 0 && removed == 0 {
+        return Err(AppError::NotFound(format!("Cursor 会话不存在: {id}")));
+    }
+    Ok(delete_result(
+        id,
+        Some(db.to_string_lossy().into_owned()),
+        removed as i64,
+        header_rows > 0,
+    ))
+}
+
+/// 一个会话被删除时要一并带走的全部会话 id（含它自己）。
+///
+/// Cursor 把子代理记在父会话 `composerData.subagentComposerIds` 上。子代理不在列表里
+/// 单独出现，只能随父会话一起删，否则父会话会留下指向已消失会话的引用。
+///
+/// 两个实测存在的边界都要处理：子代理自己还能再开子代理（需要递归），
+/// 以及同一个子代理被两个父会话共享（这种不能删，否则另一个父会话就悬空了）。
+pub(crate) fn cascade_targets(connection: &Connection, root: &str) -> AppResult<Vec<String>> {
+    let mut targets = vec![root.to_string()];
+    let mut seen = BTreeSet::from([root.to_string()]);
+    let mut queue = vec![root.to_string()];
+    while let Some(current) = queue.pop() {
+        for child in subagent_children(connection, &current)? {
+            if !seen.insert(child.clone()) {
+                continue;
+            }
+            targets.push(child.clone());
+            queue.push(child);
+        }
+    }
+    // 还被删除范围之外的父会话引用的子代理必须留下。
+    let shared = shared_children(connection, &seen)?;
+    targets.retain(|id| id == root || !shared.contains(id));
+    Ok(targets)
+}
+
+/// 父会话记子会话的两个字段。
+///
+/// `subagentComposerIds` 是子代理，`subComposerIds` 是 best-of-N 的分支会话。
+/// Cursor 自己的 `deleteComposer` 递归的是后者，前者它压根没处理——两个都要跟。
+const CHILD_ID_FIELDS: [&str; 2] = ["subagentComposerIds", "subComposerIds"];
+
+fn child_ids(data: &Value) -> impl Iterator<Item = &str> {
+    CHILD_ID_FIELDS.into_iter().flat_map(move |field| {
+        data.get(field)
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str)
+    })
+}
+
+fn subagent_children(connection: &Connection, id: &str) -> AppResult<Vec<String>> {
+    let Some(raw) = read_kv(connection, &format!("composerData:{id}"))? else {
+        return Ok(Vec::new());
+    };
+    let data = serde_json::from_slice::<Value>(&raw).unwrap_or(Value::Null);
+    Ok(child_ids(&data).map(str::to_string).collect())
+}
+
+/// 在删除范围之外，还有哪些会话引用着这批子代理。
+fn shared_children(
+    connection: &Connection,
+    scope: &BTreeSet<String>,
+) -> AppResult<BTreeSet<String>> {
+    let mut shared = BTreeSet::new();
+    let mut statement = connection.prepare(
+        "SELECT key, value FROM cursorDiskKV
+         WHERE key >= 'composerData:' AND key < 'composerData;'",
+    )?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, rusqlite::types::Value>(1)?,
+        ))
+    })?;
+    for row in rows {
+        let (key, value) = row?;
+        let Some(owner) = key.strip_prefix("composerData:") else {
+            continue;
+        };
+        if scope.contains(owner) {
+            continue;
+        }
+        let raw = match value {
+            rusqlite::types::Value::Text(text) => text.into_bytes(),
+            rusqlite::types::Value::Blob(bytes) => bytes,
+            _ => continue,
+        };
+        let data = serde_json::from_slice::<Value>(&raw).unwrap_or(Value::Null);
+        for child in child_ids(&data) {
+            if scope.contains(child) {
+                shared.insert(child.to_string());
+            }
+        }
+    }
+    Ok(shared)
+}
+
+/// 回收删除后空出的页。
+///
+/// 单独做成一个动作而不是删除时顺带执行：`state.vscdb` 实测有 8 GB，VACUUM 需要等量
+/// 临时空间，耗时以分钟计，绝不能挂在每次删除后面。
+pub fn compact_database(dirs: &ProviderDirs) -> AppResult<CursorCompactReport> {
+    ensure_cursor_not_running()?;
+    let db = cursor_sessions::state_db_path(&dirs.cursor_path());
+    let bytes_before = fs::metadata(&db)?.len();
+    let connection = open_writable(&db)?;
+    connection.execute_batch("VACUUM")?;
+    drop(connection);
+    let bytes_after = fs::metadata(&db)?.len();
+    Ok(CursorCompactReport {
+        bytes_before,
+        bytes_after,
+        bytes_reclaimed: bytes_before.saturating_sub(bytes_after),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// 定位与读写辅助
+// ---------------------------------------------------------------------------
+
+fn locate(dirs: &ProviderDirs, id: &str) -> AppResult<Target> {
+    if id.trim().is_empty() {
+        return Err(AppError::Other("会话 id 不能为空".into()));
+    }
+    let db = cursor_sessions::state_db_path(&dirs.cursor_path());
+    if db.is_file() {
+        let connection = cursor_sessions::open_readonly(&db)?;
+        if cursor_sessions::table_exists(&connection, "composerHeaders")? {
+            let found = connection
+                .query_row(
+                    "SELECT 1 FROM composerHeaders WHERE composerId = ?1",
+                    [id],
+                    |row| row.get::<_, i64>(0),
+                )
+                .optional()?;
+            if found.is_some() {
+                return Ok(Target::Composer { db });
+            }
+        }
+    }
+    // cursor-agent 的会话目录名就是 agentId。
+    let chats = paths::cursor_agent_chats_dir(&dirs.cursor_agent_path());
+    if chats.is_dir() {
+        for entry in fs::read_dir(&chats)? {
+            let candidate = entry?.path().join(id);
+            if candidate.is_dir() {
+                return Ok(Target::Agent { dir: candidate });
+            }
+        }
+    }
+    Err(AppError::NotFound(format!("Cursor 会话不存在: {id}")))
+}
+
+/// 拒绝在旧版 Cursor 上写入。
+///
+/// 开关为 false 时 Cursor 读的是 `ItemTable` 里的遗留数组，改表不会有任何效果，
+/// 与其静默无效不如直接报错。
+fn ensure_header_table_is_authoritative(connection: &Connection) -> AppResult<()> {
+    if !cursor_sessions::table_exists(connection, "composerHeaders")? {
+        return Err(AppError::Other(
+            "这个 Cursor 版本还没有 composerHeaders 表，暂不支持修改会话".into(),
+        ));
+    }
+    let gate = connection
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = ?1",
+            [HEADER_TABLE_GATE_KEY],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    match gate.as_deref().map(str::trim) {
+        // 键不存在的版本本来就只有表这一份数据。
+        None => Ok(()),
+        Some("true") => Ok(()),
+        Some(other) => Err(AppError::Other(format!(
+            "这个 Cursor 版本以 ItemTable 中的遗留会话头为准（{HEADER_TABLE_GATE_KEY}={other}），改表不会生效，已拒绝写入"
+        ))),
+    }
+}
+
+fn header_value(connection: &Connection, id: &str) -> AppResult<Value> {
+    let raw = connection
+        .query_row(
+            "SELECT value FROM composerHeaders WHERE composerId = ?1",
+            [id],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .optional()?
+        .flatten();
+    Ok(raw
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .unwrap_or(Value::Null))
+}
+
+/// 只改动指定字段，其余原样保留——会话头里还有几十个 Cursor 自己用的字段。
+fn merge_header(header: Value, edit: impl FnOnce(&mut serde_json::Map<String, Value>)) -> Value {
+    let mut object = match header {
+        Value::Object(object) => object,
+        _ => serde_json::Map::new(),
+    };
+    edit(&mut object);
+    Value::Object(object)
+}
+
+fn read_kv(connection: &Connection, key: &str) -> AppResult<Option<Vec<u8>>> {
+    use rusqlite::types::Value as SqlValue;
+    let value = connection
+        .query_row(
+            "SELECT value FROM cursorDiskKV WHERE key = ?1",
+            [key],
+            |row| row.get::<_, SqlValue>(0),
+        )
+        .optional()?;
+    Ok(match value {
+        Some(SqlValue::Text(text)) => Some(text.into_bytes()),
+        Some(SqlValue::Blob(bytes)) => Some(bytes),
+        _ => None,
+    })
+}
+
+fn rename_agent_session(dir: &Path, title: &str) -> AppResult<()> {
+    let store = crate::cursor_agent_store::store_path(dir);
+    let connection = open_writable(&store)?;
+    let row = connection
+        .query_row("SELECT key, value FROM meta ORDER BY key ASC", [], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .optional()?;
+    let Some((key, encoded)) = row else {
+        return Err(AppError::NotFound("Cursor CLI 会话缺少会话头".into()));
+    };
+    let bytes = hex::decode(encoded.trim())
+        .map_err(|error| AppError::Other(format!("Cursor CLI 会话头无法解码: {error}")))?;
+    let text = String::from_utf8(bytes)
+        .map_err(|error| AppError::Other(format!("Cursor CLI 会话头不是合法 UTF-8: {error}")))?;
+    let header = merge_header(
+        serde_json::from_str::<Value>(&text).unwrap_or(Value::Null),
+        |value| {
+            value.insert("name".into(), Value::String(title.to_string()));
+        },
+    );
+    connection.execute(
+        "UPDATE meta SET value = ?1 WHERE key = ?2",
+        params![hex::encode(header.to_string()), key],
+    )?;
+    Ok(())
+}
+
+fn delete_result(id: &str, path: Option<String>, rows: i64, removed: bool) -> DeleteResult {
+    DeleteResult {
+        id: id.into(),
+        rollout_path: path,
+        threads_rows_deleted: rows as u32,
+        logs_rows_deleted: 0,
+        history_rows_deleted: 0,
+        rollout_deleted: removed,
+        rollout_missing: !removed,
+        sidecar_deleted: false,
+        tasks_deleted: false,
+        file_history_deleted: false,
+        shared_data_preserved: false,
+        desktop_restart_required: false,
+        ok: true,
+        error: None,
+    }
+}
+
+fn open_writable(path: &Path) -> AppResult<Connection> {
+    if !path.is_file() {
+        return Err(AppError::NotFound(format!(
+            "Cursor 数据库不存在: {}",
+            path.to_string_lossy()
+        )));
+    }
+    Connection::open(path).map_err(Into::into)
+}
+
+// ---------------------------------------------------------------------------
+// 残留清理
+// ---------------------------------------------------------------------------
+
+/// 只有会话头没有内容的会话。列表里已经把它们藏起来了，但行还留在库里。
+pub const RESIDUE_EMPTY_SESSIONS: &str = "empty_sessions";
+/// 会话头已经不在，但 [`SESSION_NAMESPACES`] 里还留着行的孤儿数据。
+pub const RESIDUE_ORPHAN_RECORDS: &str = "orphan_records";
+/// 有真实对话、但项目目录已经不存在的会话。
+pub const RESIDUE_MISSING_PROJECT: &str = "missing_project";
+/// 没有任何父会话引用的子代理。子代理只随父会话管理，父没了它就永远不会再出现。
+pub const RESIDUE_ORPHAN_SUBAGENTS: &str = "orphan_subagents";
+/// `agentKv:blob:` / `composer.content.` 里没有任何会话引用得到的内容块。
+pub const RESIDUE_ORPHAN_BLOBS: &str = "orphan_blobs";
+
+/// 扫描 Cursor 数据库里可清理的残留。
+///
+/// 孤儿气泡那一类必须整段扫 `bubbleId:` 前缀（实测 9 秒 / 31 万行），所以这是一个
+/// 显式触发的诊断动作，不会挂在列表刷新上。
+pub fn diagnose_residue(dirs: &ProviderDirs) -> AppResult<CursorResidueReport> {
+    let cursor_dir = dirs.cursor_path();
+    let db = cursor_sessions::state_db_path(&cursor_dir);
+    let connection = cursor_sessions::open_readonly(&db)?;
+    if !cursor_sessions::table_exists(&connection, "composerHeaders")? {
+        return Err(AppError::Other(
+            "这个 Cursor 版本还没有 composerHeaders 表，无法诊断".into(),
+        ));
+    }
+
+    let headers = read_headers(&connection)?;
+    let counts = cursor_sessions::bubble_counts(&connection, headers.keys().map(String::as_str))?;
+
+    let referenced = referenced_subagents(&connection)?;
+    let mut empty = Vec::new();
+    let mut missing_project = Vec::new();
+    let mut orphan_subagents = Vec::new();
+    let mut visible = 0u32;
+    for (id, header) in &headers {
+        if counts.get(id).copied().unwrap_or(0) == 0 {
+            empty.push(id.clone());
+            continue;
+        }
+        if header.is_subagent {
+            // 子代理不进列表，只随父会话管理；没有父引用的就再也访问不到了。
+            if !referenced.contains(id) {
+                orphan_subagents.push(id.clone());
+            }
+            continue;
+        }
+        visible += 1;
+        let cwd = header_cwd(&header.value);
+        // 空路径说明这个会话本来就没绑定项目，不算"目录消失"。
+        if !cwd.is_empty() && !Path::new(&cwd).is_dir() {
+            missing_project.push(id.clone());
+        }
+    }
+
+    let orphans = scan_orphan_records(&connection, &headers)?;
+    let blobs = cursor_blobs::sweep(&connection)?;
+
+    let sample = |ids: &[String], with_bubbles: bool| -> Vec<CursorResidueSample> {
+        ids.iter()
+            .take(RESIDUE_SAMPLE_LIMIT)
+            .map(|id| CursorResidueSample {
+                id: id.clone(),
+                title: headers
+                    .get(id)
+                    .map(|header| header_title(&header.value, id))
+                    .unwrap_or_else(|| id.clone()),
+                cwd: headers
+                    .get(id)
+                    .map(|header| header_cwd(&header.value))
+                    .unwrap_or_default(),
+                bubbles: if with_bubbles {
+                    counts.get(id).copied().unwrap_or(0).max(0) as u32
+                } else {
+                    0
+                },
+            })
+            .collect()
+    };
+
+    let groups = vec![
+        CursorResidueGroup {
+            kind: RESIDUE_EMPTY_SESSIONS.into(),
+            label: "空会话".into(),
+            description: "只留下会话头、一条消息都没有。列表里已经不显示，删掉不会丢内容。".into(),
+            sessions: empty.len() as u32,
+            rows: empty.len() as u32,
+            bytes: 0,
+            destructive: false,
+            samples: sample(&empty, false),
+        },
+        CursorResidueGroup {
+            kind: RESIDUE_ORPHAN_RECORDS.into(),
+            label: "孤儿记录".into(),
+            description:
+                "会话头已经不在，但检查点、气泡、代码差异等数据还留在库里。Cursor 自己删会话时就漏清这些，是数据库变大的主因。"
+                    .into(),
+            sessions: orphans.sessions.len() as u32,
+            rows: orphans.rows,
+            bytes: orphans.bytes,
+            destructive: false,
+            samples: orphans
+                .sessions
+                .iter()
+                .take(RESIDUE_SAMPLE_LIMIT)
+                .map(|id| CursorResidueSample {
+                    id: id.clone(),
+                    title: "（会话头已丢失）".into(),
+                    cwd: String::new(),
+                    bubbles: 0,
+                })
+                .collect(),
+        },
+        CursorResidueGroup {
+            kind: RESIDUE_ORPHAN_BLOBS.into(),
+            label: "无引用的内容块".into(),
+            description: blob_group_description(&blobs),
+            sessions: 0,
+            rows: blobs.orphan_rows(),
+            bytes: blobs.orphan_bytes(),
+            destructive: false,
+            samples: Vec::new(),
+        },
+        CursorResidueGroup {
+            kind: RESIDUE_ORPHAN_SUBAGENTS.into(),
+            label: "无主子会话".into(),
+            description: "子会话只跟着父会话管理，但这些的父会话已经不在了，界面上再也访问不到。"
+                .into(),
+            sessions: orphan_subagents.len() as u32,
+            rows: orphan_subagents.len() as u32,
+            bytes: 0,
+            destructive: true,
+            samples: sample(&orphan_subagents, true),
+        },
+        CursorResidueGroup {
+            kind: RESIDUE_MISSING_PROJECT.into(),
+            label: "项目目录已不存在".into(),
+            description: "会话本身有完整对话，只是当初的项目目录被删或改名了。删除会丢失这些对话。"
+                .into(),
+            sessions: missing_project.len() as u32,
+            rows: missing_project.len() as u32,
+            bytes: 0,
+            destructive: true,
+            samples: sample(&missing_project, true),
+        },
+    ];
+
+    Ok(CursorResidueReport {
+        database_path: db.to_string_lossy().into_owned(),
+        database_bytes: fs::metadata(&db).map(|meta| meta.len()).unwrap_or(0),
+        header_rows: headers.len() as u32,
+        visible_sessions: visible,
+        groups,
+    })
+}
+
+/// 每类残留展示的样例条数。
+const RESIDUE_SAMPLE_LIMIT: usize = 8;
+
+fn blob_group_description(sweep: &cursor_blobs::ContentSweep) -> String {
+    if sweep.errors > 0 {
+        return format!(
+            "有 {} 行读不出来，无法确认剩下的内容块是否还被引用，这一类已锁定不可清理。",
+            sweep.errors
+        );
+    }
+    format!(
+        "会话正文引用的文件快照与代理消息，按内容哈希存放。当前 {} 个块里有 {} 个已经没有任何会话引用得到（Cursor 删会话时不回收它们）。",
+        sweep.blobs_total + sweep.content_total,
+        sweep.orphan_rows()
+    )
+}
+
+/// 按选定的类别清理残留。
+///
+/// `kinds` 必须由调用方显式给出：删除有内容的会话是不可逆的，绝不默认包含。
+pub fn prune_residue(
+    dirs: &ProviderDirs,
+    kinds: &[String],
+    dry_run: bool,
+) -> AppResult<CursorPruneReport> {
+    let known = [
+        RESIDUE_EMPTY_SESSIONS,
+        RESIDUE_ORPHAN_RECORDS,
+        RESIDUE_ORPHAN_SUBAGENTS,
+        RESIDUE_MISSING_PROJECT,
+        RESIDUE_ORPHAN_BLOBS,
+    ];
+    for kind in kinds {
+        if !known.contains(&kind.as_str()) {
+            return Err(AppError::Other(format!("未知的清理类别: {kind}")));
+        }
+    }
+    if kinds.is_empty() {
+        return Err(AppError::Other("请至少选择一类要清理的残留".into()));
+    }
+    if !dry_run {
+        ensure_cursor_not_running()?;
+    }
+
+    let cursor_dir = dirs.cursor_path();
+    let db = cursor_sessions::state_db_path(&cursor_dir);
+    let mut connection = open_writable(&db)?;
+    ensure_header_table_is_authoritative(&connection)?;
+
+    let headers = read_headers(&connection)?;
+    let counts = cursor_sessions::bubble_counts(&connection, headers.keys().map(String::as_str))?;
+
+    let mut sessions_to_drop: Vec<String> = Vec::new();
+    if kinds.iter().any(|kind| kind == RESIDUE_EMPTY_SESSIONS) {
+        sessions_to_drop.extend(
+            headers
+                .keys()
+                .filter(|id| counts.get(*id).copied().unwrap_or(0) == 0)
+                .cloned(),
+        );
+    }
+    if kinds.iter().any(|kind| kind == RESIDUE_MISSING_PROJECT) {
+        for (id, header) in &headers {
+            if counts.get(id).copied().unwrap_or(0) == 0 || header.is_subagent {
+                continue;
+            }
+            let cwd = header_cwd(&header.value);
+            if !cwd.is_empty() && !Path::new(&cwd).is_dir() {
+                sessions_to_drop.push(id.clone());
+            }
+        }
+    }
+    if kinds.iter().any(|kind| kind == RESIDUE_ORPHAN_SUBAGENTS) {
+        let referenced = referenced_subagents(&connection)?;
+        for (id, header) in &headers {
+            if counts.get(id).copied().unwrap_or(0) == 0 || !header.is_subagent {
+                continue;
+            }
+            if !referenced.contains(id) {
+                sessions_to_drop.push(id.clone());
+            }
+        }
+    }
+    // 删除主会话时要连它的子会话一起带走，否则父没了、子会话再也访问不到。
+    let mut expanded = Vec::new();
+    for id in &sessions_to_drop {
+        expanded.extend(cascade_targets(&connection, id)?);
+    }
+    sessions_to_drop = expanded;
+    sessions_to_drop.sort();
+    sessions_to_drop.dedup();
+
+    let orphans = if kinds.iter().any(|kind| kind == RESIDUE_ORPHAN_RECORDS) {
+        scan_orphan_records(&connection, &headers)?
+    } else {
+        OrphanScan::default()
+    };
+
+    let mut report = CursorPruneReport {
+        database_path: db.to_string_lossy().into_owned(),
+        dry_run,
+        removed_header_rows: sessions_to_drop.len() as u32,
+        removed_kv_rows: orphans.rows,
+        freed_bytes: orphans.bytes,
+        kinds: kinds.to_vec(),
+        blob_scan_errors: 0,
+    };
+    let sweep_blobs = kinds.iter().any(|kind| kind == RESIDUE_ORPHAN_BLOBS);
+    if dry_run {
+        // 试运行也要把待删会话自身的体积算出来，否则报的数会偏小。
+        for id in &sessions_to_drop {
+            let (rows, bytes) = session_footprint(&connection, id);
+            report.freed_bytes = report.freed_bytes.saturating_add(bytes);
+            report.removed_kv_rows = report.removed_kv_rows.saturating_add(rows);
+        }
+        if sweep_blobs {
+            // 按当前状态估算。真正执行时会话行会先被删掉，实际回收只多不少。
+            let sweep = cursor_blobs::sweep(&connection)?;
+            report.blob_scan_errors = sweep.errors;
+            if sweep.errors == 0 {
+                report.removed_kv_rows = report.removed_kv_rows.saturating_add(sweep.orphan_rows());
+                report.freed_bytes = report.freed_bytes.saturating_add(sweep.orphan_bytes());
+            }
+        }
+        return Ok(report);
+    }
+
+    let transaction = connection.transaction()?;
+    let mut removed_kv = orphans.rows;
+    let mut freed = orphans.bytes;
+    for id in &orphans.sessions {
+        delete_session_rows(&transaction, id)?;
+    }
+    for id in &sessions_to_drop {
+        freed = freed.saturating_add(session_bytes(&transaction, id));
+        removed_kv = removed_kv.saturating_add(delete_session_rows(&transaction, id)?);
+        transaction.execute("DELETE FROM composerHeaders WHERE composerId = ?1", [id])?;
+    }
+    if sweep_blobs {
+        // 必须放在会话行删完之后：那些行还在的时候，它们引用的内容块仍然算可达。
+        let sweep = cursor_blobs::sweep(&transaction)?;
+        report.blob_scan_errors = sweep.errors;
+        // 有行读不出来就整体跳过内容块，但别把已经算准的会话级清理一起回滚掉。
+        if sweep.errors == 0 {
+            freed = freed.saturating_add(sweep.orphan_bytes());
+            removed_kv =
+                removed_kv.saturating_add(cursor_blobs::delete_orphans(&transaction, &sweep)?);
+        }
+    }
+    transaction.commit()?;
+
+    report.removed_kv_rows = removed_kv;
+    report.freed_bytes = freed;
+    Ok(report)
+}
+
+#[derive(Default)]
+struct OrphanScan {
+    sessions: Vec<String>,
+    rows: u32,
+    bytes: u64,
+}
+
+/// 找出全部键空间里会话头已经不存在的行。
+fn scan_orphan_records(
+    connection: &Connection,
+    headers: &BTreeMap<String, HeaderRow>,
+) -> AppResult<OrphanScan> {
+    let mut out = OrphanScan::default();
+    let mut seen = BTreeSet::new();
+    for namespace in SESSION_NAMESPACES {
+        let mut statement = connection.prepare(
+            "SELECT key, octet_length(value) FROM cursorDiskKV
+             WHERE key >= ?1 AND key < ?2",
+        )?;
+        let rows = statement
+            .query_map([format!("{namespace}:"), format!("{namespace};")], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?))
+            })?;
+        for row in rows {
+            let (key, bytes) = row?;
+            let Some(id) = key_session_id(&key) else {
+                continue;
+            };
+            if headers.contains_key(id) {
+                continue;
+            }
+            out.rows = out.rows.saturating_add(1);
+            out.bytes = out.bytes.saturating_add(bytes.unwrap_or(0).max(0) as u64);
+            if seen.insert(id.to_string()) {
+                out.sessions.push(id.to_string());
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// 从会话级的键里取出会话 id，例如 `composerData:<id>`、`checkpointId:<id>:<检查点>`。
+fn key_session_id(key: &str) -> Option<&str> {
+    if NON_SESSION_KEYS.contains(&key) {
+        return None;
+    }
+    for namespace in SESSION_NAMESPACES {
+        let Some(rest) = key
+            .strip_prefix(namespace)
+            .and_then(|rest| rest.strip_prefix(':'))
+        else {
+            continue;
+        };
+        let id = rest.split(':').next().unwrap_or(rest);
+        return (!id.is_empty()).then_some(id);
+    }
+    None
+}
+
+/// 一个会话在 `cursorDiskKV` 里占的行数与字节数。
+fn session_footprint(connection: &Connection, id: &str) -> (u32, u64) {
+    let mut rows = 0u32;
+    let mut bytes = 0u64;
+    for namespace in SESSION_NAMESPACES {
+        let measured = connection
+            .query_row(
+                "SELECT COUNT(*), COALESCE(SUM(octet_length(value)), 0) FROM cursorDiskKV
+                 WHERE key = ?1 OR (key >= ?2 AND key < ?3)",
+                [
+                    format!("{namespace}:{id}"),
+                    format!("{namespace}:{id}:"),
+                    format!("{namespace}:{id};"),
+                ],
+                |row| Ok((row.get::<_, i64>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .unwrap_or((0, 0));
+        rows = rows.saturating_add(measured.0.max(0) as u32);
+        bytes = bytes.saturating_add(measured.1.max(0) as u64);
+    }
+    (rows, bytes)
+}
+
+fn session_bytes(connection: &Connection, id: &str) -> u64 {
+    session_footprint(connection, id).1
+}
+
+/// 删掉一个会话在 `cursorDiskKV` 里的全部行，返回删除行数。
+///
+/// 只删 `bubbleId` + `composerData` 是不够的：实测本机库里 306 个已删会话留下了
+/// 15174 行、1.9 GB 的检查点与差异数据，全部来自这里没覆盖到的键空间。
+fn delete_session_rows(connection: &Connection, id: &str) -> AppResult<u32> {
+    let mut removed = 0usize;
+    for namespace in SESSION_NAMESPACES {
+        removed += connection.execute(
+            "DELETE FROM cursorDiskKV WHERE key = ?1 OR (key >= ?2 AND key < ?3)",
+            [
+                format!("{namespace}:{id}"),
+                format!("{namespace}:{id}:"),
+                format!("{namespace}:{id};"),
+            ],
+        )?;
+    }
+    Ok(removed as u32)
+}
+
+/// 一行会话头：`isSubagent` 只在列上，`value` 的 JSON 里并没有这个字段，
+/// 所以两者都要带出来，光看 JSON 会把全部子代理漏掉。
+struct HeaderRow {
+    value: Value,
+    is_subagent: bool,
+}
+
+fn read_headers(connection: &Connection) -> AppResult<BTreeMap<String, HeaderRow>> {
+    let mut statement =
+        connection.prepare("SELECT composerId, value, isSubagent FROM composerHeaders")?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<i64>>(2)?,
+        ))
+    })?;
+    let mut out = BTreeMap::new();
+    for row in rows {
+        let (id, value, is_subagent) = row?;
+        out.insert(
+            id,
+            HeaderRow {
+                value: value
+                    .as_deref()
+                    .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+                    .unwrap_or(Value::Null),
+                is_subagent: is_subagent == Some(1),
+            },
+        );
+    }
+    Ok(out)
+}
+
+/// 库里所有被某个父会话引用着的子代理 id。
+fn referenced_subagents(connection: &Connection) -> AppResult<BTreeSet<String>> {
+    let mut out = BTreeSet::new();
+    let mut statement = connection.prepare(
+        "SELECT value FROM cursorDiskKV
+         WHERE key >= 'composerData:' AND key < 'composerData;'",
+    )?;
+    let rows = statement.query_map([], |row| row.get::<_, rusqlite::types::Value>(0))?;
+    for row in rows {
+        let raw = match row? {
+            rusqlite::types::Value::Text(text) => text.into_bytes(),
+            rusqlite::types::Value::Blob(bytes) => bytes,
+            _ => continue,
+        };
+        let data = serde_json::from_slice::<Value>(&raw).unwrap_or(Value::Null);
+        for child in child_ids(&data) {
+            out.insert(child.to_string());
+        }
+    }
+    Ok(out)
+}
+
+fn header_cwd(header: &Value) -> String {
+    header
+        .get("workspaceIdentifier")
+        .and_then(|value| value.get("uri"))
+        .and_then(|uri| uri.get("fsPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(str::to_string)
+        .unwrap_or_default()
+}
+
+fn header_title(header: &Value, id: &str) -> String {
+    for key in ["name", "subtitle"] {
+        if let Some(text) = header.get(key).and_then(Value::as_str) {
+            if !text.trim().is_empty() {
+                return text.trim().to_string();
+            }
+        }
+    }
+    id.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// 进程守卫
+// ---------------------------------------------------------------------------
+
+// 刻意不与 `codex_projects::desktop_guard` 共用实现：那边在 Windows 上还要额外比对
+// Microsoft Store 的包族名（Codex 有 Store 版本），而 Cursor 是普通桌面应用，只需要
+// 比对进程名。把两套匹配规则硬塞进一个抽象，只会让一段本来就难以在本地验证的
+// unsafe 代码更难读。
+#[cfg(test)]
+thread_local! {
+    static TEST_RUNNING_PROBE: std::cell::Cell<Option<bool>> = const { std::cell::Cell::new(None) };
+}
+
+/// 测试用注入：让下一次探测返回指定结果。
+#[cfg(test)]
+pub(crate) struct CursorRunningProbe(Option<bool>);
+
+#[cfg(test)]
+impl CursorRunningProbe {
+    pub(crate) fn running() -> Self {
+        Self(TEST_RUNNING_PROBE.replace(Some(true)))
+    }
+
+    pub(crate) fn not_running() -> Self {
+        Self(TEST_RUNNING_PROBE.replace(Some(false)))
+    }
+}
+
+#[cfg(test)]
+impl Drop for CursorRunningProbe {
+    fn drop(&mut self) {
+        TEST_RUNNING_PROBE.set(self.0.take());
+    }
+}
+
+pub fn ensure_cursor_not_running() -> AppResult<()> {
+    if cursor_is_running()? {
+        return Err(AppError::Other(CURSOR_RUNNING_ERROR.to_string()));
+    }
+    Ok(())
+}
+
+pub fn cursor_is_running() -> AppResult<bool> {
+    #[cfg(test)]
+    {
+        return Ok(TEST_RUNNING_PROBE
+            .with(|probe| probe.get())
+            .unwrap_or(false));
+    }
+    #[cfg(all(not(test), target_os = "macos"))]
+    {
+        return macos_cursor_is_running();
+    }
+    #[cfg(all(not(test), target_os = "linux"))]
+    {
+        return linux_cursor_is_running();
+    }
+    #[cfg(all(not(test), windows))]
+    {
+        return windows_cursor_is_running();
+    }
+    #[cfg(all(
+        not(test),
+        not(windows),
+        not(target_os = "linux"),
+        not(target_os = "macos")
+    ))]
+    {
+        Err(AppError::Other(
+            "当前平台无法安全确认 Cursor 是否运行，已拒绝修改会话".to_string(),
+        ))
+    }
+}
+
+/// `<...>/Cursor.app/Contents/MacOS/Cursor`。
+///
+/// 只认主进程：Electron 的 Helper 进程在主进程退出后不会长期存活，拿它们做判据
+/// 反而容易把残留子进程误判成"应用还开着"。
+#[cfg(any(target_os = "macos", test))]
+fn is_macos_cursor_executable(executable: &str) -> bool {
+    let Some((bundle_prefix, binary)) = executable.rsplit_once("/Contents/MacOS/") else {
+        return false;
+    };
+    let bundle = bundle_prefix.rsplit('/').next().unwrap_or("");
+    bundle == "Cursor.app" && binary == "Cursor"
+}
+
+#[cfg(all(target_os = "macos", not(test)))]
+fn macos_cursor_is_running() -> AppResult<bool> {
+    unsafe {
+        let needed = libc::proc_listallpids(std::ptr::null_mut(), 0);
+        if needed <= 0 {
+            return Err(AppError::Other(format!(
+                "无法确认 Cursor 是否运行（枚举进程失败: {}），已拒绝修改会话",
+                std::io::Error::last_os_error()
+            )));
+        }
+        // 两次调用之间可能有新进程产生，预留余量。
+        let capacity = (needed as usize) + 64;
+        let mut pids = vec![0 as libc::pid_t; capacity];
+        let count = libc::proc_listallpids(
+            pids.as_mut_ptr() as *mut libc::c_void,
+            (capacity * std::mem::size_of::<libc::pid_t>()) as libc::c_int,
+        );
+        if count <= 0 {
+            return Err(AppError::Other(format!(
+                "无法确认 Cursor 是否运行（枚举进程失败: {}），已拒绝修改会话",
+                std::io::Error::last_os_error()
+            )));
+        }
+        let mut path_buffer = vec![0u8; libc::PROC_PIDPATHINFO_MAXSIZE as usize];
+        for &pid in &pids[..(count as usize).min(capacity)] {
+            if pid <= 0 {
+                continue;
+            }
+            // 已退出或属于其他用户的进程读不到路径，它们也不可能持有本用户的会话状态。
+            let len = libc::proc_pidpath(
+                pid,
+                path_buffer.as_mut_ptr() as *mut libc::c_void,
+                path_buffer.len() as u32,
+            );
+            if len <= 0 {
+                continue;
+            }
+            if is_macos_cursor_executable(&String::from_utf8_lossy(&path_buffer[..len as usize])) {
+                return Ok(true);
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// Linux 版 Cursor 既有 AppImage 也有 deb 安装，可执行文件名统一是 `cursor`。
+#[cfg(any(target_os = "linux", test))]
+fn is_linux_cursor_executable(executable: &Path) -> bool {
+    let name = executable
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let name = name.strip_suffix(" (deleted)").unwrap_or(&name);
+    // `cursor-agent` 是 CLI，不会缓存 IDE 的会话状态，不能算作"Cursor 在运行"。
+    name == "cursor" || name == "Cursor"
+}
+
+#[cfg(all(target_os = "linux", not(test)))]
+fn linux_cursor_is_running() -> AppResult<bool> {
+    let entries = fs::read_dir("/proc").map_err(|error| {
+        AppError::Other(format!(
+            "无法确认 Cursor 是否运行（读取 /proc 失败: {error}），已拒绝修改会话"
+        ))
+    })?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !name.bytes().all(|byte| byte.is_ascii_digit()) {
+            continue;
+        }
+        // 进程随时可能退出，读不到 exe 就跳过。
+        let Ok(executable) = fs::read_link(entry.path().join("exe")) else {
+            continue;
+        };
+        if is_linux_cursor_executable(&executable) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(any(windows, test))]
+fn is_windows_cursor_process(name: &str) -> bool {
+    name.eq_ignore_ascii_case("Cursor.exe")
+}
+
+#[cfg(all(windows, not(test)))]
+fn windows_cursor_is_running() -> AppResult<bool> {
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, GetLastError, ERROR_NO_MORE_FILES, INVALID_HANDLE_VALUE,
+    };
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+
+    struct OwnedHandle(windows_sys::Win32::Foundation::HANDLE);
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(AppError::Other(format!(
+            "无法确认 Cursor 是否运行（进程快照失败，Windows 错误 {}），已拒绝修改会话",
+            unsafe { GetLastError() }
+        )));
+    }
+    let snapshot = OwnedHandle(snapshot);
+    let mut entry = PROCESSENTRY32W::default();
+    entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+    if unsafe { Process32FirstW(snapshot.0, &mut entry) } == 0 {
+        let error = unsafe { GetLastError() };
+        if error == ERROR_NO_MORE_FILES {
+            return Ok(false);
+        }
+        return Err(AppError::Other(format!(
+            "无法确认 Cursor 是否运行（枚举进程失败，Windows 错误 {error}），已拒绝修改会话"
+        )));
+    }
+    loop {
+        let nul = entry
+            .szExeFile
+            .iter()
+            .position(|value| *value == 0)
+            .unwrap_or(entry.szExeFile.len());
+        if is_windows_cursor_process(&String::from_utf16_lossy(&entry.szExeFile[..nul])) {
+            return Ok(true);
+        }
+        if unsafe { Process32NextW(snapshot.0, &mut entry) } == 0 {
+            let error = unsafe { GetLastError() };
+            if error == ERROR_NO_MORE_FILES {
+                return Ok(false);
+            }
+            return Err(AppError::Other(format!(
+                "无法确认 Cursor 是否运行（枚举进程失败，Windows 错误 {error}），已拒绝修改会话"
+            )));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    struct Fixture {
+        root: PathBuf,
+        dirs: ProviderDirs,
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn fixture(name: &str) -> AppResult<Fixture> {
+        let root = std::env::temp_dir().join(format!(
+            "cc-sessions-cursor-mutate-{name}-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let storage = root.join("globalStorage");
+        fs::create_dir_all(&storage)?;
+        let connection = Connection::open(storage.join("state.vscdb"))?;
+        connection.execute_batch(
+            "CREATE TABLE composerHeaders (composerId TEXT PRIMARY KEY, workspaceId TEXT,
+                createdAt INTEGER, lastUpdatedAt INTEGER, isArchived INTEGER,
+                isSubagent INTEGER, recency INTEGER, checkpointAt INTEGER, value TEXT);
+             CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);
+             CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB);",
+        )?;
+        connection.execute(
+            "INSERT INTO ItemTable VALUES (?1, 'true')",
+            [HEADER_TABLE_GATE_KEY],
+        )?;
+        connection.execute(
+            "INSERT INTO composerHeaders VALUES ('s1', 'ws', 1000, 2000, 0, 0, 2000, NULL, ?1)",
+            [json!({"name": "原名", "subtitle": "概述", "totalLinesAdded": 12}).to_string()],
+        )?;
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES ('composerData:s1', ?1)",
+            [json!({
+                "name": "原名",
+                "fullConversationHeadersOnly": [{"bubbleId": "b1"}, {"bubbleId": "b2"}]
+            })
+            .to_string()],
+        )?;
+        for bubble in ["b1", "b2"] {
+            connection.execute(
+                "INSERT INTO cursorDiskKV VALUES (?1, ?2)",
+                params![
+                    format!("bubbleId:s1:{bubble}"),
+                    json!({"type": 1}).to_string()
+                ],
+            )?;
+        }
+        // 另一个会话的气泡，必须完好无损。
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES ('bubbleId:s2:b1', ?1)",
+            [json!({"type": 1}).to_string()],
+        )?;
+        drop(connection);
+        let dirs = ProviderDirs {
+            codex_dir: root.join("codex").to_string_lossy().into_owned(),
+            cursor_dir: Some(root.to_string_lossy().into_owned()),
+            cursor_agent_dir: Some(root.join("cursor-agent").to_string_lossy().into_owned()),
+            ..ProviderDirs::default()
+        };
+        Ok(Fixture { root, dirs })
+    }
+
+    fn insert_header(
+        connection: &Connection,
+        id: &str,
+        archived: i64,
+        subagent: i64,
+        value: Value,
+    ) -> AppResult<()> {
+        connection.execute(
+            "INSERT INTO composerHeaders VALUES (?1, 'ws', 1000, 2000, ?2, ?3, 2000, NULL, ?4)",
+            params![id, archived, subagent, value.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// 列声明是 BLOB，但 Cursor 实际写 TEXT，夹具照做。
+    fn insert_kv(connection: &Connection, key: &str, value: Value) -> AppResult<()> {
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES (?1, ?2)",
+            params![key, value.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn connect(fixture: &Fixture) -> AppResult<Connection> {
+        Ok(Connection::open(cursor_sessions::state_db_path(
+            &fixture.root,
+        ))?)
+    }
+
+    #[test]
+    fn writes_are_refused_while_cursor_is_running() -> AppResult<()> {
+        let fixture = fixture("running")?;
+        let _probe = CursorRunningProbe::running();
+        let error = set_archived(&fixture.dirs, "s1", true).unwrap_err();
+        assert!(error.to_string().contains("请完全退出 Cursor"));
+        assert!(rename_session(&fixture.dirs, "s1", "新名").is_err());
+        assert!(delete_session(&fixture.dirs, "s1").is_err());
+
+        // 库必须原封不动。
+        let connection = connect(&fixture)?;
+        let archived: i64 = connection.query_row(
+            "SELECT isArchived FROM composerHeaders WHERE composerId = 's1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(archived, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn archiving_updates_both_the_column_and_the_header_json() -> AppResult<()> {
+        let fixture = fixture("archive")?;
+        let _probe = CursorRunningProbe::not_running();
+        set_archived(&fixture.dirs, "s1", true)?;
+
+        let connection = connect(&fixture)?;
+        let (archived, value): (i64, String) = connection.query_row(
+            "SELECT isArchived, value FROM composerHeaders WHERE composerId = 's1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert_eq!(archived, 1);
+        let header: Value = serde_json::from_str(&value)?;
+        assert_eq!(header["isArchived"], true);
+        // 其余字段不能被顺手抹掉。
+        assert_eq!(header["name"], "原名");
+        assert_eq!(header["totalLinesAdded"], 12);
+        Ok(())
+    }
+
+    #[test]
+    fn renaming_syncs_the_header_and_the_conversation_copy() -> AppResult<()> {
+        let fixture = fixture("rename")?;
+        let _probe = CursorRunningProbe::not_running();
+        assert_eq!(rename_session(&fixture.dirs, "s1", "  新名字  ")?, 1);
+
+        let connection = connect(&fixture)?;
+        let value: String = connection.query_row(
+            "SELECT value FROM composerHeaders WHERE composerId = 's1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(serde_json::from_str::<Value>(&value)?["name"], "新名字");
+        let data: String = connection.query_row(
+            "SELECT value FROM cursorDiskKV WHERE key = 'composerData:s1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(serde_json::from_str::<Value>(&data)?["name"], "新名字");
+        Ok(())
+    }
+
+    #[test]
+    fn renaming_rejects_blank_and_overlong_titles() -> AppResult<()> {
+        let fixture = fixture("rename-invalid")?;
+        let _probe = CursorRunningProbe::not_running();
+        assert!(rename_session(&fixture.dirs, "s1", "   ").is_err());
+        assert!(rename_session(&fixture.dirs, "s1", &"字".repeat(121)).is_err());
+        assert!(rename_session(&fixture.dirs, "s1", &"字".repeat(120)).is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn deleting_removes_the_header_index_and_every_bubble() -> AppResult<()> {
+        let fixture = fixture("delete")?;
+        let _probe = CursorRunningProbe::not_running();
+        let report = delete_session(&fixture.dirs, "s1")?;
+        assert!(report.ok);
+        // 2 条气泡 + composerData；messageRequestContext 不存在所以不计。
+        assert_eq!(report.threads_rows_deleted, 3);
+
+        let connection = connect(&fixture)?;
+        let headers: i64 =
+            connection.query_row("SELECT COUNT(*) FROM composerHeaders", [], |row| row.get(0))?;
+        assert_eq!(headers, 0);
+        let leftovers: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key LIKE 'bubbleId:s1:%' OR key = 'composerData:s1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(leftovers, 0);
+        // 同库里其它会话的气泡不能受影响。
+        let others: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key = 'bubbleId:s2:b1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(others, 1);
+        Ok(())
+    }
+
+    /// 删一个会话要把它在全部键空间里的行都带走。
+    ///
+    /// Cursor 自己的删除只清了一部分，实测本机因此攒下 1.9 GB 已删会话的检查点数据。
+    #[test]
+    fn deleting_clears_every_session_scoped_namespace() -> AppResult<()> {
+        let fixture = fixture("delete-namespaces")?;
+        let connection = connect(&fixture)?;
+        for namespace in SESSION_NAMESPACES {
+            // 两种键形状都铺一遍：精确键与 `<空间>:<id>:<子 id>`。
+            insert_kv(&connection, &format!("{namespace}:s1"), json!({"x": 1}))?;
+            insert_kv(&connection, &format!("{namespace}:s1:sub"), json!({"x": 1}))?;
+            // 同名前缀的另一个会话不能被误删。
+            insert_kv(&connection, &format!("{namespace}:s2:sub"), json!({"x": 1}))?;
+        }
+        // 落在会话键空间里的全局键必须留下。
+        insert_kv(
+            &connection,
+            "composerVirtualRowHeights:_recentIds",
+            json!(["s1"]),
+        )?;
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        delete_session(&fixture.dirs, "s1")?;
+
+        let connection = connect(&fixture)?;
+        for namespace in SESSION_NAMESPACES {
+            let left: i64 = connection.query_row(
+                "SELECT COUNT(*) FROM cursorDiskKV WHERE key = ?1 OR (key >= ?2 AND key < ?3)",
+                [
+                    format!("{namespace}:s1"),
+                    format!("{namespace}:s1:"),
+                    format!("{namespace}:s1;"),
+                ],
+                |row| row.get(0),
+            )?;
+            assert_eq!(left, 0, "{namespace} 还有 s1 的残留");
+            let other: i64 = connection.query_row(
+                "SELECT COUNT(*) FROM cursorDiskKV WHERE key = ?1",
+                [format!("{namespace}:s2:sub")],
+                |row| row.get(0),
+            )?;
+            assert_eq!(other, 1, "{namespace} 误删了 s2");
+        }
+        let recent: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key = 'composerVirtualRowHeights:_recentIds'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(recent, 1, "全局键被当成孤儿删掉了");
+        Ok(())
+    }
+
+    /// 会话头没了但辅助数据还在的行，要被算成孤儿并清掉。
+    #[test]
+    fn orphan_scan_covers_auxiliary_namespaces() -> AppResult<()> {
+        let fixture = fixture("orphan-namespaces")?;
+        let connection = connect(&fixture)?;
+        for namespace in ["checkpointId", "codeBlockDiff", "messageRequestContext"] {
+            insert_kv(
+                &connection,
+                &format!("{namespace}:gone:x"),
+                json!({"payload": "1234567890"}),
+            )?;
+        }
+        insert_kv(&connection, "composerVirtualRowHeights:gone", json!([1, 2]))?;
+        insert_kv(
+            &connection,
+            "composerVirtualRowHeights:_recentIds",
+            json!(["s1"]),
+        )?;
+        drop(connection);
+
+        let report = diagnose_residue(&fixture.dirs)?;
+        let orphans = report
+            .groups
+            .iter()
+            .find(|group| group.kind == RESIDUE_ORPHAN_RECORDS)
+            .expect("孤儿记录分组");
+        // `gone` 的 4 行，外加夹具里本来就没有会话头的 `bubbleId:s2:b1`。
+        assert_eq!(orphans.sessions, 2);
+        assert_eq!(orphans.rows, 5);
+        assert!(orphans.bytes > 0);
+
+        let _probe = CursorRunningProbe::not_running();
+        prune_residue(&fixture.dirs, &[RESIDUE_ORPHAN_RECORDS.to_string()], false)?;
+        let connection = connect(&fixture)?;
+        let left: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key LIKE '%:gone%'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(left, 0);
+        let recent: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key = 'composerVirtualRowHeights:_recentIds'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(recent, 1, "全局键被当成孤儿删掉了");
+        Ok(())
+    }
+
+    /// 索引缺失时不能留下孤儿气泡。
+    #[test]
+    fn deleting_sweeps_bubbles_even_without_a_usable_index() -> AppResult<()> {
+        let fixture = fixture("delete-orphan")?;
+        let connection = connect(&fixture)?;
+        connection.execute(
+            "UPDATE cursorDiskKV SET value = ?1 WHERE key = 'composerData:s1'",
+            [json!({"name": "原名"}).to_string()],
+        )?;
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        delete_session(&fixture.dirs, "s1")?;
+        let connection = connect(&fixture)?;
+        let leftovers: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key LIKE 'bubbleId:s1:%'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(leftovers, 0);
+        Ok(())
+    }
+
+    /// 删除主会话必须把它的子会话一起带走，否则父没了、子会话再也访问不到。
+    #[test]
+    fn deleting_a_parent_cascades_to_its_subagents() -> AppResult<()> {
+        let fixture = fixture("cascade")?;
+        let connection = connect(&fixture)?;
+        // parent -> kid -> grandkid，实测存在这种多层嵌套。
+        for (id, kids) in [
+            ("parent", vec!["kid"]),
+            ("kid", vec!["grandkid"]),
+            ("grandkid", Vec::new()),
+        ] {
+            let subagent = i64::from(id != "parent");
+            insert_header(&connection, id, 0, subagent, json!({ "name": id }))?;
+            insert_kv(
+                &connection,
+                &format!("composerData:{id}"),
+                json!({
+                    "fullConversationHeadersOnly": [{"bubbleId": "b1"}],
+                    "subagentComposerIds": kids,
+                }),
+            )?;
+            insert_kv(
+                &connection,
+                &format!("bubbleId:{id}:b1"),
+                json!({"type": 1, "text": id}),
+            )?;
+        }
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        delete_session(&fixture.dirs, "parent")?;
+
+        let connection = connect(&fixture)?;
+        let ids: Vec<String> = connection
+            .prepare("SELECT composerId FROM composerHeaders ORDER BY composerId")?
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<_, _>>()?;
+        // 整条链都应消失，夹具自带的 s1 不受影响。
+        assert_eq!(ids, vec!["s1".to_string()]);
+        let leftovers: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV
+             WHERE key LIKE 'bubbleId:parent:%' OR key LIKE 'bubbleId:kid:%'
+                OR key LIKE 'bubbleId:grandkid:%'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(leftovers, 0);
+        Ok(())
+    }
+
+    /// 同一个子会话被两个父引用时，删其中一个父不能把它带走。
+    #[test]
+    fn a_subagent_shared_with_another_parent_survives() -> AppResult<()> {
+        let fixture = fixture("cascade-shared")?;
+        let connection = connect(&fixture)?;
+        for id in ["p1", "p2", "shared"] {
+            let subagent = i64::from(id == "shared");
+            insert_header(&connection, id, 0, subagent, json!({ "name": id }))?;
+            insert_kv(
+                &connection,
+                &format!("bubbleId:{id}:b1"),
+                json!({"type": 1, "text": id}),
+            )?;
+        }
+        for parent in ["p1", "p2"] {
+            insert_kv(
+                &connection,
+                &format!("composerData:{parent}"),
+                json!({
+                    "fullConversationHeadersOnly": [{"bubbleId": "b1"}],
+                    "subagentComposerIds": ["shared"],
+                }),
+            )?;
+        }
+        insert_kv(
+            &connection,
+            "composerData:shared",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}]}),
+        )?;
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        delete_session(&fixture.dirs, "p1")?;
+
+        let connection = connect(&fixture)?;
+        let ids: Vec<String> = connection
+            .prepare("SELECT composerId FROM composerHeaders ORDER BY composerId")?
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<_, _>>()?;
+        // p2 还引用着 shared，它必须留下。
+        assert_eq!(
+            ids,
+            vec!["p2".to_string(), "s1".to_string(), "shared".to_string()]
+        );
+        Ok(())
+    }
+
+    /// 没有父引用的子会话是访问不到的死数据，应当被诊断出来。
+    #[test]
+    fn subagents_without_a_parent_are_reported_as_residue() -> AppResult<()> {
+        let fixture = fixture("orphan-subagent")?;
+        let connection = connect(&fixture)?;
+        insert_header(
+            &connection,
+            "lonely",
+            0,
+            1,
+            json!({ "name": "没爹的子会话" }),
+        )?;
+        insert_kv(
+            &connection,
+            "composerData:lonely",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}]}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:lonely:b1",
+            json!({"type": 1, "text": "x"}),
+        )?;
+        // 有父引用的子会话不该被算进来。
+        insert_header(&connection, "owned", 0, 1, json!({ "name": "有爹的" }))?;
+        insert_kv(
+            &connection,
+            "composerData:owned",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}]}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:owned:b1",
+            json!({"type": 1, "text": "y"}),
+        )?;
+        insert_kv(
+            &connection,
+            "composerData:s1",
+            json!({
+                "fullConversationHeadersOnly": [{"bubbleId": "b1"}, {"bubbleId": "b2"}],
+                "subagentComposerIds": ["owned"],
+            }),
+        )?;
+        drop(connection);
+
+        let report = diagnose_residue(&fixture.dirs)?;
+        let group = report
+            .groups
+            .iter()
+            .find(|g| g.kind == RESIDUE_ORPHAN_SUBAGENTS)
+            .expect("缺少无主子会话分组");
+        assert_eq!(group.sessions, 1);
+        assert_eq!(group.samples[0].id, "lonely");
+        assert!(group.destructive);
+        // 子会话不计入可见会话，只有 s1 是主会话。
+        assert_eq!(report.visible_sessions, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn unknown_sessions_are_reported_as_missing() -> AppResult<()> {
+        let fixture = fixture("missing")?;
+        let _probe = CursorRunningProbe::not_running();
+        let error = delete_session(&fixture.dirs, "does-not-exist").unwrap_err();
+        assert!(error.to_string().contains("不存在"));
+        Ok(())
+    }
+
+    #[test]
+    fn writes_are_refused_when_the_legacy_header_store_is_authoritative() -> AppResult<()> {
+        let fixture = fixture("legacy-gate")?;
+        let connection = connect(&fixture)?;
+        connection.execute(
+            "UPDATE ItemTable SET value = 'false' WHERE key = ?1",
+            [HEADER_TABLE_GATE_KEY],
+        )?;
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        let error = set_archived(&fixture.dirs, "s1", true).unwrap_err();
+        assert!(error.to_string().contains("已拒绝写入"));
+        Ok(())
+    }
+
+    /// 内容块读不动的时候，跳过那一类就行，会话级的清理不能跟着回滚。
+    #[test]
+    fn an_unreadable_content_block_only_skips_its_own_kind() -> AppResult<()> {
+        let fixture = fixture("blob-scan-error")?;
+        let connection = connect(&fixture)?;
+        // 一个没人引用的内容块。
+        insert_kv(
+            &connection,
+            &format!("agentKv:blob:{}", "ab".repeat(32)),
+            json!({"role": "user"}),
+        )?;
+        // 一行解不开的 conversationState，让可达性扫描报错。
+        connection.execute(
+            "UPDATE cursorDiskKV SET value = ?1 WHERE key = 'composerData:s1'",
+            [json!({"conversationState": "~不是 base64"}).to_string()],
+        )?;
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        let report = prune_residue(
+            &fixture.dirs,
+            &[
+                RESIDUE_ORPHAN_RECORDS.to_string(),
+                RESIDUE_ORPHAN_BLOBS.to_string(),
+            ],
+            false,
+        )?;
+        assert_eq!(report.blob_scan_errors, 1);
+
+        let connection = connect(&fixture)?;
+        let blobs: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key LIKE 'agentKv:blob:%'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(blobs, 1, "扫描出错时内容块一个都不许删");
+        // 夹具里 `bubbleId:s2:b1` 没有会话头，属于孤儿记录，这一类必须照常清掉。
+        let orphan: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key = 'bubbleId:s2:b1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(orphan, 0, "会话级清理被内容块的错误连累回滚了");
+        Ok(())
+    }
+
+    /// 诊断要能分清三类残留，且不把正常会话算进去。
+    #[test]
+    fn residue_diagnosis_separates_empty_orphan_and_missing_project() -> AppResult<()> {
+        let fixture = fixture("residue")?;
+        let connection = connect(&fixture)?;
+        // s1 是夹具自带的正常会话（2 条气泡、无项目路径）。
+        // 空会话：有标题没内容。
+        insert_header(&connection, "empty1", 0, 0, json!({ "name": "空的" }))?;
+        // 项目目录已不存在，但有内容。
+        insert_header(
+            &connection,
+            "gone",
+            0,
+            0,
+            json!({ "name": "目录没了", "workspaceIdentifier": {"uri": {"fsPath": "/definitely/not/here"}} }),
+        )?;
+        insert_kv(
+            &connection,
+            "composerData:gone",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}]}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:gone:b1",
+            json!({"type": 1, "text": "有内容"}),
+        )?;
+        // 孤儿：没有会话头，但索引和气泡都在。
+        insert_kv(
+            &connection,
+            "composerData:orphan",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}]}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:orphan:b1",
+            json!({"type": 1, "text": "孤儿"}),
+        )?;
+        drop(connection);
+
+        let report = diagnose_residue(&fixture.dirs)?;
+        let group = |kind: &str| {
+            report
+                .groups
+                .iter()
+                .find(|g| g.kind == kind)
+                .unwrap_or_else(|| panic!("缺少分组 {kind}"))
+        };
+        assert_eq!(group(RESIDUE_EMPTY_SESSIONS).sessions, 1);
+        assert_eq!(group(RESIDUE_MISSING_PROJECT).sessions, 1);
+        assert!(group(RESIDUE_MISSING_PROJECT).destructive);
+        // orphan（索引 + 气泡）与夹具自带的 s2（只有一条气泡）都没有会话头。
+        assert_eq!(group(RESIDUE_ORPHAN_RECORDS).sessions, 2);
+        assert_eq!(group(RESIDUE_ORPHAN_RECORDS).rows, 3);
+        assert!(group(RESIDUE_ORPHAN_RECORDS).bytes > 0);
+        // s1 与 gone 有内容，都算可见会话；empty1 不算。
+        assert_eq!(report.visible_sessions, 2);
+        Ok(())
+    }
+
+    /// 默认只清安全的两类，有内容的会话必须显式勾选才会删。
+    #[test]
+    fn pruning_only_touches_the_selected_kinds() -> AppResult<()> {
+        let fixture = fixture("residue-prune")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "empty1", 0, 0, json!({ "name": "空的" }))?;
+        insert_header(
+            &connection,
+            "gone",
+            0,
+            0,
+            json!({ "name": "目录没了", "workspaceIdentifier": {"uri": {"fsPath": "/definitely/not/here"}} }),
+        )?;
+        insert_kv(
+            &connection,
+            "composerData:gone",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}]}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:gone:b1",
+            json!({"type": 1, "text": "有内容"}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:orphan:b1",
+            json!({"type": 1, "text": "孤儿"}),
+        )?;
+        drop(connection);
+
+        let _probe = CursorRunningProbe::not_running();
+        let report = prune_residue(
+            &fixture.dirs,
+            &[
+                RESIDUE_EMPTY_SESSIONS.to_string(),
+                RESIDUE_ORPHAN_RECORDS.to_string(),
+            ],
+            false,
+        )?;
+        assert_eq!(report.removed_header_rows, 1);
+        assert!(report.freed_bytes > 0);
+
+        let connection = connect(&fixture)?;
+        let ids: Vec<String> = connection
+            .prepare("SELECT composerId FROM composerHeaders ORDER BY composerId")?
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<_, _>>()?;
+        // 目录不存在的会话没被勾选，必须原样保留。
+        assert_eq!(ids, vec!["gone".to_string(), "s1".to_string()]);
+        let orphan: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key = 'bubbleId:orphan:b1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(orphan, 0);
+        // 正常会话的气泡不能受影响。
+        let kept: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key LIKE 'bubbleId:s1:%'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(kept, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn a_dry_run_reports_without_changing_anything() -> AppResult<()> {
+        let fixture = fixture("residue-dry")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "empty1", 0, 0, json!({ "name": "空的" }))?;
+        drop(connection);
+
+        // 试运行不需要 Cursor 退出。
+        let _probe = CursorRunningProbe::running();
+        let report = prune_residue(&fixture.dirs, &[RESIDUE_EMPTY_SESSIONS.to_string()], true)?;
+        assert!(report.dry_run);
+        assert_eq!(report.removed_header_rows, 1);
+
+        let connection = connect(&fixture)?;
+        let rows: i64 =
+            connection.query_row("SELECT COUNT(*) FROM composerHeaders", [], |row| row.get(0))?;
+        assert_eq!(rows, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn pruning_rejects_an_empty_or_unknown_selection() -> AppResult<()> {
+        let fixture = fixture("residue-args")?;
+        let _probe = CursorRunningProbe::not_running();
+        assert!(prune_residue(&fixture.dirs, &[], false).is_err());
+        assert!(prune_residue(&fixture.dirs, &["whatever".to_string()], false).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn residue_pruning_is_refused_while_cursor_is_running() -> AppResult<()> {
+        let fixture = fixture("residue-running")?;
+        let _probe = CursorRunningProbe::running();
+        let error =
+            prune_residue(&fixture.dirs, &[RESIDUE_EMPTY_SESSIONS.to_string()], false).unwrap_err();
+        assert!(error.to_string().contains("请完全退出 Cursor"));
+        Ok(())
+    }
+
+    #[test]
+    fn session_ids_are_parsed_out_of_both_key_shapes() {
+        assert_eq!(key_session_id("composerData:abc"), Some("abc"));
+        assert_eq!(key_session_id("bubbleId:abc:b1"), Some("abc"));
+        assert_eq!(key_session_id("other:abc"), None);
+    }
+
+    #[test]
+    fn only_the_cursor_bundle_main_binary_counts_as_running() {
+        assert!(is_macos_cursor_executable(
+            "/Applications/Cursor.app/Contents/MacOS/Cursor"
+        ));
+        // 同名目录、其它应用、Helper 进程都不算。
+        assert!(!is_macos_cursor_executable(
+            "/Applications/Cursor.app/Contents/Frameworks/Cursor Helper.app/Contents/MacOS/Cursor Helper"
+        ));
+        assert!(!is_macos_cursor_executable(
+            "/Applications/Visual Studio Code.app/Contents/MacOS/Electron"
+        ));
+        assert!(!is_macos_cursor_executable("/usr/local/bin/Cursor"));
+
+        assert!(is_linux_cursor_executable(Path::new("/opt/cursor/cursor")));
+        assert!(is_linux_cursor_executable(Path::new(
+            "/opt/cursor/cursor (deleted)"
+        )));
+        // CLI 不缓存 IDE 会话状态。
+        assert!(!is_linux_cursor_executable(Path::new(
+            "/home/u/.local/bin/cursor-agent"
+        )));
+
+        assert!(is_windows_cursor_process("Cursor.exe"));
+        assert!(is_windows_cursor_process("cursor.exe"));
+        assert!(!is_windows_cursor_process("cursor-agent.exe"));
+    }
+}

--- a/src-tauri/src/cursor_sessions.rs
+++ b/src-tauri/src/cursor_sessions.rs
@@ -1,0 +1,1540 @@
+//! Cursor 会话的只读接入。
+//!
+//! Cursor 在本机有两套互不相干的会话存储，本模块统一成一个 provider 对外呈现：
+//!
+//! - **IDE Composer**：`<cursor_dir>/globalStorage/state.vscdb`，绝大多数会话都在这里。
+//!   `composerHeaders` 表是权威列表，消息体散在 `cursorDiskKV` 的
+//!   `composerData:<id>`（有序气泡索引）与 `bubbleId:<会话>:<气泡>`（消息本体）里。
+//! - **cursor-agent CLI**：`~/.cursor/chats`，由 [`crate::cursor_agent_store`] 解析。
+//!
+//! `~/.cursor/projects/*/agent-transcripts/*.jsonl` 是同一批会话的展示副本，既没有工具
+//! 结果也没有时间戳，并且实测独有会话数为 0，因此刻意不读。
+//!
+//! 这个库单文件可达数 GB，列表页只查 `composerHeaders`（有索引，毫秒级），气泡一律等到
+//! 预览、搜索或迁移时按主键点查。**任何对 `cursorDiskKV` 的范围扫描都不可接受**：实测
+//! 全量扫一遍 `bubbleId:` 前缀要 23 秒。
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use chrono::{SecondsFormat, Utc};
+use rusqlite::{Connection, OpenFlags};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::error::{AppError, AppResult};
+use crate::models::{PreviewEvent, SessionMetaBrief, SessionSummary, UserPromptList};
+use crate::paths;
+
+pub(crate) const PROVIDER: &str = "cursor";
+const LOCATOR_PREFIX: &str = "cursor:";
+const TITLE_MAX_CHARS: usize = 120;
+
+/// `composerHeaders` 里 `type` 字段的取值。
+const BUBBLE_TYPE_USER: i64 = 1;
+const BUBBLE_TYPE_ASSISTANT: i64 = 2;
+
+/// 会话定位符。Cursor 与 OpenCode 一样，`SessionSummary.rollout_path` 不是文件路径。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SessionLocator {
+    /// `composer` = IDE 的 state.vscdb；`agent` = cursor-agent 的会话目录。
+    pub store: String,
+    /// composer 存 state.vscdb 的路径，agent 存会话目录的路径。
+    pub path: String,
+    pub session: String,
+}
+
+impl SessionLocator {
+    pub fn is_agent(&self) -> bool {
+        self.store == "agent"
+    }
+}
+
+pub fn default_data_dir() -> PathBuf {
+    paths::default_cursor_dir()
+}
+
+pub fn default_agent_dir() -> PathBuf {
+    paths::default_cursor_agent_dir()
+}
+
+pub fn state_db_path(cursor_dir: &Path) -> PathBuf {
+    paths::cursor_state_db_path(cursor_dir)
+}
+
+/// 返回可见会话总数，供设置页校验目录用。
+///
+/// 口径必须与 [`list_sessions`] 一致，否则设置页报的数和列表里看到的对不上。
+pub fn validate_data_dir(cursor_dir: &Path, agent_dir: &Path) -> AppResult<u32> {
+    let mut count = 0u32;
+    let db = state_db_path(cursor_dir);
+    if db.is_file() {
+        let connection = open_readonly(&db)?;
+        if table_exists(&connection, "composerHeaders")? {
+            let mut statement = connection.prepare(
+                "SELECT composerId, value FROM composerHeaders WHERE isSubagent IS NOT 1",
+            )?;
+            let rows = statement.query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+            })?;
+            let mut renderable = Vec::new();
+            for row in rows {
+                let (id, value) = row?;
+                let header = value
+                    .as_deref()
+                    .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+                    .unwrap_or(Value::Null);
+                if header_is_renderable(&header) {
+                    renderable.push(id);
+                }
+            }
+            let counts = bubble_counts(&connection, renderable.iter().map(String::as_str))?;
+            count = counts.values().filter(|count| **count > 0).count() as u32;
+        }
+    }
+    count = count.saturating_add(crate::cursor_agent_store::list_sessions(agent_dir)?.len() as u32);
+    Ok(count)
+}
+
+pub fn list_sessions(cursor_dir: &Path, agent_dir: &Path) -> AppResult<Vec<SessionSummary>> {
+    let db = state_db_path(cursor_dir);
+    let chats = paths::cursor_agent_chats_dir(agent_dir);
+    if !db.is_file() && !chats.is_dir() {
+        return Err(AppError::NotFound(format!(
+            "未找到 Cursor 会话数据：{} 与 {} 都不存在",
+            db.to_string_lossy(),
+            chats.to_string_lossy()
+        )));
+    }
+    let mut out = if db.is_file() {
+        list_composer_sessions(cursor_dir)?
+    } else {
+        Vec::new()
+    };
+    out.extend(crate::cursor_agent_store::list_sessions(agent_dir)?);
+    out.sort_by_key(|session| std::cmp::Reverse(session.updated_at));
+    Ok(out)
+}
+
+fn list_composer_sessions(cursor_dir: &Path) -> AppResult<Vec<SessionSummary>> {
+    let db_path = state_db_path(cursor_dir);
+    let connection = open_readonly(&db_path)?;
+    // 老版本 Cursor 把会话头存在 ItemTable 的 JSON 数组里，还没有这张表。
+    if !table_exists(&connection, "composerHeaders")? {
+        return Ok(Vec::new());
+    }
+    let workspaces = load_workspace_paths(cursor_dir);
+    let mut statement = connection.prepare(
+        "SELECT composerId, workspaceId, createdAt, lastUpdatedAt, isArchived, isSubagent, value
+         FROM composerHeaders",
+    )?;
+    let rows = statement.query_map([], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<i64>>(2)?,
+            row.get::<_, Option<i64>>(3)?,
+            row.get::<_, Option<i64>>(4)?,
+            row.get::<_, Option<i64>>(5)?,
+            row.get::<_, Option<String>>(6)?,
+        ))
+    })?;
+
+    let mut candidates = Vec::new();
+    for row in rows {
+        let (id, workspace_id, created, updated, archived, subagent, value) = row?;
+        let header = value
+            .as_deref()
+            .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+            .unwrap_or(Value::Null);
+        // 既没有项目路径也没有标题的行是 Cursor 留下的空草稿，列表里渲染不出
+        // 任何可辨识的信息。这一步是纯字符串判断，先把大头挡掉。
+        if !header_is_renderable(&header) {
+            continue;
+        }
+        candidates.push((
+            id,
+            workspace_id,
+            created,
+            updated,
+            archived,
+            subagent,
+            header,
+        ));
+    }
+
+    // 光有标题或项目路径还不够：实测 446 个"可渲染"的会话里有 137 个气泡数为 0，
+    // 它们在界面上点开是一片空白。气泡数从 SQLite 侧用 json_array_length 批量取，
+    // 446 个会话实测 26ms，不需要把索引 JSON 搬到 Rust 里解析。
+    let bubble_counts = bubble_counts(&connection, candidates.iter().map(|(id, ..)| id.as_str()))?;
+    let mut sizes = SizeBudget::new(&connection);
+
+    let mut sessions = Vec::new();
+    for (id, workspace_id, created, updated, archived, subagent, header) in candidates {
+        if bubble_counts.get(&id).copied().unwrap_or(0) == 0 {
+            continue;
+        }
+        // 子代理不单独出现在列表里：它们记在父会话的 subagentComposerIds 上，
+        // 单独删掉会让父会话留下悬空引用，所以只随父会话一起管理。
+        if subagent == Some(1) || header.get("isSubagent").and_then(Value::as_bool) == Some(true) {
+            continue;
+        }
+        let cwd =
+            paths::strip_verbatim(&resolve_cwd(&header, workspace_id.as_deref(), &workspaces));
+        let subtitle = string_field(&header, "subtitle");
+        let created_ms = created
+            .filter(|value| *value > 0)
+            .or_else(|| header.get("createdAt").and_then(Value::as_i64))
+            .unwrap_or(0);
+        let updated_ms = updated
+            .filter(|value| *value > 0)
+            .or_else(|| header.get("lastUpdatedAt").and_then(Value::as_i64))
+            .unwrap_or(created_ms)
+            .max(created_ms);
+        sessions.push(SessionSummary {
+            provider: PROVIDER.into(),
+            id: id.clone(),
+            rollout_path: encode_composer_locator(&db_path, &id)?,
+            cwd_display: paths::basename_display(&cwd),
+            cwd,
+            title: composer_title(&header, &subtitle, &id),
+            // Cursor 不在会话头里存首条提问，`subtitle` 是它自己生成的一句话概述。
+            first_user_message: subtitle,
+            model: None,
+            reasoning_effort: None,
+            source: None,
+            agent_nickname: None,
+            agent_role: None,
+            conversion_origin: None,
+            // Cursor 全程不记录 token 用量：气泡里的 tokenCount 恒为 0，
+            // composerData 里只有当前上下文窗口占用，不是累计消耗。
+            tokens_used: 0,
+            created_at: created_ms / 1000,
+            updated_at: updated_ms / 1000,
+            archived: archived == Some(1)
+                || header.get("isArchived").and_then(Value::as_bool) == Some(true),
+            git_branch: git_branch(&header),
+            // 0 表示"这次没算出来"，前端按未知渲染；下次刷新会继续补。
+            rollout_bytes: sizes.get(&id, updated_ms),
+            logs_count: 0,
+            has_backup: false,
+            // Composer 会话只能在 Cursor 里打开，没有可续聊的命令行。
+            resume_command: String::new(),
+        });
+    }
+    Ok(sessions)
+}
+
+/// 批量取每个会话的气泡数。
+///
+/// `json_array_length` 在 SQLite 侧解析，比把几 MB 的索引 JSON 取回 Rust 再解析快得多。
+/// 分批是为了不撞上 SQLite 的绑定参数上限。
+pub(crate) fn bubble_counts<'a>(
+    connection: &Connection,
+    ids: impl Iterator<Item = &'a str>,
+) -> AppResult<HashMap<String, i64>> {
+    /// SQLite 默认上限是 32766，取一个远小于它的批量。
+    const CHUNK: usize = 400;
+    let ids = ids.collect::<Vec<_>>();
+    let mut out = HashMap::with_capacity(ids.len());
+    for chunk in ids.chunks(CHUNK) {
+        let marks = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let mut statement = connection.prepare(&format!(
+            "SELECT key, json_array_length(value, '$.fullConversationHeadersOnly')
+             FROM cursorDiskKV WHERE key IN ({marks})"
+        ))?;
+        let keys = chunk
+            .iter()
+            .map(|id| format!("composerData:{id}"))
+            .collect::<Vec<_>>();
+        let rows = statement.query_map(rusqlite::params_from_iter(keys.iter()), |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<i64>>(1)?))
+        })?;
+        for row in rows {
+            let (key, count) = row?;
+            if let Some(id) = key.strip_prefix("composerData:") {
+                out.insert(id.to_string(), count.unwrap_or(0));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// 会话体积的按需计算器。
+///
+/// 单个会话的字节数要把它全部气泡扫一遍，实测平均 16ms、大会话能到 170ms，
+/// 309 个会话一次算完要 5 秒——对一个每 5 秒刷新一次的列表来说太重（Claude 侧
+/// 同一台机器只要 0.12s）。所以：结果按会话缓存，每次列表只花固定的时间预算去补
+/// 还没算过的，几次刷新后自然补齐。算不出来的先给 0，前端按"未知"渲染。
+struct SizeBudget<'a> {
+    connection: &'a Connection,
+    deadline: std::time::Instant,
+}
+
+/// 每次列举最多花在补算体积上的时间。
+const SIZE_BUDGET: std::time::Duration = std::time::Duration::from_millis(300);
+
+impl<'a> SizeBudget<'a> {
+    fn new(connection: &'a Connection) -> Self {
+        Self {
+            connection,
+            deadline: std::time::Instant::now() + SIZE_BUDGET,
+        }
+    }
+
+    fn get(&mut self, id: &str, updated_ms: i64) -> u64 {
+        let cache = size_cache();
+        {
+            let cache = cache.lock().unwrap_or_else(|error| error.into_inner());
+            if let Some((cached_updated, bytes)) = cache.get(id) {
+                if *cached_updated == updated_ms {
+                    return *bytes;
+                }
+            }
+        }
+        if std::time::Instant::now() >= self.deadline {
+            return 0;
+        }
+        // `octet_length` 直接从记录头拿字节数；`length` 要把 TEXT 解码成字符再数，
+        // 实测同一批数据 24s 对 7s。
+        let bytes = self
+            .connection
+            .query_row(
+                "SELECT COALESCE(SUM(octet_length(value)), 0) FROM cursorDiskKV
+                 WHERE key >= ?1 AND key < ?2",
+                [format!("bubbleId:{id}:"), format!("bubbleId:{id};")],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap_or(0)
+            .max(0) as u64;
+        let mut cache = cache.lock().unwrap_or_else(|error| error.into_inner());
+        if cache.len() >= SIZE_CACHE_CAPACITY {
+            cache.clear();
+        }
+        cache.insert(id.to_string(), (updated_ms, bytes));
+        bytes
+    }
+}
+
+/// 会话 id → (会话更新时间, 字节数)。更新时间变了就重算。
+fn size_cache() -> &'static Mutex<HashMap<String, (i64, u64)>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, (i64, u64)>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// 缓存的会话数上限，避免长期运行后无限增长。
+const SIZE_CACHE_CAPACITY: usize = 4096;
+
+/// 判断一行会话头是否值得出现在列表里。
+///
+/// 只要有项目路径、标题或概述三者之一就保留——这是"能不能渲染"，不是"猜它是不是空的"。
+fn header_is_renderable(header: &Value) -> bool {
+    !string_field(header, "name").is_empty()
+        || !string_field(header, "subtitle").is_empty()
+        || header_workspace_path(header).is_some()
+}
+
+fn composer_title(header: &Value, subtitle: &str, id: &str) -> String {
+    let name = string_field(header, "name");
+    if !name.is_empty() {
+        return truncate_title(&name);
+    }
+    if !subtitle.is_empty() {
+        return truncate_title(subtitle);
+    }
+    header_workspace_path(header)
+        .map(|path| paths::basename_display(&path))
+        .filter(|path| !path.is_empty())
+        .unwrap_or_else(|| id.to_string())
+}
+
+fn header_workspace_path(header: &Value) -> Option<String> {
+    header
+        .get("workspaceIdentifier")
+        .and_then(|value| value.get("uri"))
+        .and_then(|uri| uri.get("fsPath"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            header
+                .get("trackedGitRepos")
+                .and_then(Value::as_array)?
+                .iter()
+                .find_map(|repo| {
+                    repo.get("repoPath")
+                        .and_then(Value::as_str)
+                        .map(str::trim)
+                        .filter(|path| !path.is_empty())
+                        .map(str::to_string)
+                })
+        })
+}
+
+/// 项目路径三级回退：会话头 → 追踪的 git 仓库 → VS Code 的 workspaceStorage 索引。
+fn resolve_cwd(
+    header: &Value,
+    workspace_id: Option<&str>,
+    workspaces: &HashMap<String, String>,
+) -> String {
+    header_workspace_path(header)
+        .or_else(|| {
+            workspace_id
+                .and_then(|id| workspaces.get(id))
+                .map(String::clone)
+        })
+        .unwrap_or_default()
+}
+
+fn git_branch(header: &Value) -> Option<String> {
+    header
+        .get("trackedGitRepos")
+        .and_then(Value::as_array)?
+        .iter()
+        .find_map(|repo| {
+            repo.get("branches")
+                .and_then(Value::as_array)?
+                .first()?
+                .get("branchName")
+                .and_then(Value::as_str)
+                .filter(|name| !name.trim().is_empty())
+                .map(str::to_string)
+        })
+}
+
+/// `workspaceStorage/<id>/workspace.json` 把工作区 id 映射到 `file://` 目录。
+fn load_workspace_paths(cursor_dir: &Path) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let Ok(entries) = fs::read_dir(paths::cursor_workspace_storage_dir(cursor_dir)) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let Some(id) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        let Ok(raw) = fs::read_to_string(entry.path().join("workspace.json")) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(&raw) else {
+            continue;
+        };
+        if let Some(folder) = value.get("folder").and_then(Value::as_str) {
+            if let Some(path) = file_uri_to_path(folder) {
+                out.insert(id, path);
+            }
+        }
+    }
+    out
+}
+
+/// 把 `file:///a/b%20c` 还原成本地路径。只处理百分号转义，不引入 URL 依赖。
+fn file_uri_to_path(uri: &str) -> Option<String> {
+    let rest = uri.strip_prefix("file://")?;
+    let mut out = String::with_capacity(rest.len());
+    let bytes = rest.as_bytes();
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            if let Ok(byte) = u8::from_str_radix(&rest[index + 1..index + 3], 16) {
+                out.push(byte as char);
+                index += 3;
+                continue;
+            }
+        }
+        out.push(bytes[index] as char);
+        index += 1;
+    }
+    Some(out).filter(|path| !path.is_empty())
+}
+
+// ---------------------------------------------------------------------------
+// 预览
+// ---------------------------------------------------------------------------
+
+pub fn preview_range(locator: &str, offset: usize, limit: usize) -> AppResult<Vec<PreviewEvent>> {
+    let decoded = decode_locator(locator)?;
+    if decoded.is_agent() {
+        return Ok(
+            crate::cursor_agent_store::load_preview_events(Path::new(&decoded.path))?
+                .into_iter()
+                .skip(offset)
+                .take(limit)
+                .collect(),
+        );
+    }
+    // 大会话可以有上万条气泡，逐页全量展开代价太高：只读到本页末尾就停。
+    let db = Path::new(&decoded.path);
+    let connection = open_readonly(db)?;
+    let needed = offset.saturating_add(limit);
+    Ok(
+        load_composer_events(&connection, db, &decoded.session, Some(needed))?
+            .into_iter()
+            .skip(offset)
+            .take(limit)
+            .collect(),
+    )
+}
+
+pub(crate) fn load_preview_events_from_locator(locator: &str) -> AppResult<Vec<PreviewEvent>> {
+    let locator = decode_locator(locator)?;
+    if locator.is_agent() {
+        return crate::cursor_agent_store::load_preview_events(Path::new(&locator.path));
+    }
+    let db = Path::new(&locator.path);
+    let connection = open_readonly(db)?;
+    load_composer_events(&connection, db, &locator.session, None)
+}
+
+pub fn preview_user_prompts(locator: &str) -> AppResult<UserPromptList> {
+    let decoded = decode_locator(locator)?;
+    if decoded.is_agent() {
+        return crate::cursor_agent_store::preview_user_prompts(Path::new(&decoded.path));
+    }
+    let events = load_preview_events_from_locator(locator)?;
+    Ok(crate::rollout::user_prompts_from_events(events, |event| {
+        matches!(event.role.as_str(), "assistant" | "reasoning" | "tool_call")
+    }))
+}
+
+pub fn preview_meta(locator: &str) -> AppResult<SessionMetaBrief> {
+    let locator = decode_locator(locator)?;
+    if locator.is_agent() {
+        return crate::cursor_agent_store::preview_meta(Path::new(&locator.path));
+    }
+    let db = Path::new(&locator.path);
+    let connection = open_readonly(db)?;
+    let header = composer_header(&connection, &locator.session)?;
+    let index = session_index(&connection, db, &locator.session)?;
+    Ok(SessionMetaBrief {
+        id: Some(locator.session.clone()),
+        timestamp: timestamp_from_millis(
+            header.get("createdAt").and_then(Value::as_i64).unwrap_or(0),
+        ),
+        cwd: header_workspace_path(&header),
+        originator: Some("Cursor".into()),
+        cli_version: index
+            .schema_version
+            .map(|version| format!("composerData v{version}")),
+        source: Some("state.vscdb".into()),
+        model_provider: index.model.clone(),
+    })
+}
+
+/// 按 `fullConversationHeadersOnly` 记录的顺序展开会话气泡。
+///
+/// `stop_after` 给出调用方需要的事件条数，达到即停止读取后续气泡；`None` 表示全量。
+/// 一条气泡会产出 1~3 个事件，事件序号和气泡序号无法直接换算，所以只能顺序推进。
+fn load_composer_events(
+    connection: &Connection,
+    db: &Path,
+    session: &str,
+    stop_after: Option<usize>,
+) -> AppResult<Vec<PreviewEvent>> {
+    let index = session_index(connection, db, session)?;
+    let mut statement = connection.prepare("SELECT value FROM cursorDiskKV WHERE key = ?1")?;
+    let mut events = Vec::new();
+    for entry in index.order.iter() {
+        if stop_after.is_some_and(|needed| events.len() >= needed) {
+            break;
+        }
+        let key = format!("bubbleId:{session}:{}", entry.id);
+        // 气泡被 Cursor 清理过时，退回索引里的预览文本，好过在时间线上留一个空洞。
+        let Some(raw) = read_kv(&mut statement, &key)? else {
+            push_event(&mut events, fallback_raw(entry));
+            continue;
+        };
+        let Ok(bubble) = serde_json::from_slice::<Value>(&raw) else {
+            push_event(&mut events, fallback_raw(entry));
+            continue;
+        };
+        push_bubble_events(&mut events, &bubble);
+    }
+    Ok(events)
+}
+
+/// 一条气泡在会话索引中的位置信息。
+#[derive(Debug, Clone)]
+struct BubbleRef {
+    id: String,
+    kind: i64,
+    created_at: String,
+    preview: String,
+}
+
+/// 一个会话的索引：气泡顺序 + 从 `composerData` 顶层取到的少量元信息。
+#[derive(Debug, Clone)]
+struct SessionIndex {
+    order: Vec<BubbleRef>,
+    model: Option<String>,
+    schema_version: Option<i64>,
+}
+
+/// 索引缓存条目的有效性指纹。
+type IndexFingerprint = (i64, i64);
+
+/// 按会话缓存 `composerData` 的解析结果。
+///
+/// 这个 JSON 在大会话里有好几 MB（近万条气泡索引），而翻页、时间线、全文搜索都要
+/// 反复拿它。不缓存的话每次调用固定要花 100ms 上下，分页会退化成 O(页数²)——实测
+/// CLI 预览一个 8799 气泡的会话要 7 秒。
+///
+/// 只缓存索引本身，不缓存展开后的事件：那份数据可以到几百 MB。
+fn index_cache() -> &'static Mutex<HashMap<String, (IndexFingerprint, Arc<SessionIndex>)>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, (IndexFingerprint, Arc<SessionIndex>)>>> =
+        OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// 缓存的会话数上限。预览一次只看一个会话，留几个位置够覆盖来回切换。
+const INDEX_CACHE_CAPACITY: usize = 8;
+
+fn session_index(
+    connection: &Connection,
+    db: &Path,
+    session: &str,
+) -> AppResult<Arc<SessionIndex>> {
+    let fingerprint = index_fingerprint(connection, session)?;
+    let key = format!("{}\u{0}{session}", db.to_string_lossy());
+    {
+        let cache = index_cache()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        if let Some((cached, index)) = cache.get(&key) {
+            if *cached == fingerprint {
+                return Ok(Arc::clone(index));
+            }
+        }
+    }
+
+    let data = composer_data(connection, session)?;
+    let order = data
+        .get("fullConversationHeadersOnly")
+        .and_then(Value::as_array)
+        .map(|entries| entries.iter().map(bubble_ref).collect::<Vec<_>>())
+        .unwrap_or_default();
+    let index = Arc::new(SessionIndex {
+        order,
+        model: session_model(&data),
+        schema_version: data.get("_v").and_then(Value::as_i64),
+    });
+
+    let mut cache = index_cache()
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    // 简单封顶即可：这里只是省掉重复解析，命中率不值得再维护一套 LRU 记账。
+    if cache.len() >= INDEX_CACHE_CAPACITY {
+        cache.clear();
+    }
+    cache.insert(key, (fingerprint, Arc::clone(&index)));
+    Ok(index)
+}
+
+/// 会话头的更新时间加索引字节数：Cursor 改动会话时两者必变其一，且都是单行点查。
+fn index_fingerprint(connection: &Connection, session: &str) -> AppResult<IndexFingerprint> {
+    use rusqlite::OptionalExtension;
+    let updated = connection
+        .query_row(
+            "SELECT lastUpdatedAt FROM composerHeaders WHERE composerId = ?1",
+            [session],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()?
+        .flatten()
+        .unwrap_or(0);
+    let bytes = connection
+        .query_row(
+            "SELECT length(value) FROM cursorDiskKV WHERE key = ?1",
+            [format!("composerData:{session}")],
+            |row| row.get::<_, Option<i64>>(0),
+        )
+        .optional()?
+        .flatten()
+        .unwrap_or(0);
+    Ok((updated, bytes))
+}
+
+fn bubble_ref(entry: &Value) -> BubbleRef {
+    BubbleRef {
+        id: entry
+            .get("bubbleId")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        kind: entry.get("type").and_then(Value::as_i64).unwrap_or(0),
+        created_at: entry
+            .get("createdAt")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        preview: entry
+            .get("grouping")
+            .and_then(|grouping| grouping.get("textPreview"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+    }
+}
+
+/// 一个气泡最多产出三类事件：思考、正文、工具调用与其结果。
+///
+/// Cursor 把工具调用和它的输出放在同一个气泡的 `toolFormerData` 里，这里拆成
+/// `tool_use` / `tool_result` 一对，与 Claude、Codex 的时间线粒度对齐。
+fn push_bubble_events(events: &mut Vec<PreviewEvent>, bubble: &Value) {
+    let bubble_type = bubble.get("type").and_then(Value::as_i64).unwrap_or(0);
+    let role = if bubble_type == BUBBLE_TYPE_USER {
+        "user"
+    } else {
+        "assistant"
+    };
+    let timestamp = bubble
+        .get("createdAt")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    let origin = json!({
+        "store": "composer",
+        "bubble_id": bubble.get("bubbleId").cloned().unwrap_or(Value::Null),
+        "capability_type": bubble.get("capabilityType").cloned().unwrap_or(Value::Null),
+    });
+
+    if bubble_type == BUBBLE_TYPE_ASSISTANT {
+        if let Some(thinking) = thinking_text(bubble) {
+            push_event(
+                events,
+                message_raw(
+                    "assistant",
+                    json!([{ "type": "thinking", "thinking": thinking }]),
+                    &timestamp,
+                    &origin,
+                ),
+            );
+        }
+    }
+
+    let text = bubble
+        .get("text")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or("");
+    if !text.is_empty() {
+        push_event(
+            events,
+            message_raw(
+                role,
+                json!([{ "type": "text", "text": unwrap_user_query(text) }]),
+                &timestamp,
+                &origin,
+            ),
+        );
+    }
+
+    let Some(tool) = bubble
+        .get("toolFormerData")
+        .filter(|value| value.is_object())
+    else {
+        return;
+    };
+    let tool_id = tool
+        .get("toolCallId")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+    push_event(
+        events,
+        message_raw(
+            "assistant",
+            json!([{
+                "type": "tool_use",
+                "id": tool_id,
+                "name": tool.get("name").cloned().unwrap_or(Value::Null),
+                "input": tool_input(tool),
+            }]),
+            &timestamp,
+            &origin,
+        ),
+    );
+    if let Some(result) = tool.get("result").filter(|value| !value.is_null()) {
+        push_event(
+            events,
+            message_raw(
+                "user",
+                json!([{
+                    "type": "tool_result",
+                    "tool_use_id": tool_id,
+                    "content": tool_result_content(Some(result)),
+                    "is_error": tool_is_error(tool),
+                }]),
+                &timestamp,
+                &origin,
+            ),
+        );
+    }
+}
+
+/// `thinking` 存的是一段 JSON 字符串，真正的文本在它的 `text` 字段里。
+fn thinking_text(bubble: &Value) -> Option<String> {
+    let raw = bubble.get("thinking")?;
+    let text = match raw {
+        Value::String(encoded) => serde_json::from_str::<Value>(encoded)
+            .ok()
+            .and_then(|value| {
+                value
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| encoded.clone()),
+        other => other
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+    };
+    Some(text).filter(|text| !text.trim().is_empty())
+}
+
+/// `rawArgs` 是模型给出的原始入参，`params` 是 Cursor 补全后的版本；优先用后者。
+fn tool_input(tool: &Value) -> Value {
+    for key in ["params", "rawArgs"] {
+        match tool.get(key) {
+            Some(Value::String(encoded)) => {
+                if let Ok(value) = serde_json::from_str::<Value>(encoded) {
+                    return value;
+                }
+                if !encoded.trim().is_empty() {
+                    return json!({ "raw": encoded });
+                }
+            }
+            Some(value) if value.is_object() || value.is_array() => return value.clone(),
+            _ => {}
+        }
+    }
+    Value::Null
+}
+
+fn tool_is_error(tool: &Value) -> bool {
+    matches!(
+        tool.get("status").and_then(Value::as_str),
+        Some("error") | Some("failed") | Some("cancelled")
+    )
+}
+
+/// 会话使用的模型。
+///
+/// `modelConfig` 是 `composerData` 的顶层字段，一次读取即可；气泡里的 `modelInfo`
+/// 出现得非常稀疏（实测 8799 条气泡里只有 18 条带），不能靠扫描一段窗口来找。
+fn session_model(data: &Value) -> Option<String> {
+    data.get("modelConfig")?
+        .get("modelName")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+fn push_event(events: &mut Vec<PreviewEvent>, raw: Value) {
+    if let Some(event) = crate::claude_sessions::classify_preview(events.len(), raw) {
+        events.push(event);
+    }
+}
+
+/// 合成 Claude 记录的形状，直接复用它的角色判定与前端渲染。
+fn message_raw(role: &str, content: Value, timestamp: &str, origin: &Value) -> Value {
+    json!({
+        "type": role,
+        "timestamp": timestamp,
+        "message": { "role": role, "content": content },
+        "cursor": origin,
+    })
+}
+
+fn fallback_raw(entry: &BubbleRef) -> Value {
+    let role = if entry.kind == BUBBLE_TYPE_USER {
+        "user"
+    } else {
+        "assistant"
+    };
+    message_raw(
+        role,
+        json!([{ "type": "text", "text": entry.preview }]),
+        &entry.created_at,
+        &json!({ "store": "composer", "bubble_missing": true }),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// 共享工具
+// ---------------------------------------------------------------------------
+
+pub(crate) fn composer_header(connection: &Connection, session: &str) -> AppResult<Value> {
+    let raw = connection
+        .query_row(
+            "SELECT value FROM composerHeaders WHERE composerId = ?1",
+            [session],
+            |row| row.get::<_, Option<String>>(0),
+        )
+        .ok()
+        .flatten();
+    Ok(raw
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+        .unwrap_or(Value::Null))
+}
+
+pub(crate) fn composer_data(connection: &Connection, session: &str) -> AppResult<Value> {
+    let mut statement = connection.prepare("SELECT value FROM cursorDiskKV WHERE key = ?1")?;
+    let key = format!("composerData:{session}");
+    let Some(raw) = read_kv(&mut statement, &key)? else {
+        return Err(AppError::NotFound(format!("Cursor 会话不存在: {session}")));
+    };
+    Ok(serde_json::from_slice::<Value>(&raw).unwrap_or(Value::Null))
+}
+
+/// 读取一个 `cursorDiskKV` 取值。
+///
+/// 这张表把列声明成 BLOB，但 Cursor 实际按 TEXT 写入 JSON，同一张表里还混着真正的
+/// 二进制（`agentKv:blob:` 下是图片）。所以必须两种存储类都接受，直接按 `Vec<u8>` 取会
+/// 在 TEXT 上报类型错误。查不到行返回 `Ok(None)`，真正的 SQL 错误照常上抛。
+fn read_kv(statement: &mut rusqlite::Statement<'_>, key: &str) -> AppResult<Option<Vec<u8>>> {
+    use rusqlite::types::Value as SqlValue;
+    use rusqlite::OptionalExtension;
+
+    let value = statement
+        .query_row([key], |row| row.get::<_, SqlValue>(0))
+        .optional()?;
+    Ok(match value {
+        Some(SqlValue::Text(text)) => Some(text.into_bytes()),
+        Some(SqlValue::Blob(bytes)) => Some(bytes),
+        _ => None,
+    })
+}
+
+/// 工具输出可能是字符串，也可能是结构化对象；统一成前端能直接展示的文本。
+pub(crate) fn tool_result_content(result: Option<&Value>) -> Value {
+    match result {
+        Some(Value::String(text)) => Value::String(text.clone()),
+        Some(value) if !value.is_null() => {
+            Value::String(serde_json::to_string(value).unwrap_or_default())
+        }
+        _ => Value::String(String::new()),
+    }
+}
+
+/// Cursor 会把用户提问包在 `<user_query>` 里，展示时剥掉。
+pub(crate) fn unwrap_user_query(text: &str) -> String {
+    let trimmed = text.trim();
+    trimmed
+        .strip_prefix("<user_query>")
+        .and_then(|inner| inner.strip_suffix("</user_query>"))
+        .map(str::trim)
+        .filter(|inner| !inner.is_empty())
+        .map(String::from)
+        .unwrap_or_else(|| text.to_string())
+}
+
+/// 判断一段"用户消息"其实是客户端注入的环境上下文而非真人输入。
+pub(crate) fn is_injected_context(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    if trimmed.contains("<user_query>") {
+        return false;
+    }
+    ["<user_info>", "<environment_context>", "<additional_data>"]
+        .iter()
+        .any(|marker| trimmed.starts_with(marker))
+}
+
+pub(crate) fn truncate_title(text: &str) -> String {
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= TITLE_MAX_CHARS {
+        return trimmed.to_string();
+    }
+    let mut out: String = trimmed.chars().take(TITLE_MAX_CHARS).collect();
+    out.push('…');
+    out
+}
+
+pub(crate) fn timestamp_from_millis(millis: i64) -> Option<String> {
+    chrono::DateTime::<Utc>::from_timestamp_millis(millis)
+        .map(|value| value.to_rfc3339_opts(SecondsFormat::Millis, true))
+}
+
+fn string_field(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim()
+        .to_string()
+}
+
+pub(crate) fn encode_composer_locator(db: &Path, session: &str) -> AppResult<String> {
+    encode_locator(&SessionLocator {
+        store: "composer".into(),
+        path: db.to_string_lossy().into_owned(),
+        session: session.to_string(),
+    })
+}
+
+pub(crate) fn encode_agent_locator(dir: &Path, session: &str) -> AppResult<String> {
+    encode_locator(&SessionLocator {
+        store: "agent".into(),
+        path: dir.to_string_lossy().into_owned(),
+        session: session.to_string(),
+    })
+}
+
+fn encode_locator(locator: &SessionLocator) -> AppResult<String> {
+    let raw = serde_json::to_vec(locator)?;
+    Ok(format!("{LOCATOR_PREFIX}{}", URL_SAFE_NO_PAD.encode(raw)))
+}
+
+pub(crate) fn decode_locator(value: &str) -> AppResult<SessionLocator> {
+    let encoded = value
+        .strip_prefix(LOCATOR_PREFIX)
+        .ok_or_else(|| AppError::Path("Cursor 会话定位符格式无效".into()))?;
+    let raw = URL_SAFE_NO_PAD
+        .decode(encoded)
+        .map_err(|error| AppError::Path(format!("Cursor 会话定位符无法解码: {error}")))?;
+    let locator: SessionLocator = serde_json::from_slice(&raw)?;
+    if locator.session.trim().is_empty() {
+        return Err(AppError::Path("Cursor 会话定位符缺少会话 id".into()));
+    }
+    let path = Path::new(&locator.path);
+    let exists = if locator.is_agent() {
+        path.is_dir()
+    } else {
+        path.is_file()
+    };
+    if !exists {
+        return Err(AppError::Path(format!(
+            "Cursor 会话定位符指向的位置不存在: {}",
+            locator.path
+        )));
+    }
+    Ok(locator)
+}
+
+pub(crate) fn open_readonly(path: &Path) -> AppResult<Connection> {
+    if !path.is_file() {
+        return Err(AppError::NotFound(format!(
+            "Cursor 数据库不存在: {}",
+            path.to_string_lossy()
+        )));
+    }
+    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(Into::into)
+}
+
+pub(crate) fn table_exists(connection: &Connection, table: &str) -> AppResult<bool> {
+    Ok(connection.query_row(
+        "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1)",
+        [table],
+        |row| row.get::<_, bool>(0),
+    )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_root(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "cc-sessions-cursor-{name}-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    struct Fixture {
+        root: PathBuf,
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    /// 造一个最小可用的 state.vscdb，表结构与真实 Cursor 一致。
+    fn fixture(name: &str) -> AppResult<Fixture> {
+        let root = temp_root(name);
+        let storage = root.join("globalStorage");
+        fs::create_dir_all(&storage)?;
+        let connection = Connection::open(storage.join("state.vscdb"))?;
+        connection.execute_batch(
+            "CREATE TABLE composerHeaders (composerId TEXT PRIMARY KEY, workspaceId TEXT,
+                createdAt INTEGER, lastUpdatedAt INTEGER, isArchived INTEGER,
+                isSubagent INTEGER, recency INTEGER, checkpointAt INTEGER, value TEXT);
+             CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);",
+        )?;
+        Ok(Fixture { root })
+    }
+
+    fn connect(fixture: &Fixture) -> AppResult<Connection> {
+        Ok(Connection::open(state_db_path(&fixture.root))?)
+    }
+
+    fn insert_header(
+        connection: &Connection,
+        id: &str,
+        archived: i64,
+        subagent: i64,
+        value: Value,
+    ) -> AppResult<()> {
+        connection.execute(
+            "INSERT INTO composerHeaders VALUES (?1, 'ws-1', 1000, 2000, ?2, ?3, 2000, NULL, ?4)",
+            rusqlite::params![id, archived, subagent, value.to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// 列虽然声明成 BLOB，Cursor 实际写的是 TEXT，夹具必须照做才能覆盖真实读路径。
+    fn insert_kv(connection: &Connection, key: &str, value: Value) -> AppResult<()> {
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES (?1, ?2)",
+            rusqlite::params![key, value.to_string()],
+        )?;
+        Ok(())
+    }
+
+    fn insert_kv_blob(connection: &Connection, key: &str, value: Value) -> AppResult<()> {
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES (?1, ?2)",
+            rusqlite::params![key, value.to_string().into_bytes()],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn list_sessions_skips_headers_without_anything_to_render() -> AppResult<()> {
+        let fixture = fixture("blank")?;
+        let connection = connect(&fixture)?;
+        insert_header(
+            &connection,
+            "real",
+            0,
+            0,
+            json!({
+                "name": "真实会话",
+                "subtitle": "改了两个文件",
+                "workspaceIdentifier": {"uri": {"fsPath": "/tmp/proj"}}
+            }),
+        )?;
+        insert_kv(
+            &connection,
+            "composerData:real",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 1}]}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:real:b1",
+            json!({"type": 1, "text": "问题"}),
+        )?;
+        // 空草稿：无标题、无概述、无项目路径。
+        insert_header(&connection, "draft", 0, 0, json!({ "isDraft": true }))?;
+        drop(connection);
+
+        let sessions = list_sessions(&fixture.root, &fixture.root.join("agent"))?;
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, "real");
+        assert_eq!(sessions[0].cwd, "/tmp/proj");
+        assert_eq!(sessions[0].cwd_display, "proj");
+        assert_eq!(sessions[0].title, "真实会话");
+        assert_eq!(sessions[0].first_user_message, "改了两个文件");
+        // Cursor 不记录 token 用量，不能拿上下文占用冒充。
+        assert_eq!(sessions[0].tokens_used, 0);
+        Ok(())
+    }
+
+    /// 有标题或项目路径、但一条气泡都没有的会话点开是空白，不该出现在列表里。
+    #[test]
+    fn list_sessions_skips_sessions_that_have_no_bubbles() -> AppResult<()> {
+        let fixture = fixture("empty-conversation")?;
+        let connection = connect(&fixture)?;
+        // 只有项目路径、没有任何内容——本机 whisper 那个会话就是这样。
+        insert_header(
+            &connection,
+            "drafted",
+            0,
+            0,
+            json!({ "workspaceIdentifier": {"uri": {"fsPath": "/tmp/gone"}} }),
+        )?;
+        insert_kv(
+            &connection,
+            "composerData:drafted",
+            json!({"fullConversationHeadersOnly": []}),
+        )?;
+        // 有标题但连 composerData 都没有。
+        insert_header(&connection, "headless", 0, 0, json!({ "name": "只有标题" }))?;
+        // 正常会话。
+        insert_header(&connection, "real", 0, 0, json!({ "name": "有内容" }))?;
+        insert_kv(
+            &connection,
+            "composerData:real",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 1}]}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:real:b1",
+            json!({"type": 1, "text": "问题"}),
+        )?;
+        drop(connection);
+
+        let sessions = list_sessions(&fixture.root, &fixture.root.join("agent"))?;
+        assert_eq!(
+            sessions.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["real"]
+        );
+        // 设置页的计数要和列表一致。
+        assert_eq!(
+            validate_data_dir(&fixture.root, &fixture.root.join("agent"))?,
+            1
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn list_sessions_reports_the_conversation_byte_size() -> AppResult<()> {
+        let fixture = fixture("size")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "s1", 0, 0, json!({ "name": "会话" }))?;
+        insert_kv(
+            &connection,
+            "composerData:s1",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}, {"bubbleId": "b2"}]}),
+        )?;
+        let first = json!({"type": 1, "text": "第一条"});
+        let second = json!({"type": 2, "text": "第二条稍微长一点"});
+        insert_kv(&connection, "bubbleId:s1:b1", first.clone())?;
+        insert_kv(&connection, "bubbleId:s1:b2", second.clone())?;
+        // 别的会话的气泡不能算进来。
+        insert_kv(
+            &connection,
+            "bubbleId:s2:b1",
+            json!({"type": 1, "text": "别人的"}),
+        )?;
+        drop(connection);
+
+        let expected = (first.to_string().len() + second.to_string().len()) as u64;
+        let sessions = list_sessions(&fixture.root, &fixture.root.join("agent"))?;
+        assert_eq!(sessions[0].rollout_bytes, expected);
+        Ok(())
+    }
+
+    /// 子代理只随父会话管理，不单独出现在列表里。
+    #[test]
+    fn list_sessions_marks_archived_and_hides_subagent_rows() -> AppResult<()> {
+        let fixture = fixture("flags")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "archived", 1, 0, json!({ "name": "已归档" }))?;
+        insert_header(&connection, "sub", 0, 1, json!({ "name": "子代理" }))?;
+        for id in ["archived", "sub"] {
+            insert_kv(
+                &connection,
+                &format!("composerData:{id}"),
+                json!({"fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 1}]}),
+            )?;
+            insert_kv(
+                &connection,
+                &format!("bubbleId:{id}:b1"),
+                json!({"type": 1, "text": "问题"}),
+            )?;
+        }
+        drop(connection);
+
+        let sessions = list_sessions(&fixture.root, &fixture.root.join("agent"))?;
+        let archived = sessions.iter().find(|s| s.id == "archived").unwrap();
+        assert!(archived.archived);
+        // 子代理不出现在列表里。
+        assert!(sessions.iter().all(|s| s.id != "sub"));
+        Ok(())
+    }
+
+    #[test]
+    fn cwd_falls_back_to_git_repo_then_workspace_storage() -> AppResult<()> {
+        let fixture = fixture("cwd")?;
+        let workspace = paths::cursor_workspace_storage_dir(&fixture.root).join("ws-1");
+        fs::create_dir_all(&workspace)?;
+        fs::write(
+            workspace.join("workspace.json"),
+            json!({ "folder": "file:///tmp/from%20storage" }).to_string(),
+        )?;
+        let connection = connect(&fixture)?;
+        insert_header(
+            &connection,
+            "git",
+            0,
+            0,
+            json!({
+                "name": "走 git 回退",
+                "trackedGitRepos": [{"repoPath": "/tmp/repo", "branches": [{"branchName": "main"}]}]
+            }),
+        )?;
+        insert_header(
+            &connection,
+            "storage",
+            0,
+            0,
+            json!({ "name": "走索引回退" }),
+        )?;
+        for id in ["git", "storage"] {
+            insert_kv(
+                &connection,
+                &format!("composerData:{id}"),
+                json!({"fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 1}]}),
+            )?;
+            insert_kv(
+                &connection,
+                &format!("bubbleId:{id}:b1"),
+                json!({"type": 1, "text": "问题"}),
+            )?;
+        }
+        drop(connection);
+
+        let sessions = list_sessions(&fixture.root, &fixture.root.join("agent"))?;
+        let git = sessions.iter().find(|s| s.id == "git").unwrap();
+        let storage = sessions.iter().find(|s| s.id == "storage").unwrap();
+        assert_eq!(git.cwd, "/tmp/repo");
+        assert_eq!(git.git_branch.as_deref(), Some("main"));
+        // 百分号转义要还原成真实路径。
+        assert_eq!(storage.cwd, "/tmp/from storage");
+        Ok(())
+    }
+
+    #[test]
+    fn preview_splits_thinking_text_and_tool_pairs() -> AppResult<()> {
+        let fixture = fixture("preview")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "s1", 0, 0, json!({ "name": "会话" }))?;
+        insert_kv(
+            &connection,
+            "composerData:s1",
+            json!({
+                "_v": 18,
+                "fullConversationHeadersOnly": [
+                    {"bubbleId": "b1", "type": 1},
+                    {"bubbleId": "b2", "type": 2},
+                    {"bubbleId": "b3", "type": 2}
+                ]
+            }),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:s1:b1",
+            json!({"type": 1, "text": "<user_query>\n帮我看看\n</user_query>", "createdAt": "2026-08-13T15:34:11.009Z"}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:s1:b2",
+            json!({
+                "type": 2,
+                "thinking": r#"{"text":"先读文件","isLastThinkingChunk":true}"#,
+                "createdAt": "2026-08-13T15:34:12.000Z"
+            }),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:s1:b3",
+            json!({
+                "type": 2,
+                "toolFormerData": {
+                    "toolCallId": "toolu_1",
+                    "name": "read_file_v2",
+                    "rawArgs": "{\"target_file\":\"a.rs\"}",
+                    "params": "{\"target_file\":\"a.rs\",\"explanation\":\"读\"}",
+                    "status": "completed",
+                    "result": "文件内容"
+                },
+                "createdAt": "2026-08-13T15:34:13.000Z"
+            }),
+        )?;
+        drop(connection);
+
+        let locator = encode_composer_locator(&state_db_path(&fixture.root), "s1")?;
+        let events = load_preview_events_from_locator(&locator)?;
+        let roles = events.iter().map(|e| e.role.as_str()).collect::<Vec<_>>();
+        assert_eq!(roles, vec!["user", "reasoning", "tool_call", "tool_result"]);
+        // <user_query> 包裹要剥掉。
+        assert_eq!(events[0].text_summary, "帮我看看");
+        assert_eq!(events[1].text_summary, "先读文件");
+        // params 比 rawArgs 更完整，应当优先。
+        let input = events[2].raw["message"]["content"][0]["input"].clone();
+        assert_eq!(input["explanation"], "读");
+        assert_eq!(events[3].raw["message"]["content"][0]["is_error"], false);
+
+        // 分页要作用在展开后的事件上。
+        assert_eq!(preview_range(&locator, 2, 1)?.len(), 1);
+        assert_eq!(preview_range(&locator, 2, 1)?[0].role, "tool_call");
+        Ok(())
+    }
+
+    #[test]
+    fn preview_falls_back_to_index_preview_when_a_bubble_is_gone() -> AppResult<()> {
+        let fixture = fixture("missing")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "s1", 0, 0, json!({ "name": "会话" }))?;
+        insert_kv(
+            &connection,
+            "composerData:s1",
+            json!({
+                "fullConversationHeadersOnly": [
+                    {"bubbleId": "gone", "type": 1, "grouping": {"textPreview": "被清理的提问"}}
+                ]
+            }),
+        )?;
+        drop(connection);
+
+        let locator = encode_composer_locator(&state_db_path(&fixture.root), "s1")?;
+        let events = load_preview_events_from_locator(&locator)?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].role, "user");
+        assert_eq!(events[0].text_summary, "被清理的提问");
+        Ok(())
+    }
+
+    #[test]
+    fn cancelled_tool_calls_are_reported_as_errors() -> AppResult<()> {
+        let fixture = fixture("cancelled")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "s1", 0, 0, json!({ "name": "会话" }))?;
+        insert_kv(
+            &connection,
+            "composerData:s1",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 2}]}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:s1:b1",
+            json!({
+                "type": 2,
+                "toolFormerData": {
+                    "toolCallId": "toolu_1",
+                    "name": "run_terminal_command_v2",
+                    "status": "cancelled",
+                    "result": "中断"
+                }
+            }),
+        )?;
+        drop(connection);
+
+        let locator = encode_composer_locator(&state_db_path(&fixture.root), "s1")?;
+        let events = load_preview_events_from_locator(&locator)?;
+        assert_eq!(events[1].raw["message"]["content"][0]["is_error"], true);
+        Ok(())
+    }
+
+    /// 同一张表里 TEXT 与 BLOB 混存，两种都必须能读出来。
+    #[test]
+    fn kv_values_are_read_as_text_or_blob() -> AppResult<()> {
+        let fixture = fixture("storage-class")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "s1", 0, 0, json!({ "name": "会话" }))?;
+        insert_kv(
+            &connection,
+            "composerData:s1",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 1}]}),
+        )?;
+        insert_kv_blob(
+            &connection,
+            "bubbleId:s1:b1",
+            json!({"type": 1, "text": "以二进制存的气泡"}),
+        )?;
+        drop(connection);
+
+        let locator = encode_composer_locator(&state_db_path(&fixture.root), "s1")?;
+        let events = load_preview_events_from_locator(&locator)?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].text_summary, "以二进制存的气泡");
+        Ok(())
+    }
+
+    /// 索引缓存必须跟着会话内容失效，否则改完会话还会读到旧的气泡顺序。
+    #[test]
+    fn the_session_index_cache_is_invalidated_when_the_session_changes() -> AppResult<()> {
+        let fixture = fixture("index-cache")?;
+        let connection = connect(&fixture)?;
+        insert_header(&connection, "s1", 0, 0, json!({ "name": "会话" }))?;
+        insert_kv(
+            &connection,
+            "composerData:s1",
+            json!({"fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 1}]}),
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:s1:b1",
+            json!({"type": 1, "text": "第一条"}),
+        )?;
+        drop(connection);
+
+        let locator = encode_composer_locator(&state_db_path(&fixture.root), "s1")?;
+        assert_eq!(load_preview_events_from_locator(&locator)?.len(), 1);
+
+        // 追加一条气泡，并按 Cursor 的行为同步更新会话头的时间戳。
+        let connection = connect(&fixture)?;
+        connection.execute(
+            "UPDATE cursorDiskKV SET value = ?1 WHERE key = 'composerData:s1'",
+            [json!({"fullConversationHeadersOnly": [
+                {"bubbleId": "b1", "type": 1},
+                {"bubbleId": "b2", "type": 2}
+            ]})
+            .to_string()],
+        )?;
+        insert_kv(
+            &connection,
+            "bubbleId:s1:b2",
+            json!({"type": 2, "text": "第二条"}),
+        )?;
+        connection.execute(
+            "UPDATE composerHeaders SET lastUpdatedAt = 9999 WHERE composerId = 's1'",
+            [],
+        )?;
+        drop(connection);
+
+        let events = load_preview_events_from_locator(&locator)?;
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].text_summary, "第二条");
+        Ok(())
+    }
+
+    #[test]
+    fn locator_round_trips_and_rejects_foreign_prefixes() -> AppResult<()> {
+        let fixture = fixture("locator")?;
+        let db = state_db_path(&fixture.root);
+        let encoded = encode_composer_locator(&db, "s1")?;
+        let decoded = decode_locator(&encoded)?;
+        assert_eq!(decoded.session, "s1");
+        assert!(!decoded.is_agent());
+        assert!(decode_locator("opencode:abc").is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn missing_both_stores_is_an_error_but_a_missing_cli_store_is_not() -> AppResult<()> {
+        let fixture = fixture("stores")?;
+        // state.vscdb 在，CLI 目录不在：正常返回。
+        assert!(list_sessions(&fixture.root, &fixture.root.join("agent")).is_ok());
+
+        let empty = temp_root("nothing");
+        fs::create_dir_all(&empty)?;
+        assert!(list_sessions(&empty, &empty).is_err());
+        fs::remove_dir_all(&empty)?;
+        Ok(())
+    }
+
+    #[test]
+    fn injected_context_is_detected_only_without_a_real_query() {
+        assert!(is_injected_context("<user_info>OS darwin</user_info>"));
+        assert!(!is_injected_context(
+            "<user_info>OS</user_info>\n<user_query>真的提问</user_query>"
+        ));
+        assert!(!is_injected_context("普通提问"));
+    }
+}

--- a/src-tauri/src/cursor_transfer.rs
+++ b/src-tauri/src/cursor_transfer.rs
@@ -1,0 +1,511 @@
+//! Cursor 会话的快照导出与导入，供备份与会话包使用。
+//!
+//! **绝不整库拷贝**：`state.vscdb` 里除了会话，还有 `ItemTable` 保存的登录态、
+//! 工作区状态和各种扩展数据；而且这个文件实测有 8 GB。快照只带走一个会话真正拥有的
+//! 三部分内容：
+//!
+//! - `composerHeaders` 的那一行（会话头，含标题、时间、归档位、项目路径）
+//! - `cursorDiskKV` 的 `composerData:<id>`（有序气泡索引）
+//! - `cursorDiskKV` 的 `bubbleId:<id>:<气泡>`（消息本体）
+//!
+//! 导入时按当前库的列做交集写入，Cursor 升级新增列不会导致导入失败。
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use rusqlite::types::Value as SqlValue;
+use rusqlite::{Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+use crate::cursor_sessions;
+use crate::error::{AppError, AppResult};
+
+const SNAPSHOT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CursorSessionSnapshot {
+    pub version: u32,
+    pub exported_at: String,
+    pub session_id: String,
+    pub source_cwd: String,
+    pub source_updated_at: i64,
+    /// `composerHeaders` 的列名与取值，按列名存以便导入时做交集。
+    pub header: HashMap<String, SnapshotValue>,
+    /// 会话正文的 `composerData:<id>` 原文。
+    pub composer_data: Option<String>,
+    /// 气泡：键去掉 `bubbleId:<id>:` 前缀后的气泡 id → 原文。
+    pub bubbles: Vec<(String, String)>,
+}
+
+/// SQLite 的取值在 JSON 里的表示。`cursorDiskKV` 同一列既有 TEXT 也有 BLOB。
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value")]
+pub enum SnapshotValue {
+    Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    /// base64 编码的二进制。
+    Blob(String),
+}
+
+impl SnapshotValue {
+    fn from_sql(value: SqlValue) -> Self {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+        match value {
+            SqlValue::Null => Self::Null,
+            SqlValue::Integer(value) => Self::Integer(value),
+            SqlValue::Real(value) => Self::Real(value),
+            SqlValue::Text(value) => Self::Text(value),
+            SqlValue::Blob(value) => Self::Blob(STANDARD.encode(value)),
+        }
+    }
+
+    fn to_sql(&self) -> AppResult<SqlValue> {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+        Ok(match self {
+            Self::Null => SqlValue::Null,
+            Self::Integer(value) => SqlValue::Integer(*value),
+            Self::Real(value) => SqlValue::Real(*value),
+            Self::Text(value) => SqlValue::Text(value.clone()),
+            Self::Blob(value) => SqlValue::Blob(
+                STANDARD
+                    .decode(value)
+                    .map_err(|error| AppError::Other(format!("快照中的二进制无法解码: {error}")))?,
+            ),
+        })
+    }
+}
+
+pub fn export_snapshot(cursor_dir: &Path, session_id: &str) -> AppResult<CursorSessionSnapshot> {
+    validate_session_id(session_id)?;
+    let db = cursor_sessions::state_db_path(cursor_dir);
+    let connection = cursor_sessions::open_readonly(&db)?;
+    if !cursor_sessions::table_exists(&connection, "composerHeaders")? {
+        return Err(AppError::Other(
+            "这个 Cursor 版本还没有 composerHeaders 表，无法导出会话".into(),
+        ));
+    }
+
+    let columns = table_columns(&connection, "composerHeaders")?;
+    let placeholders = columns.join(", ");
+    let header = connection
+        .query_row(
+            &format!("SELECT {placeholders} FROM composerHeaders WHERE composerId = ?1"),
+            [session_id],
+            |row| {
+                let mut out = HashMap::new();
+                for (index, name) in columns.iter().enumerate() {
+                    out.insert(name.clone(), SnapshotValue::from_sql(row.get(index)?));
+                }
+                Ok(out)
+            },
+        )
+        .optional()?
+        .ok_or_else(|| AppError::NotFound(format!("Cursor 会话不存在: {session_id}")))?;
+
+    let composer_data = read_text(&connection, &format!("composerData:{session_id}"))?;
+    let mut bubbles = Vec::new();
+    if let Some(raw) = composer_data.as_deref() {
+        let data =
+            serde_json::from_str::<serde_json::Value>(raw).unwrap_or(serde_json::Value::Null);
+        for entry in data
+            .get("fullConversationHeadersOnly")
+            .and_then(serde_json::Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            let Some(bubble) = entry.get("bubbleId").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            if let Some(text) = read_text(&connection, &format!("bubbleId:{session_id}:{bubble}"))?
+            {
+                bubbles.push((bubble.to_string(), text));
+            }
+        }
+    }
+
+    let source_cwd = header
+        .get("value")
+        .and_then(|value| match value {
+            SnapshotValue::Text(text) => serde_json::from_str::<serde_json::Value>(text).ok(),
+            _ => None,
+        })
+        .and_then(|value| {
+            value
+                .get("workspaceIdentifier")?
+                .get("uri")?
+                .get("fsPath")?
+                .as_str()
+                .map(str::to_string)
+        })
+        .unwrap_or_default();
+    let source_updated_at = match header.get("lastUpdatedAt") {
+        Some(SnapshotValue::Integer(value)) => *value,
+        _ => 0,
+    };
+
+    Ok(CursorSessionSnapshot {
+        version: SNAPSHOT_VERSION,
+        exported_at: chrono::Utc::now().to_rfc3339(),
+        session_id: session_id.to_string(),
+        source_cwd,
+        source_updated_at,
+        header,
+        composer_data,
+        bubbles,
+    })
+}
+
+pub fn write_snapshot(path: &Path, snapshot: &CursorSessionSnapshot) -> AppResult<()> {
+    validate_snapshot(snapshot)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_vec_pretty(snapshot)?)?;
+    Ok(())
+}
+
+pub fn read_snapshot(path: &Path, expected_id: &str) -> AppResult<CursorSessionSnapshot> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_file() || crate::path_safety::metadata_is_link_or_reparse(&metadata) {
+        return Err(AppError::Path(format!(
+            "Cursor 会话快照必须是普通文件: {}",
+            path.to_string_lossy()
+        )));
+    }
+    let snapshot: CursorSessionSnapshot = serde_json::from_slice(&fs::read(path)?)?;
+    validate_snapshot(&snapshot)?;
+    if snapshot.session_id != expected_id {
+        return Err(AppError::Other(format!(
+            "Cursor 会话快照 id 与清单不一致: 快照 {}，清单 {expected_id}",
+            snapshot.session_id
+        )));
+    }
+    Ok(snapshot)
+}
+
+pub fn verify_snapshot_file(path: &Path, expected_id: &str) -> AppResult<()> {
+    read_snapshot(path, expected_id).map(|_| ())
+}
+
+/// 把快照写回当前的 Cursor 数据库。
+///
+/// 与其它写操作一样先确认 Cursor 已退出；整个导入在一个事务里完成。
+pub fn import_snapshot(
+    cursor_dir: &Path,
+    snapshot: &CursorSessionSnapshot,
+    overwrite: bool,
+) -> AppResult<bool> {
+    validate_snapshot(snapshot)?;
+    crate::cursor_mutate::ensure_cursor_not_running()?;
+    let db = cursor_sessions::state_db_path(cursor_dir);
+    if !db.is_file() {
+        return Err(AppError::NotFound(format!(
+            "Cursor 数据库不存在: {}",
+            db.to_string_lossy()
+        )));
+    }
+    let mut connection = Connection::open(&db)?;
+    if !cursor_sessions::table_exists(&connection, "composerHeaders")? {
+        return Err(AppError::Other(
+            "这个 Cursor 版本还没有 composerHeaders 表，无法导入会话".into(),
+        ));
+    }
+    let transaction = connection.transaction()?;
+    let exists = transaction
+        .query_row(
+            "SELECT 1 FROM composerHeaders WHERE composerId = ?1",
+            [&snapshot.session_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?
+        .is_some();
+    if exists && !overwrite {
+        return Ok(false);
+    }
+
+    // 取当前库与快照的列交集：Cursor 升级新增列时旧快照仍然可用，反之亦然。
+    let columns = table_columns(&transaction, "composerHeaders")?
+        .into_iter()
+        .filter(|name| snapshot.header.contains_key(name))
+        .collect::<Vec<_>>();
+    if !columns.iter().any(|name| name == "composerId") {
+        return Err(AppError::Other("快照缺少 composerId，无法导入".into()));
+    }
+    let names = columns.join(", ");
+    let marks = (1..=columns.len())
+        .map(|index| format!("?{index}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let values = columns
+        .iter()
+        .map(|name| snapshot.header[name].to_sql())
+        .collect::<AppResult<Vec<_>>>()?;
+    transaction.execute(
+        &format!("INSERT OR REPLACE INTO composerHeaders ({names}) VALUES ({marks})"),
+        rusqlite::params_from_iter(values),
+    )?;
+
+    // 覆盖导入时先清掉旧气泡，避免残留上一版会话的内容。
+    transaction.execute(
+        "DELETE FROM cursorDiskKV WHERE key LIKE ?1 ESCAPE '\\'",
+        [format!("bubbleId:{}:%", escape_like(&snapshot.session_id))],
+    )?;
+    if let Some(data) = snapshot.composer_data.as_deref() {
+        transaction.execute(
+            "INSERT OR REPLACE INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![format!("composerData:{}", snapshot.session_id), data],
+        )?;
+    }
+    for (bubble, raw) in &snapshot.bubbles {
+        transaction.execute(
+            "INSERT OR REPLACE INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![format!("bubbleId:{}:{bubble}", snapshot.session_id), raw],
+        )?;
+    }
+    transaction.commit()?;
+    Ok(true)
+}
+
+fn validate_snapshot(snapshot: &CursorSessionSnapshot) -> AppResult<()> {
+    if snapshot.version == 0 || snapshot.version > SNAPSHOT_VERSION {
+        return Err(AppError::Other(format!(
+            "不支持的 Cursor 会话快照版本: {}",
+            snapshot.version
+        )));
+    }
+    validate_session_id(&snapshot.session_id)?;
+    for (bubble, _) in &snapshot.bubbles {
+        validate_session_id(bubble)?;
+    }
+    Ok(())
+}
+
+/// 会话与气泡 id 都会拼进 SQL 的 key，只允许安全字符。
+fn validate_session_id(id: &str) -> AppResult<()> {
+    let trimmed = id.trim();
+    if trimmed.is_empty() || trimmed.len() > 128 {
+        return Err(AppError::Other(format!("Cursor 会话 id 无效: {id}")));
+    }
+    if !trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+    {
+        return Err(AppError::Other(format!("Cursor 会话 id 含非法字符: {id}")));
+    }
+    Ok(())
+}
+
+fn escape_like(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+fn table_columns(connection: &Connection, table: &str) -> AppResult<Vec<String>> {
+    let mut statement = connection.prepare(&format!("PRAGMA table_info({table})"))?;
+    let rows = statement.query_map([], |row| row.get::<_, String>(1))?;
+    Ok(rows.collect::<Result<Vec<_>, _>>()?)
+}
+
+fn read_text(connection: &Connection, key: &str) -> AppResult<Option<String>> {
+    let value = connection
+        .query_row(
+            "SELECT value FROM cursorDiskKV WHERE key = ?1",
+            [key],
+            |row| row.get::<_, SqlValue>(0),
+        )
+        .optional()?;
+    Ok(match value {
+        Some(SqlValue::Text(text)) => Some(text),
+        Some(SqlValue::Blob(bytes)) => Some(String::from_utf8_lossy(&bytes).into_owned()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+    struct Fixture {
+        root: PathBuf,
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn fixture(name: &str) -> AppResult<Fixture> {
+        let root = std::env::temp_dir().join(format!(
+            "cc-sessions-cursor-transfer-{name}-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(root.join("globalStorage"))?;
+        let connection = Connection::open(cursor_sessions::state_db_path(&root))?;
+        connection.execute_batch(
+            "CREATE TABLE composerHeaders (composerId TEXT PRIMARY KEY, workspaceId TEXT,
+                createdAt INTEGER, lastUpdatedAt INTEGER, isArchived INTEGER,
+                isSubagent INTEGER, recency INTEGER, checkpointAt INTEGER, value TEXT);
+             CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);
+             CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value BLOB);",
+        )?;
+        connection.execute(
+            "INSERT INTO composerHeaders VALUES ('s1', 'ws', 1000, 2000, 0, 0, 2000, NULL, ?1)",
+            [json!({
+                "name": "会话",
+                "workspaceIdentifier": {"uri": {"fsPath": "/work/demo"}}
+            })
+            .to_string()],
+        )?;
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES ('composerData:s1', ?1)",
+            [
+                json!({"fullConversationHeadersOnly": [{"bubbleId": "b1"}, {"bubbleId": "b2"}]})
+                    .to_string(),
+            ],
+        )?;
+        for (bubble, text) in [("b1", "第一条"), ("b2", "第二条")] {
+            connection.execute(
+                "INSERT INTO cursorDiskKV VALUES (?1, ?2)",
+                rusqlite::params![
+                    format!("bubbleId:s1:{bubble}"),
+                    json!({"type": 1, "text": text}).to_string()
+                ],
+            )?;
+        }
+        // 另一个会话的数据，导入导出都不能碰。
+        connection.execute(
+            "INSERT INTO cursorDiskKV VALUES ('bubbleId:s2:b1', ?1)",
+            [json!({"type": 1, "text": "别人的"}).to_string()],
+        )?;
+        connection.execute("INSERT INTO ItemTable VALUES ('secret', 'token')", [])?;
+        drop(connection);
+        Ok(Fixture { root })
+    }
+
+    #[test]
+    fn a_snapshot_carries_only_the_session_it_names() -> AppResult<()> {
+        let fixture = fixture("export")?;
+        let snapshot = export_snapshot(&fixture.root, "s1")?;
+        assert_eq!(snapshot.session_id, "s1");
+        assert_eq!(snapshot.source_cwd, "/work/demo");
+        assert_eq!(snapshot.source_updated_at, 2000);
+        assert_eq!(snapshot.bubbles.len(), 2);
+        // 快照里不该出现别的会话或 ItemTable 的内容。
+        let serialized = serde_json::to_string(&snapshot)?;
+        assert!(!serialized.contains("别人的"));
+        assert!(!serialized.contains("token"));
+        Ok(())
+    }
+
+    #[test]
+    fn importing_into_a_fresh_database_restores_the_conversation() -> AppResult<()> {
+        let source = fixture("import-src")?;
+        let target = fixture("import-dst")?;
+        let snapshot = export_snapshot(&source.root, "s1")?;
+
+        // 目标库先清掉这个会话，模拟"另一台机器上没有它"。
+        let connection = Connection::open(cursor_sessions::state_db_path(&target.root))?;
+        connection.execute("DELETE FROM composerHeaders WHERE composerId = 's1'", [])?;
+        connection.execute(
+            "DELETE FROM cursorDiskKV WHERE key LIKE 'bubbleId:s1:%'",
+            [],
+        )?;
+        connection.execute("DELETE FROM cursorDiskKV WHERE key = 'composerData:s1'", [])?;
+        drop(connection);
+
+        let _probe = crate::cursor_mutate::CursorRunningProbe::not_running();
+        assert!(import_snapshot(&target.root, &snapshot, false)?);
+
+        let connection = Connection::open(cursor_sessions::state_db_path(&target.root))?;
+        let name: String = connection.query_row(
+            "SELECT value FROM composerHeaders WHERE composerId = 's1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(name.contains("会话"));
+        let bubbles: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key LIKE 'bubbleId:s1:%'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(bubbles, 2);
+        // 目标库里别的会话不受影响。
+        let others: i64 = connection.query_row(
+            "SELECT COUNT(*) FROM cursorDiskKV WHERE key = 'bubbleId:s2:b1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(others, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn an_existing_session_is_kept_unless_overwrite_is_requested() -> AppResult<()> {
+        let fixture = fixture("import-existing")?;
+        let snapshot = export_snapshot(&fixture.root, "s1")?;
+        let _probe = crate::cursor_mutate::CursorRunningProbe::not_running();
+        assert!(!import_snapshot(&fixture.root, &snapshot, false)?);
+        assert!(import_snapshot(&fixture.root, &snapshot, true)?);
+        Ok(())
+    }
+
+    /// 覆盖导入要把旧气泡清干净，不能留下上一版的残留。
+    #[test]
+    fn overwriting_replaces_the_previous_bubbles() -> AppResult<()> {
+        let fixture = fixture("import-overwrite")?;
+        let mut snapshot = export_snapshot(&fixture.root, "s1")?;
+        snapshot.bubbles = vec![("b3".into(), json!({"type": 1, "text": "新的"}).to_string())];
+        snapshot.composer_data =
+            Some(json!({"fullConversationHeadersOnly": [{"bubbleId": "b3"}]}).to_string());
+
+        let _probe = crate::cursor_mutate::CursorRunningProbe::not_running();
+        assert!(import_snapshot(&fixture.root, &snapshot, true)?);
+
+        let connection = Connection::open(cursor_sessions::state_db_path(&fixture.root))?;
+        let keys: Vec<String> = connection
+            .prepare("SELECT key FROM cursorDiskKV WHERE key LIKE 'bubbleId:s1:%' ORDER BY key")?
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<_, _>>()?;
+        assert_eq!(keys, vec!["bubbleId:s1:b3"]);
+        Ok(())
+    }
+
+    #[test]
+    fn imports_are_refused_while_cursor_is_running() -> AppResult<()> {
+        let fixture = fixture("import-running")?;
+        let snapshot = export_snapshot(&fixture.root, "s1")?;
+        let _probe = crate::cursor_mutate::CursorRunningProbe::running();
+        assert!(import_snapshot(&fixture.root, &snapshot, true).is_err());
+        Ok(())
+    }
+
+    /// 会话 id 会拼进 LIKE 模式，`%` `_` 不能变成通配符。
+    #[test]
+    fn like_wildcards_in_session_ids_cannot_widen_the_delete() {
+        assert_eq!(escape_like("a%b_c"), "a\\%b\\_c");
+        assert_eq!(escape_like("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn snapshot_ids_are_rejected_when_they_could_break_out_of_a_key() {
+        assert!(validate_session_id("00000000-1111-2222-3333-444444444444").is_ok());
+        assert!(validate_session_id("a:b").is_err());
+        assert!(validate_session_id("a%b").is_err());
+        assert!(validate_session_id("../x").is_err());
+        assert!(validate_session_id("  ").is_err());
+    }
+}

--- a/src-tauri/src/fs_ops.rs
+++ b/src-tauri/src/fs_ops.rs
@@ -196,6 +196,9 @@ pub fn resume_command_text(
         "codex" => format!("codex resume {}", session_id),
         "claude" => claude_resume_command(&session_id, cwd.as_deref()),
         "opencode" => format!("opencode --session {}", session_id),
+        // Cursor 的 IDE 会话没有命令行入口；只有 cursor-agent 的会话可以续聊，
+        // 具体命令在 SessionSummary.resume_command 里按会话给出。
+        "cursor" => String::new(),
         other => return Err(AppError::Other(format!("不支持的 provider: {other}"))),
     };
     Ok(text)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,11 @@ pub mod codex_rollout_cwd;
 pub mod commands;
 pub mod content_search;
 pub mod convert;
+pub mod cursor_agent_store;
+pub mod cursor_blobs;
+pub mod cursor_mutate;
+pub mod cursor_sessions;
+pub mod cursor_transfer;
 pub mod edit;
 pub mod error;
 pub mod family;
@@ -74,9 +79,11 @@ pub fn run() {
             settings::default_codex_dir,
             settings::default_claude_dir,
             settings::default_opencode_dir,
+            settings::default_cursor_dir,
             settings::validate_codex_dir,
             settings::validate_claude_dir,
             settings::validate_opencode_dir,
+            settings::validate_cursor_dir,
             fs_ops::reveal_cwd,
             fs_ops::open_latest_release_page,
             fs_ops::copy_resume_command,
@@ -92,6 +99,9 @@ pub fn run() {
             commands::move_session_cwd,
             commands::delete_session,
             commands::delete_sessions,
+            commands::compact_cursor_database,
+            commands::diagnose_cursor_residue,
+            commands::prune_cursor_residue,
             commands::preview_session_head,
             commands::preview_session_range,
             commands::preview_session_user_prompts,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -9,6 +9,8 @@ pub struct Settings {
     pub claude_dir: String,
     #[serde(default = "default_opencode_dir")]
     pub opencode_dir: String,
+    #[serde(default = "default_cursor_dir")]
+    pub cursor_dir: String,
     pub backup_dir: String,
     #[serde(default = "default_open_cmd")]
     pub open_command: String,
@@ -37,6 +39,12 @@ fn default_opencode_dir() -> String {
         .into_owned()
 }
 
+fn default_cursor_dir() -> String {
+    crate::paths::default_cursor_dir()
+        .to_string_lossy()
+        .into_owned()
+}
+
 fn default_refresh_ms() -> u64 {
     5000
 }
@@ -46,11 +54,13 @@ impl Default for Settings {
         let codex = crate::paths::default_codex_dir();
         let claude = crate::paths::default_claude_dir();
         let opencode = crate::paths::default_opencode_dir();
+        let cursor = crate::paths::default_cursor_dir();
         let backup = crate::paths::default_backup_dir();
         Self {
             codex_dir: codex.to_string_lossy().into_owned(),
             claude_dir: claude.to_string_lossy().into_owned(),
             opencode_dir: opencode.to_string_lossy().into_owned(),
+            cursor_dir: cursor.to_string_lossy().into_owned(),
             backup_dir: backup.to_string_lossy().into_owned(),
             open_command: "auto".into(),
             refresh_interval_ms: 5000,
@@ -58,6 +68,66 @@ impl Default for Settings {
             preview_collapse_process: true,
         }
     }
+}
+
+/// 各 provider 的数据目录。
+///
+/// provider 每多一个，逐个透传目录就会让 `*_with_opencode` 这类函数变体组合爆炸。
+/// 统一收进一个结构体后，再加 provider 只需要多一个字段，调用点签名不必再改。
+/// 字段为 `None` 表示"用该 provider 的默认目录"。
+#[derive(Debug, Clone, Default)]
+pub struct ProviderDirs {
+    pub codex_dir: String,
+    pub claude_dir: Option<String>,
+    pub opencode_dir: Option<String>,
+    pub cursor_dir: Option<String>,
+    /// cursor-agent 的家目录。不在设置页暴露（一个 Cursor 目录已经够用），
+    /// 但必须可覆盖：否则任何走到 Cursor 分支的代码都会读到本机真实的 `~/.cursor`。
+    pub cursor_agent_dir: Option<String>,
+}
+
+impl ProviderDirs {
+    pub fn new(codex_dir: String) -> Self {
+        Self {
+            codex_dir,
+            ..Self::default()
+        }
+    }
+
+    pub fn codex_path(&self) -> std::path::PathBuf {
+        std::path::PathBuf::from(&self.codex_dir)
+    }
+
+    pub fn claude_path(&self) -> std::path::PathBuf {
+        resolve(&self.claude_dir, crate::paths::default_claude_dir)
+    }
+
+    pub fn opencode_path(&self) -> std::path::PathBuf {
+        resolve(&self.opencode_dir, crate::paths::default_opencode_dir)
+    }
+
+    pub fn cursor_path(&self) -> std::path::PathBuf {
+        resolve(&self.cursor_dir, crate::paths::default_cursor_dir)
+    }
+
+    pub fn cursor_agent_path(&self) -> std::path::PathBuf {
+        resolve(
+            &self.cursor_agent_dir,
+            crate::paths::default_cursor_agent_dir,
+        )
+    }
+}
+
+fn resolve(
+    configured: &Option<String>,
+    fallback: fn() -> std::path::PathBuf,
+) -> std::path::PathBuf {
+    configured
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(fallback)
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -891,6 +961,57 @@ pub struct SetArchiveOriginReport {
     pub origin: ArchiveOrigin,
     /// 是否同时同步了 family 分支的 archive_origin 字段（会话不在任何 family 时为 false）
     pub family_synced: bool,
+}
+
+/// Cursor 数据库里一类可清理的残留。
+#[derive(Debug, Clone, Serialize)]
+pub struct CursorResidueGroup {
+    /// 稳定标识，前端按它决定清理哪几类。
+    pub kind: String,
+    pub label: String,
+    pub description: String,
+    /// 涉及的会话数。
+    pub sessions: u32,
+    /// 涉及的 cursorDiskKV 行数。
+    pub rows: u32,
+    /// 这些行占用的字节数；未统计时为 0。
+    pub bytes: u64,
+    /// 删掉会丢失真实对话内容，前端必须额外确认。
+    pub destructive: bool,
+    /// 少量样例，让用户能判断该不该删。
+    pub samples: Vec<CursorResidueSample>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CursorResidueSample {
+    pub id: String,
+    pub title: String,
+    pub cwd: String,
+    pub bubbles: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CursorResidueReport {
+    pub database_path: String,
+    pub database_bytes: u64,
+    /// `composerHeaders` 总行数。
+    pub header_rows: u32,
+    /// 列表里真正能看到的会话数。
+    pub visible_sessions: u32,
+    pub groups: Vec<CursorResidueGroup>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CursorPruneReport {
+    pub database_path: String,
+    pub dry_run: bool,
+    pub removed_header_rows: u32,
+    pub removed_kv_rows: u32,
+    /// 从库里释放出来的字节数。磁盘占用要另外执行"压缩数据库"才会真正回落。
+    pub freed_bytes: u64,
+    pub kinds: Vec<String>,
+    /// 内容块可达性扫描中读不出来的行数。不为 0 时这一类会被整体跳过，其余照常清理。
+    pub blob_scan_errors: u32,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -137,6 +137,42 @@ pub fn default_opencode_dir() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(".local/share/opencode"))
 }
 
+/// Cursor IDE 的用户数据目录，即 VS Code 系的 `<config>/Cursor/User`。
+///
+/// `dirs::config_dir()` 在三个平台上恰好给出 Cursor 使用的父目录：
+/// macOS `~/Library/Application Support`、Windows `%APPDATA%`、Linux `~/.config`。
+/// 会话主体存放在其下的 `globalStorage/state.vscdb`。
+pub fn default_cursor_dir() -> PathBuf {
+    dirs::config_dir()
+        .map(|config| config.join("Cursor").join("User"))
+        .unwrap_or_else(|| PathBuf::from("Cursor/User"))
+}
+
+/// cursor-agent CLI 的家目录 `~/.cursor`，与 IDE 数据目录相互独立。
+///
+/// 只有 `chats/` 子目录里的会话对本工具有意义；`projects/*/agent-transcripts/`
+/// 是同一批会话的有损展示副本（无工具结果、无时间戳），刻意不读。
+pub fn default_cursor_agent_dir() -> PathBuf {
+    dirs::home_dir()
+        .map(|home| home.join(".cursor"))
+        .unwrap_or_else(|| PathBuf::from(".cursor"))
+}
+
+/// Cursor IDE 的会话数据库。
+pub fn cursor_state_db_path(cursor_dir: &Path) -> PathBuf {
+    cursor_dir.join("globalStorage").join("state.vscdb")
+}
+
+/// VS Code 系的工作区元数据目录，用于把 `workspaceId` 回查成项目路径。
+pub fn cursor_workspace_storage_dir(cursor_dir: &Path) -> PathBuf {
+    cursor_dir.join("workspaceStorage")
+}
+
+/// cursor-agent 的会话根目录，布局为 `chats/<md5(cwd)>/<agentId>/`。
+pub fn cursor_agent_chats_dir(agent_dir: &Path) -> PathBuf {
+    agent_dir.join("chats")
+}
+
 pub fn default_backup_dir() -> PathBuf {
     let cc_root = default_codex_dir();
     cc_root

--- a/src-tauri/src/provenance.rs
+++ b/src-tauri/src/provenance.rs
@@ -84,8 +84,9 @@ pub fn record_conversion(
     conversion_mode: Option<&str>,
 ) -> AppResult<()> {
     if codex_dir.as_os_str().is_empty()
+        // 目标只可能是 codex 或 claude；来源还可以是 Cursor（只出不进）。
         || !matches!(target_provider, "codex" | "claude")
-        || !matches!(source_provider, "codex" | "claude")
+        || !matches!(source_provider, "codex" | "claude" | "cursor")
         || target_id.trim().is_empty()
         || source_id.trim().is_empty()
     {

--- a/src-tauri/src/rollout.rs
+++ b/src-tauri/src/rollout.rs
@@ -448,6 +448,7 @@ fn preview_range_by_provider(
         "codex" => preview_range_impl(path, offset, limit),
         "claude" => crate::claude_sessions::preview_range(path, offset, limit),
         "opencode" => crate::opencode_sessions::preview_range(path, offset, limit),
+        "cursor" => crate::cursor_sessions::preview_range(path, offset, limit),
         other => Err(crate::error::AppError::Other(format!(
             "不支持的 provider: {other}"
         ))),
@@ -508,6 +509,7 @@ pub fn preview_session_user_prompts(
             claude_event_is_agent_activity,
         ),
         "opencode" => crate::opencode_sessions::preview_user_prompts(&rollout_path),
+        "cursor" => crate::cursor_sessions::preview_user_prompts(&rollout_path),
         other => Err(crate::error::AppError::Other(format!(
             "不支持的 provider: {other}"
         ))),
@@ -821,6 +823,7 @@ pub fn preview_session_meta(
     match provider.as_deref().unwrap_or("codex") {
         "claude" => return crate::claude_sessions::preview_meta(&rollout_path),
         "opencode" => return crate::opencode_sessions::preview_meta(&rollout_path),
+        "cursor" => return crate::cursor_sessions::preview_meta(&rollout_path),
         "codex" => {}
         other => {
             return Err(crate::error::AppError::Other(format!(

--- a/src-tauri/src/sessions.rs
+++ b/src-tauri/src/sessions.rs
@@ -12,7 +12,8 @@ use crate::family;
 use crate::history;
 use crate::logs_db;
 use crate::models::{
-    ArchiveOrigin, DeleteResult, DeleteTarget, MoveSessionCwdReport, ProjectGroup, SessionSummary,
+    ArchiveOrigin, DeleteResult, DeleteTarget, MoveSessionCwdReport, ProjectGroup, ProviderDirs,
+    SessionSummary,
 };
 use crate::paths;
 use crate::provenance;
@@ -280,7 +281,14 @@ pub fn list_sessions(
     codex_dir: String,
     claude_dir: Option<String>,
 ) -> AppResult<Vec<SessionSummary>> {
-    list_sessions_with_opencode(provider, codex_dir, claude_dir, None)
+    list_sessions_with_dirs(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            ..ProviderDirs::default()
+        },
+    )
 }
 
 pub fn list_sessions_with_opencode(
@@ -289,7 +297,22 @@ pub fn list_sessions_with_opencode(
     claude_dir: Option<String>,
     opencode_dir: Option<String>,
 ) -> AppResult<Vec<SessionSummary>> {
-    list_sessions_impl(provider, codex_dir, claude_dir, opencode_dir, None)
+    list_sessions_with_dirs(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            opencode_dir,
+            ..ProviderDirs::default()
+        },
+    )
+}
+
+pub fn list_sessions_with_dirs(
+    provider: Option<String>,
+    dirs: ProviderDirs,
+) -> AppResult<Vec<SessionSummary>> {
+    list_sessions_impl(provider, dirs, None)
 }
 
 pub fn list_sessions_cancellable(
@@ -298,28 +321,32 @@ pub fn list_sessions_cancellable(
     claude_dir: Option<String>,
     cancel: &AtomicBool,
 ) -> AppResult<Vec<SessionSummary>> {
-    list_sessions_impl(provider, codex_dir, claude_dir, None, Some(cancel))
+    list_sessions_impl(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            ..ProviderDirs::default()
+        },
+        Some(cancel),
+    )
 }
 
-pub fn list_sessions_cancellable_with_opencode(
+pub fn list_sessions_cancellable_with_dirs(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     cancel: &AtomicBool,
 ) -> AppResult<Vec<SessionSummary>> {
-    list_sessions_impl(provider, codex_dir, claude_dir, opencode_dir, Some(cancel))
+    list_sessions_impl(provider, dirs, Some(cancel))
 }
 
 fn list_sessions_impl(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     cancel: Option<&AtomicBool>,
 ) -> AppResult<Vec<SessionSummary>> {
     ensure_not_cancelled(cancel)?;
-    let codex = PathBuf::from(&codex_dir);
+    let codex = dirs.codex_path();
     match provider_or_codex(provider).as_str() {
         "codex" => {
             let mut list = query_summaries(&codex, "", &[], cancel)?;
@@ -336,10 +363,7 @@ fn list_sessions_impl(
             Ok(list)
         }
         "claude" => {
-            let p = PathBuf::from(
-                claude_dir
-                    .unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned()),
-            );
+            let p = dirs.claude_path();
             let mut list = match cancel {
                 Some(cancel) => crate::claude_sessions::scan_sessions_cancellable(&p, cancel)?,
                 None => crate::claude_sessions::scan_sessions(&p)?,
@@ -349,11 +373,16 @@ fn list_sessions_impl(
             Ok(list)
         }
         "opencode" => {
-            let data_dir =
-                PathBuf::from(opencode_dir.unwrap_or_else(|| {
-                    paths::default_opencode_dir().to_string_lossy().into_owned()
-                }));
-            let mut list = crate::opencode_sessions::list_sessions(&data_dir)?;
+            let mut list = crate::opencode_sessions::list_sessions(&dirs.opencode_path())?;
+            provenance::annotate_sessions(&codex, &mut list);
+            Ok(list)
+        }
+        "cursor" => {
+            let mut list = crate::cursor_sessions::list_sessions(
+                &dirs.cursor_path(),
+                &dirs.cursor_agent_path(),
+            )?;
+            ensure_not_cancelled(cancel)?;
             provenance::annotate_sessions(&codex, &mut list);
             Ok(list)
         }
@@ -434,16 +463,21 @@ pub fn group_sessions_by_project(
     codex_dir: String,
     claude_dir: Option<String>,
 ) -> AppResult<Vec<ProjectGroup>> {
-    group_sessions_by_project_with_opencode(provider, codex_dir, claude_dir, None)
+    group_sessions_by_project_with_dirs(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            ..ProviderDirs::default()
+        },
+    )
 }
 
-pub fn group_sessions_by_project_with_opencode(
+pub fn group_sessions_by_project_with_dirs(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
 ) -> AppResult<Vec<ProjectGroup>> {
-    let list = list_sessions_with_opencode(provider, codex_dir, claude_dir, opencode_dir)?;
+    let list = list_sessions_with_dirs(provider, dirs)?;
     let mut groups: HashMap<String, ProjectGroup> = HashMap::new();
     for s in list {
         let key = s.cwd.clone();
@@ -472,21 +506,27 @@ pub fn search_sessions(
     claude_dir: Option<String>,
     query: String,
 ) -> AppResult<Vec<SessionSummary>> {
-    search_sessions_with_opencode(provider, codex_dir, claude_dir, None, query)
+    search_sessions_with_dirs(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            ..ProviderDirs::default()
+        },
+        query,
+    )
 }
 
-pub fn search_sessions_with_opencode(
+pub fn search_sessions_with_dirs(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     query: String,
 ) -> AppResult<Vec<SessionSummary>> {
     let q = query.trim();
     if q.is_empty() {
-        return list_sessions_with_opencode(provider, codex_dir, claude_dir, opencode_dir);
+        return list_sessions_with_dirs(provider, dirs);
     }
-    let all = list_sessions_with_opencode(provider, codex_dir, claude_dir, opencode_dir)?;
+    let all = list_sessions_with_dirs(provider, dirs)?;
     let low = q.to_lowercase();
 
     // 前缀/过滤：id: cwd: model: archived:
@@ -570,26 +610,22 @@ pub fn set_archived_with_lock(
     v: bool,
     lock: &family::FamilyLock,
 ) -> AppResult<()> {
-    set_archived_with_provider_dir(provider, codex_dir, None, id, v, lock)
+    set_archived_with_dirs(provider, ProviderDirs::new(codex_dir), id, v, lock)
 }
 
-pub fn set_archived_with_provider_dir(
+pub fn set_archived_with_dirs(
     provider: Option<String>,
-    codex_dir: String,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     id: String,
     v: bool,
     lock: &family::FamilyLock,
 ) -> AppResult<()> {
     match provider_or_codex(provider).as_str() {
-        "codex" => family::with_lock(lock, |_guard| set_archived_codex_locked(codex_dir, id, v)),
-        "opencode" => {
-            let data_dir =
-                PathBuf::from(opencode_dir.unwrap_or_else(|| {
-                    paths::default_opencode_dir().to_string_lossy().into_owned()
-                }));
-            crate::opencode_sessions::set_archived(&data_dir, &id, v)
-        }
+        "codex" => family::with_lock(lock, |_guard| {
+            set_archived_codex_locked(dirs.codex_dir, id, v)
+        }),
+        "opencode" => crate::opencode_sessions::set_archived(&dirs.opencode_path(), &id, v),
+        "cursor" => crate::cursor_mutate::set_archived(&dirs, &id, v),
         "claude" => Err(AppError::Other("Claude 会话不支持归档".into())),
         other => Err(AppError::Other(format!("不支持的 provider: {other}"))),
     }
@@ -606,22 +642,9 @@ pub fn rename_session_with_lock(
     title: String,
     lock: &family::FamilyLock,
 ) -> AppResult<u32> {
-    rename_session_with_provider_dir(provider, codex_dir, None, id, title, lock)
-}
-
-pub fn rename_session_with_provider_dir(
-    provider: Option<String>,
-    codex_dir: String,
-    opencode_dir: Option<String>,
-    id: String,
-    title: String,
-    lock: &family::FamilyLock,
-) -> AppResult<u32> {
-    rename_session_with_provider_dirs(
+    rename_session_with_dirs(
         provider,
-        codex_dir,
-        None,
-        opencode_dir,
+        ProviderDirs::new(codex_dir),
         id,
         None,
         title,
@@ -629,31 +652,28 @@ pub fn rename_session_with_provider_dir(
     )
 }
 
-pub fn rename_session_with_provider_dirs(
+pub fn rename_session_with_dirs(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     id: String,
     rollout_path: Option<String>,
     title: String,
     lock: &family::FamilyLock,
 ) -> AppResult<u32> {
     let provider = provider_or_codex(provider);
+    let codex_dir = dirs.codex_dir.clone();
     if provider == "opencode" {
-        let data_dir = PathBuf::from(
-            opencode_dir
-                .unwrap_or_else(|| paths::default_opencode_dir().to_string_lossy().into_owned()),
-        );
         return family::with_lock(lock, |_guard| {
-            crate::opencode_sessions::rename_session(&data_dir, &id, &title)
+            crate::opencode_sessions::rename_session(&dirs.opencode_path(), &id, &title)
+        });
+    }
+    if provider == "cursor" {
+        return family::with_lock(lock, |_guard| {
+            crate::cursor_mutate::rename_session(&dirs, &id, &title)
         });
     }
     if provider == "claude" {
-        let claude = PathBuf::from(
-            claude_dir
-                .unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned()),
-        );
+        let claude = dirs.claude_path();
         return family::with_lock(lock, |_guard| {
             crate::claude_transfer::rename_session(&claude, &id, rollout_path.as_deref(), &title)
         });
@@ -1477,14 +1497,22 @@ pub fn delete_session_with_lock(
     target: Option<DeleteTarget>,
     lock: &family::FamilyLock,
 ) -> AppResult<DeleteResult> {
-    delete_session_with_provider_dir(provider, codex_dir, claude_dir, None, id, target, lock)
+    delete_session_with_dirs(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            ..ProviderDirs::default()
+        },
+        id,
+        target,
+        lock,
+    )
 }
 
-pub fn delete_session_with_provider_dir(
+pub fn delete_session_with_dirs(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     id: String,
     target: Option<DeleteTarget>,
     lock: &family::FamilyLock,
@@ -1504,24 +1532,15 @@ pub fn delete_session_with_provider_dir(
     };
     match provider_or_codex(provider).as_str() {
         "codex" => family::with_lock(lock, |_guard| {
-            delete_codex_targets_locked(Path::new(&codex_dir), vec![target])?
+            delete_codex_targets_locked(&dirs.codex_path(), vec![target])?
                 .pop()
                 .ok_or_else(|| AppError::Other("Codex 删除未返回结果".to_string()))
         }),
-        "claude" => {
-            let dir = claude_dir
-                .unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned());
-            delete_claude_targets(Path::new(&dir), vec![target])?
-                .pop()
-                .ok_or_else(|| AppError::Other("Claude 删除未返回结果".to_string()))
-        }
-        "opencode" => {
-            let dir =
-                PathBuf::from(opencode_dir.unwrap_or_else(|| {
-                    paths::default_opencode_dir().to_string_lossy().into_owned()
-                }));
-            crate::opencode_sessions::delete_session(&dir, &target.id)
-        }
+        "claude" => delete_claude_targets(&dirs.claude_path(), vec![target])?
+            .pop()
+            .ok_or_else(|| AppError::Other("Claude 删除未返回结果".to_string())),
+        "opencode" => crate::opencode_sessions::delete_session(&dirs.opencode_path(), &target.id),
+        "cursor" => crate::cursor_mutate::delete_session(&dirs, &target.id),
         other => Err(AppError::Other(format!("不支持的 provider: {other}"))),
     }
 }
@@ -1534,14 +1553,22 @@ pub fn delete_sessions_with_lock(
     targets: Option<Vec<DeleteTarget>>,
     lock: &family::FamilyLock,
 ) -> AppResult<Vec<DeleteResult>> {
-    delete_sessions_with_provider_dir(provider, codex_dir, claude_dir, None, ids, targets, lock)
+    delete_sessions_with_dirs(
+        provider,
+        ProviderDirs {
+            codex_dir,
+            claude_dir,
+            ..ProviderDirs::default()
+        },
+        ids,
+        targets,
+        lock,
+    )
 }
 
-pub fn delete_sessions_with_provider_dir(
+pub fn delete_sessions_with_dirs(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     ids: Vec<String>,
     targets: Option<Vec<DeleteTarget>>,
     lock: &family::FamilyLock,
@@ -1571,24 +1598,25 @@ pub fn delete_sessions_with_provider_dir(
     };
     match provider_or_codex(provider).as_str() {
         "codex" => family::with_lock(lock, |_guard| {
-            delete_codex_targets_locked(Path::new(&codex_dir), targets)
+            delete_codex_targets_locked(&dirs.codex_path(), targets)
         }),
-        "claude" => {
-            let dir = PathBuf::from(
-                claude_dir
-                    .unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned()),
-            );
-            delete_claude_targets(&dir, targets)
-        }
+        "claude" => delete_claude_targets(&dirs.claude_path(), targets),
         "opencode" => {
-            let dir =
-                PathBuf::from(opencode_dir.unwrap_or_else(|| {
-                    paths::default_opencode_dir().to_string_lossy().into_owned()
-                }));
+            let dir = dirs.opencode_path();
             Ok(targets
                 .into_iter()
                 .map(|target| {
                     crate::opencode_sessions::delete_session(&dir, &target.id)
+                        .unwrap_or_else(|error| failed_delete_result(&target, error.to_string()))
+                })
+                .collect())
+        }
+        "cursor" => {
+            // 逐个删：Cursor 在跑时守卫会让第一个就失败，逐条上报比整批中断清楚。
+            Ok(targets
+                .into_iter()
+                .map(|target| {
+                    crate::cursor_mutate::delete_session(&dirs, &target.id)
                         .unwrap_or_else(|error| failed_delete_result(&target, error.to_string()))
                 })
                 .collect())

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -194,6 +194,11 @@ pub fn default_opencode_dir() -> String {
 }
 
 #[cfg_attr(feature = "desktop", tauri::command)]
+pub fn default_cursor_dir() -> String {
+    paths::default_cursor_dir().to_string_lossy().into_owned()
+}
+
+#[cfg_attr(feature = "desktop", tauri::command)]
 pub fn validate_codex_dir(path: String) -> AppResult<DirValidation> {
     let p = PathBuf::from(&path);
     let (exists, has_state, has_sessions) = paths::validate_codex_dir(&p);
@@ -236,6 +241,21 @@ pub fn validate_opencode_dir(path: String) -> AppResult<DirValidation> {
         valid: data_dir.is_dir() && database.is_file(),
         has_state_db: database.is_file(),
         has_sessions: database.is_file(),
+        threads_count: count,
+    })
+}
+
+/// Cursor 的会话分散在 IDE 数据库与 cursor-agent 目录两处，任一处有会话即视为可用。
+#[cfg_attr(feature = "desktop", tauri::command)]
+pub fn validate_cursor_dir(path: String) -> AppResult<DirValidation> {
+    let cursor_dir = PathBuf::from(&path);
+    let agent_dir = paths::default_cursor_agent_dir();
+    let database = crate::cursor_sessions::state_db_path(&cursor_dir);
+    let count = crate::cursor_sessions::validate_data_dir(&cursor_dir, &agent_dir)?;
+    Ok(DirValidation {
+        valid: count > 0 || database.is_file(),
+        has_state_db: database.is_file(),
+        has_sessions: count > 0,
         threads_count: count,
     })
 }

--- a/src-tauri/src/stats.rs
+++ b/src-tauri/src/stats.rs
@@ -4,48 +4,44 @@ use std::path::PathBuf;
 use chrono::{Datelike, Duration, TimeZone, Timelike, Utc};
 
 use crate::error::{AppError, AppResult};
-use crate::models::{Kpi, ModelStat, ProjectStat, SessionSummary, StatsSnapshot, TimeseriesPoint};
-use crate::paths;
+use crate::models::{
+    Kpi, ModelStat, ProjectStat, ProviderDirs, SessionSummary, StatsSnapshot, TimeseriesPoint,
+};
 
 fn provider_or_codex(provider: Option<String>) -> String {
     provider.unwrap_or_else(|| "codex".to_string())
 }
 
-fn claude_root(claude_dir: Option<String>) -> PathBuf {
-    PathBuf::from(
-        claude_dir.unwrap_or_else(|| paths::default_claude_dir().to_string_lossy().into_owned()),
-    )
-}
-
-fn opencode_root(opencode_dir: Option<String>) -> PathBuf {
-    PathBuf::from(
-        opencode_dir
-            .unwrap_or_else(|| paths::default_opencode_dir().to_string_lossy().into_owned()),
-    )
-}
-
-fn load_sessions(
-    provider: &str,
-    codex_dir: &str,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
-) -> AppResult<Vec<SessionSummary>> {
+fn load_sessions(provider: &str, dirs: &ProviderDirs) -> AppResult<Vec<SessionSummary>> {
     match provider {
-        "codex" => {
-            crate::sessions::list_sessions(Some("codex".into()), codex_dir.to_string(), claude_dir)
+        "codex" => crate::sessions::list_sessions(
+            Some("codex".into()),
+            dirs.codex_dir.clone(),
+            dirs.claude_dir.clone(),
+        ),
+        "claude" => crate::claude_sessions::scan_sessions(&dirs.claude_path()),
+        "opencode" => crate::opencode_sessions::list_sessions(&dirs.opencode_path()),
+        "cursor" => {
+            crate::cursor_sessions::list_sessions(&dirs.cursor_path(), &dirs.cursor_agent_path())
         }
-        "claude" => crate::claude_sessions::scan_sessions(&claude_root(claude_dir)),
-        "opencode" => crate::opencode_sessions::list_sessions(&opencode_root(opencode_dir)),
         "all" => {
             let mut out =
-                crate::sessions::list_sessions(Some("codex".into()), codex_dir.to_string(), None)?;
-            out.extend(crate::claude_sessions::scan_sessions(&claude_root(
-                claude_dir,
-            ))?);
-            // 没装 / 没配 OpenCode 时按"零会话"处理，不让缺少 opencode.db 拖垮整块统计。
-            let opencode = opencode_root(opencode_dir);
+                crate::sessions::list_sessions(Some("codex".into()), dirs.codex_dir.clone(), None)?;
+            out.extend(crate::claude_sessions::scan_sessions(&dirs.claude_path())?);
+            // 没装 / 没配某个 Agent 时按"零会话"处理，不让它拖垮整块统计。
+            let opencode = dirs.opencode_path();
             if crate::opencode_sessions::database_path(&opencode).is_file() {
                 out.extend(crate::opencode_sessions::list_sessions(&opencode)?);
+            }
+            let cursor = dirs.cursor_path();
+            let cursor_agent = dirs.cursor_agent_path();
+            if crate::cursor_sessions::state_db_path(&cursor).is_file()
+                || crate::paths::cursor_agent_chats_dir(&cursor_agent).is_dir()
+            {
+                out.extend(crate::cursor_sessions::list_sessions(
+                    &cursor,
+                    &cursor_agent,
+                )?);
             }
             Ok(out)
         }
@@ -103,17 +99,15 @@ fn filter_family_active_sessions(
 
 fn stat_sessions(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     from_ts: Option<i64>,
     to_ts: Option<i64>,
     cwd_filter: Vec<String>,
     include_archived: bool,
 ) -> AppResult<Vec<SessionSummary>> {
     let provider = provider_or_codex(provider);
-    let sessions = load_sessions(&provider, &codex_dir, claude_dir, opencode_dir)?;
-    let sessions = filter_family_active_sessions(sessions, &codex_dir)?;
+    let sessions = load_sessions(&provider, &dirs)?;
+    let sessions = filter_family_active_sessions(sessions, &dirs.codex_dir)?;
     Ok(filter_sessions(
         sessions,
         from_ts,
@@ -125,24 +119,13 @@ fn stat_sessions(
 
 pub fn stats_kpi(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     from_ts: Option<i64>,
     to_ts: Option<i64>,
     cwd_filter: Vec<String>,
     include_archived: bool,
 ) -> AppResult<Kpi> {
-    let sessions = stat_sessions(
-        provider,
-        codex_dir,
-        claude_dir,
-        opencode_dir,
-        from_ts,
-        to_ts,
-        cwd_filter,
-        include_archived,
-    )?;
+    let sessions = stat_sessions(provider, dirs, from_ts, to_ts, cwd_filter, include_archived)?;
     Ok(build_kpi(&sessions))
 }
 
@@ -169,25 +152,14 @@ fn build_kpi(sessions: &[SessionSummary]) -> Kpi {
 
 pub fn stats_timeseries(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     from_ts: Option<i64>,
     to_ts: Option<i64>,
     bucket: String,
     cwd_filter: Vec<String>,
     include_archived: bool,
 ) -> AppResult<Vec<TimeseriesPoint>> {
-    let sessions = stat_sessions(
-        provider,
-        codex_dir,
-        claude_dir,
-        opencode_dir,
-        from_ts,
-        to_ts,
-        cwd_filter,
-        include_archived,
-    )?;
+    let sessions = stat_sessions(provider, dirs, from_ts, to_ts, cwd_filter, include_archived)?;
     Ok(build_timeseries(&sessions, &bucket))
 }
 
@@ -210,25 +182,14 @@ fn build_timeseries(sessions: &[SessionSummary], bucket: &str) -> Vec<Timeseries
 
 pub fn stats_by_project(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     from_ts: Option<i64>,
     to_ts: Option<i64>,
     limit: usize,
     cwd_filter: Vec<String>,
     include_archived: bool,
 ) -> AppResult<Vec<ProjectStat>> {
-    let sessions = stat_sessions(
-        provider,
-        codex_dir,
-        claude_dir,
-        opencode_dir,
-        from_ts,
-        to_ts,
-        cwd_filter,
-        include_archived,
-    )?;
+    let sessions = stat_sessions(provider, dirs, from_ts, to_ts, cwd_filter, include_archived)?;
     Ok(build_by_project(&sessions, limit))
 }
 
@@ -258,24 +219,13 @@ fn build_by_project(sessions: &[SessionSummary], limit: usize) -> Vec<ProjectSta
 
 pub fn stats_by_model(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     from_ts: Option<i64>,
     to_ts: Option<i64>,
     cwd_filter: Vec<String>,
     include_archived: bool,
 ) -> AppResult<Vec<ModelStat>> {
-    let sessions = stat_sessions(
-        provider,
-        codex_dir,
-        claude_dir,
-        opencode_dir,
-        from_ts,
-        to_ts,
-        cwd_filter,
-        include_archived,
-    )?;
+    let sessions = stat_sessions(provider, dirs, from_ts, to_ts, cwd_filter, include_archived)?;
     Ok(build_by_model(&sessions))
 }
 
@@ -309,24 +259,13 @@ fn build_by_model(sessions: &[SessionSummary]) -> Vec<ModelStat> {
 
 pub fn stats_heatmap(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     from_ts: Option<i64>,
     to_ts: Option<i64>,
     cwd_filter: Vec<String>,
     include_archived: bool,
 ) -> AppResult<Vec<Vec<u32>>> {
-    let sessions = stat_sessions(
-        provider,
-        codex_dir,
-        claude_dir,
-        opencode_dir,
-        from_ts,
-        to_ts,
-        cwd_filter,
-        include_archived,
-    )?;
+    let sessions = stat_sessions(provider, dirs, from_ts, to_ts, cwd_filter, include_archived)?;
     Ok(build_heatmap(&sessions))
 }
 
@@ -346,9 +285,7 @@ fn build_heatmap(sessions: &[SessionSummary]) -> Vec<Vec<u32>> {
 
 pub fn stats_snapshot(
     provider: Option<String>,
-    codex_dir: String,
-    claude_dir: Option<String>,
-    opencode_dir: Option<String>,
+    dirs: ProviderDirs,
     from_ts: Option<i64>,
     to_ts: Option<i64>,
     bucket: String,
@@ -356,16 +293,7 @@ pub fn stats_snapshot(
     cwd_filter: Vec<String>,
     include_archived: bool,
 ) -> AppResult<StatsSnapshot> {
-    let sessions = stat_sessions(
-        provider,
-        codex_dir,
-        claude_dir,
-        opencode_dir,
-        from_ts,
-        to_ts,
-        cwd_filter,
-        include_archived,
-    )?;
+    let sessions = stat_sessions(provider, dirs, from_ts, to_ts, cwd_filter, include_archived)?;
     Ok(StatsSnapshot {
         kpi: build_kpi(&sessions),
         timeseries: build_timeseries(&sessions, &bucket),
@@ -501,35 +429,79 @@ mod tests {
         Ok(())
     }
 
+    fn create_cursor_session(cursor: &Path) -> AppResult<()> {
+        let storage = cursor.join("globalStorage");
+        fs::create_dir_all(&storage)?;
+        let conn = rusqlite::Connection::open(storage.join("state.vscdb"))?;
+        conn.execute_batch(
+            "CREATE TABLE composerHeaders (composerId TEXT PRIMARY KEY, workspaceId TEXT,
+                createdAt INTEGER, lastUpdatedAt INTEGER, isArchived INTEGER,
+                isSubagent INTEGER, recency INTEGER, checkpointAt INTEGER, value TEXT);
+             CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);",
+        )?;
+        conn.execute(
+            "INSERT INTO composerHeaders VALUES ('cur_stats', 'ws', 1770000000000, 1770000900000, 0, 0, 1770000900000, NULL, ?1)",
+            [serde_json::json!({
+                "name": "Cursor title",
+                "workspaceIdentifier": {"uri": {"fsPath": "/work/cursor-project"}}
+            })
+            .to_string()],
+        )?;
+        // 没有气泡的会话会被列表过滤掉，夹具必须给一条真实内容。
+        conn.execute(
+            "INSERT INTO cursorDiskKV VALUES ('composerData:cur_stats', ?1)",
+            [
+                serde_json::json!({"fullConversationHeadersOnly": [{"bubbleId": "b1", "type": 1}]})
+                    .to_string(),
+            ],
+        )?;
+        conn.execute(
+            "INSERT INTO cursorDiskKV VALUES ('bubbleId:cur_stats:b1', ?1)",
+            [serde_json::json!({"type": 1, "text": "问题"}).to_string()],
+        )?;
+        Ok(())
+    }
+
+    /// 测试必须显式给出每个目录：`ProviderDirs` 的字段留空会回退到本机真实目录，
+    /// 那样统计断言会被开发机上的真实会话污染。
+    fn stats_dirs(root: &Path) -> ProviderDirs {
+        ProviderDirs {
+            codex_dir: root.join("codex").to_string_lossy().into_owned(),
+            claude_dir: Some(root.join("claude").to_string_lossy().into_owned()),
+            opencode_dir: Some(root.join("opencode").to_string_lossy().into_owned()),
+            cursor_dir: Some(root.join("cursor").to_string_lossy().into_owned()),
+            cursor_agent_dir: Some(root.join("cursor-agent").to_string_lossy().into_owned()),
+        }
+    }
+
     #[test]
     fn aggregates_codex_claude_and_opencode_stats() -> AppResult<()> {
         let root = temp_dir("cc-session-manager-stats-test");
         let codex = root.join("codex");
         let claude = root.join("claude");
         let opencode = root.join("opencode");
+        let cursor = root.join("cursor");
         create_codex_session(&codex)?;
         create_claude_session(&claude)?;
         create_opencode_session(&opencode)?;
+        create_cursor_session(&cursor)?;
+        let dirs = stats_dirs(&root);
 
         let kpi = stats_kpi(
             Some("all".to_string()),
-            codex.to_string_lossy().into_owned(),
-            Some(claude.to_string_lossy().into_owned()),
-            Some(opencode.to_string_lossy().into_owned()),
+            dirs.clone(),
             None,
             None,
             Vec::new(),
             false,
         )?;
-        assert_eq!(kpi.sessions_total, 3);
+        assert_eq!(kpi.sessions_total, 4);
         assert_eq!(kpi.tokens_total, 41);
-        assert_eq!(kpi.active_projects, 3);
+        assert_eq!(kpi.active_projects, 4);
 
         let snapshot = stats_snapshot(
             Some("all".to_string()),
-            codex.to_string_lossy().into_owned(),
-            Some(claude.to_string_lossy().into_owned()),
-            Some(opencode.to_string_lossy().into_owned()),
+            dirs.clone(),
             None,
             None,
             "day".to_string(),
@@ -539,23 +511,27 @@ mod tests {
         )?;
         assert_eq!(snapshot.kpi.sessions_total, kpi.sessions_total);
         assert_eq!(snapshot.kpi.tokens_total, kpi.tokens_total);
-        assert_eq!(snapshot.by_project.len(), 3);
-        assert_eq!(snapshot.by_model.len(), 3);
+        assert_eq!(snapshot.by_project.len(), 4);
+        assert_eq!(snapshot.by_model.len(), 4);
+        // Cursor 的模型名要展开会话正文才拿得到，列表里一律留空，
+        // 因此它在模型维度上聚成一个"未知模型"分组。
+        assert!(snapshot
+            .by_model
+            .iter()
+            .any(|m| m.provider.as_deref() == Some("cursor") && m.model.is_empty()));
         assert_eq!(
             snapshot
                 .timeseries
                 .iter()
                 .map(|point| point.sessions)
                 .sum::<u32>(),
-            3
+            4
         );
-        assert_eq!(snapshot.heatmap.iter().flatten().sum::<u32>(), 3);
+        assert_eq!(snapshot.heatmap.iter().flatten().sum::<u32>(), 4);
 
         let projects = stats_by_project(
             Some("all".to_string()),
-            codex.to_string_lossy().into_owned(),
-            Some(claude.to_string_lossy().into_owned()),
-            Some(opencode.to_string_lossy().into_owned()),
+            dirs.clone(),
             None,
             None,
             10,
@@ -571,12 +547,13 @@ mod tests {
         assert!(projects
             .iter()
             .any(|p| p.provider.as_deref() == Some("opencode")));
+        assert!(projects
+            .iter()
+            .any(|p| p.provider.as_deref() == Some("cursor")));
 
         let models = stats_by_model(
             Some("all".to_string()),
-            codex.to_string_lossy().into_owned(),
-            Some(claude.to_string_lossy().into_owned()),
-            Some(opencode.to_string_lossy().into_owned()),
+            dirs.clone(),
             None,
             None,
             Vec::new(),
@@ -595,9 +572,7 @@ mod tests {
         // 只看 OpenCode 时不应混入其他 Agent 的会话。
         let opencode_only = stats_kpi(
             Some("opencode".to_string()),
-            codex.to_string_lossy().into_owned(),
-            Some(claude.to_string_lossy().into_owned()),
-            Some(opencode.to_string_lossy().into_owned()),
+            dirs.clone(),
             None,
             None,
             Vec::new(),
@@ -618,11 +593,10 @@ mod tests {
         create_codex_session(&codex)?;
         create_claude_session(&claude)?;
 
+        // Cursor 与 OpenCode 都不存在，统计仍应正常产出。
         let kpi = stats_kpi(
             Some("all".to_string()),
-            codex.to_string_lossy().into_owned(),
-            Some(claude.to_string_lossy().into_owned()),
-            Some(root.join("opencode").to_string_lossy().into_owned()),
+            stats_dirs(&root),
             None,
             None,
             Vec::new(),
@@ -708,9 +682,7 @@ mod tests {
         for include_archived in [false, true] {
             let kpi = stats_kpi(
                 Some("codex".to_string()),
-                codex.to_string_lossy().into_owned(),
-                None,
-                None,
+                ProviderDirs::new(codex.to_string_lossy().into_owned()),
                 None,
                 None,
                 Vec::new(),

--- a/src-tauri/src/webui.rs
+++ b/src-tauri/src/webui.rs
@@ -36,6 +36,8 @@ pub struct WebuiConfig {
     pub claude_dir_explicit: bool,
     pub opencode_dir: String,
     pub opencode_dir_explicit: bool,
+    pub cursor_dir: String,
+    pub cursor_dir_explicit: bool,
 }
 
 struct WebuiState {
@@ -65,10 +67,14 @@ pub fn run(config: WebuiConfig) -> AppResult<()> {
     if !settings_exists || config.opencode_dir_explicit {
         initial_settings.opencode_dir = config.opencode_dir;
     }
+    if !settings_exists || config.cursor_dir_explicit {
+        initial_settings.cursor_dir = config.cursor_dir;
+    }
     if !settings_exists
         || config.codex_dir_explicit
         || config.claude_dir_explicit
         || config.opencode_dir_explicit
+        || config.cursor_dir_explicit
     {
         settings::write_settings_file(&settings_file, &initial_settings)?;
     }
@@ -179,32 +185,28 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
         "validate_opencode_dir" => {
             to_result_value(settings::validate_opencode_dir(string_arg(&args, "path")?))
         }
-        "list_sessions" => to_result_value(sessions::list_sessions_with_opencode(
+        "validate_cursor_dir" => {
+            to_result_value(settings::validate_cursor_dir(string_arg(&args, "path")?))
+        }
+        "default_cursor_dir" => to_value(settings::default_cursor_dir()),
+        "list_sessions" => to_result_value(sessions::list_sessions_with_dirs(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
         )),
         "group_sessions_by_project" => {
-            to_result_value(sessions::group_sessions_by_project_with_opencode(
+            to_result_value(sessions::group_sessions_by_project_with_dirs(
                 opt_string_arg(&args, "provider")?,
-                string_arg(&args, "codexDir")?,
-                opt_string_arg(&args, "claudeDir")?,
-                opt_string_arg(&args, "opencodeDir")?,
+                provider_dirs_arg(&args)?,
             ))
         }
-        "search_sessions" => to_result_value(sessions::search_sessions_with_opencode(
+        "search_sessions" => to_result_value(sessions::search_sessions_with_dirs(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             string_arg(&args, "query")?,
         )),
         "start_content_search" => to_result_value(content_search::start_content_search(
             string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            string_arg(&args, "claudeDir")?,
-            string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             string_arg(&args, "query")?,
             arg(&args, "rolloutPaths")?,
         )),
@@ -215,19 +217,16 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
         "cancel_content_search" => to_result_value(content_search::cancel_content_search(
             usize_arg(&args, "jobId")? as u64,
         )),
-        "set_archived" => to_result_value(sessions::set_archived_with_provider_dir(
+        "set_archived" => to_result_value(sessions::set_archived_with_dirs(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             string_arg(&args, "id")?,
             bool_arg(&args, "v")?,
             &state.family_lock,
         )),
-        "rename_session" => to_result_value(sessions::rename_session_with_provider_dirs(
+        "rename_session" => to_result_value(sessions::rename_session_with_dirs(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             string_arg(&args, "id")?,
             opt_string_arg(&args, "rolloutPath")?,
             string_arg(&args, "title")?,
@@ -246,20 +245,16 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
                 &state.family_lock,
             ))
         }
-        "delete_session" => to_result_value(sessions::delete_session_with_provider_dir(
+        "delete_session" => to_result_value(sessions::delete_session_with_dirs(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             string_arg(&args, "id")?,
             opt_arg(&args, "target")?,
             &state.family_lock,
         )),
-        "delete_sessions" => to_result_value(sessions::delete_sessions_with_provider_dir(
+        "delete_sessions" => to_result_value(sessions::delete_sessions_with_dirs(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             arg(&args, "ids")?,
             opt_arg(&args, "targets")?,
             &state.family_lock,
@@ -368,11 +363,9 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
             arg(&args, "header")?,
             arg(&args, "options")?,
         )),
-        "create_backup" => to_result_value(backup::create_backup_with_opencode(
+        "create_backup" => to_result_value(backup::create_backup_with_dirs(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             string_arg(&args, "backupDir")?,
             arg(&args, "ids")?,
             opt_arg(&args, "targets")?,
@@ -391,9 +384,7 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
             opt_string_arg(&args, "provider")?,
             string_arg(&args, "backupDir")?,
             string_arg(&args, "backupPath")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             string_arg(&args, "id")?,
             opt_string_arg(&args, "backupRolloutRelpath")?,
             bool_arg(&args, "overwrite")?,
@@ -403,9 +394,7 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
             opt_string_arg(&args, "provider")?,
             string_arg(&args, "backupDir")?,
             string_arg(&args, "backupPath")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             bool_arg(&args, "overwrite")?,
             &state.family_lock,
         )),
@@ -419,15 +408,24 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
         )),
         "stats_snapshot" => to_result_value(stats::stats_snapshot(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             opt_i64_arg(&args, "fromTs")?,
             opt_i64_arg(&args, "toTs")?,
             string_arg(&args, "bucket")?,
             usize_arg(&args, "projectLimit")?,
             arg(&args, "cwdFilter")?,
             bool_arg(&args, "includeArchived")?,
+        )),
+        "compact_cursor_database" => to_result_value(crate::cursor_mutate::compact_database(
+            &provider_dirs_arg(&args)?,
+        )),
+        "diagnose_cursor_residue" => to_result_value(crate::cursor_mutate::diagnose_residue(
+            &provider_dirs_arg(&args)?,
+        )),
+        "prune_cursor_residue" => to_result_value(crate::cursor_mutate::prune_residue(
+            &provider_dirs_arg(&args)?,
+            &arg::<Vec<String>>(&args, "kinds")?,
+            bool_arg(&args, "dryRun")?,
         )),
         "reveal_cwd" => to_result_value(fs_ops::reveal_cwd(string_arg(&args, "cwd")?)),
         "open_latest_release_page" => to_result_value(fs_ops::open_latest_release_page()),
@@ -492,10 +490,10 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
             bool_arg(&args, "dryRun")?,
             opt_string_vec_arg(&args, "sessionIds")?,
         )),
-        "convert_session_provider" => to_result_value(convert::convert_session_with_lock(
-            string_arg(&args, "codexDir")?,
-            string_arg(&args, "claudeDir")?,
+        "convert_session_provider" => to_result_value(convert::convert_session_with_target(
+            provider_dirs_arg(&args)?,
             string_arg(&args, "sourceProvider")?,
+            opt_string_arg(&args, "targetProvider")?,
             string_arg(&args, "rolloutPath")?,
             opt_string_arg(&args, "conversionMode")?,
             &state.family_lock,
@@ -591,22 +589,18 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
                 &state.family_lock,
             ))
         }
-        "export_session_bundles" => to_result_value(bundle::export_session_bundles_with_opencode(
+        "export_session_bundles" => to_result_value(bundle::export_session_bundles_with_dirs(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             string_arg(&args, "outDir")?,
             arg(&args, "ids")?,
             opt_arg(&args, "targets")?,
             opt_string_arg(&args, "machineLabel")?,
             opt_string_arg(&args, "exportGroup")?,
         )),
-        "export_all_bundles" => to_result_value(bundle::export_all_bundles_with_opencode(
+        "export_all_bundles" => to_result_value(bundle::export_all_bundles_with_dirs(
             opt_string_arg(&args, "provider")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             string_arg(&args, "outDir")?,
             opt_string_arg(&args, "machineLabel")?,
             opt_string_arg(&args, "exportGroup")?,
@@ -623,9 +617,7 @@ fn dispatch_invoke(state: &WebuiState, command: &str, args: Value) -> AppResult<
         "import_session_bundles" => to_result_value(bundle::import_session_bundles_with_lock(
             opt_string_arg(&args, "provider")?,
             string_arg(&args, "srcDir")?,
-            string_arg(&args, "codexDir")?,
-            opt_string_arg(&args, "claudeDir")?,
-            opt_string_arg(&args, "opencodeDir")?,
+            provider_dirs_arg(&args)?,
             enum_arg::<ImportMode>(&args, "mode")?,
             bool_arg(&args, "makeVisible")?,
             bool_arg(&args, "strict")?,
@@ -883,6 +875,17 @@ fn opt_arg<T: DeserializeOwned>(args: &Value, name: &str) -> AppResult<Option<T>
 
 fn enum_arg<T: DeserializeOwned>(args: &Value, name: &str) -> AppResult<T> {
     arg(args, name)
+}
+
+/// 各 provider 目录一次性收齐，新增 provider 时只需要改这一处。
+fn provider_dirs_arg(args: &Value) -> AppResult<crate::models::ProviderDirs> {
+    Ok(crate::models::ProviderDirs {
+        codex_dir: string_arg(args, "codexDir")?,
+        claude_dir: opt_string_arg(args, "claudeDir")?,
+        opencode_dir: opt_string_arg(args, "opencodeDir")?,
+        cursor_dir: opt_string_arg(args, "cursorDir")?,
+        cursor_agent_dir: None,
+    })
 }
 
 fn string_arg(args: &Value, name: &str) -> AppResult<String> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ export default function App() {
   const initTheme = useTheme((s) => s.init);
   const toggleTheme = useTheme((s) => s.toggle);
   const defaultProvider = webuiDefaultProvider();
+  // OpenCode 没有修复页，落回 Codex；其余 provider 都有自己的。
   const defaultRepairProvider = defaultProvider === "opencode" ? "codex" : defaultProvider;
   const defaultSessionsPath = `/${defaultProvider}/sessions`;
   const defaultRepairPath = `/${defaultRepairProvider}/repair`;
@@ -77,6 +78,11 @@ export default function App() {
             <Route path="/opencode/backups" element={<BackupsRoute key="opencode-backups" provider="opencode" />} />
             <Route path="/opencode/backups/:name" element={<BackupDetailRoute key="opencode-backup-detail" provider="opencode" />} />
             <Route path="/opencode/transfer" element={<TransferRoute key="opencode-transfer" provider="opencode" />} />
+            <Route path="/cursor/sessions" element={<SessionsRoute key="cursor-sessions" provider="cursor" />} />
+            <Route path="/cursor/repair" element={<RepairRoute key="cursor-repair" provider="cursor" />} />
+            <Route path="/cursor/backups" element={<BackupsRoute key="cursor-backups" provider="cursor" />} />
+            <Route path="/cursor/backups/:name" element={<BackupDetailRoute key="cursor-backup-detail" provider="cursor" />} />
+            <Route path="/cursor/transfer" element={<TransferRoute key="cursor-transfer" provider="cursor" />} />
             <Route path="/sessions" element={<Navigate to={defaultSessionsPath} replace />} />
             <Route path="/repair" element={<Navigate to={defaultRepairPath} replace />} />
             <Route path="/backups" element={<Navigate to={defaultBackupsPath} replace />} />

--- a/src/components/BackupCreateDialog.tsx
+++ b/src/components/BackupCreateDialog.tsx
@@ -60,6 +60,7 @@ export function BackupCreateDialog({ open, onOpenChange, provider, sessions, onD
         codex_dir: settings.codex_dir,
         claude_dir: settings.claude_dir,
         opencode_dir: settings.opencode_dir,
+        cursor_dir: settings.cursor_dir,
         backup_dir: settings.backup_dir,
         ids: sessions.map((s) => s.id),
         targets: sessions.map((s) => ({ id: s.id, rollout_path: s.rollout_path })),

--- a/src/components/ContentSearchDialog.tsx
+++ b/src/components/ContentSearchDialog.tsx
@@ -30,6 +30,7 @@ type Props = {
   codexDir: string;
   claudeDir: string;
   opencodeDir: string;
+  cursorDir: string;
   showSubagentSessions: boolean;
   showArchivedSessions: boolean;
   rolloutPaths: readonly string[];
@@ -47,6 +48,7 @@ export function ContentSearchDialog({
   codexDir,
   claudeDir,
   opencodeDir,
+  cursorDir,
   showSubagentSessions,
   showArchivedSessions,
   rolloutPaths,
@@ -70,6 +72,7 @@ export function ContentSearchDialog({
     codexDir,
     claudeDir,
     opencodeDir,
+    cursorDir,
     showSubagentSessions,
     showArchivedSessions,
     rolloutPaths,
@@ -224,6 +227,7 @@ export function ContentSearchDialog({
         codexDir,
         claudeDir,
         opencodeDir,
+        cursorDir,
         query: normalized,
         rolloutPaths,
       });

--- a/src/components/ConvertSessionDialog.tsx
+++ b/src/components/ConvertSessionDialog.tsx
@@ -14,6 +14,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   api,
   type ConvertReport,
+  type CoreSessionProvider,
   type SessionConversionMode,
   type SessionSummary,
 } from "@/lib/api";
@@ -32,22 +33,37 @@ export function ConvertSessionDialog({ target, onOpenChange, onDone }: Props) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [conversionMode, setConversionMode] = useState<SessionConversionMode>("simple");
+  // Cursor 只出不进，两个目标都可选；Codex 与 Claude 各自只有一个可能的目标。
+  const isCursorSource = target?.provider === "cursor";
+  const [targetProvider, setTargetProvider] = useState<CoreSessionProvider>("claude");
+  const effectiveTarget: CoreSessionProvider = isCursorSource
+    ? targetProvider
+    : target?.provider === "codex"
+      ? "claude"
+      : "codex";
 
-  const targetProviderLabel = target?.provider === "codex" ? "Claude Code" : "Codex";
-  const sourceProviderLabel = target?.provider === "codex" ? "Codex" : "Claude Code";
-  const nativeModeLabel = target?.provider === "codex" ? "原生Claude（实验）" : "原生Codex（实验）";
+  const providerLabels: Record<string, string> = {
+    codex: "Codex",
+    claude: "Claude Code",
+    cursor: "Cursor",
+  };
+  const targetProviderLabel = providerLabels[effectiveTarget];
+  const sourceProviderLabel = providerLabels[target?.provider ?? ""] ?? "会话";
+  const nativeModeLabel =
+    effectiveTarget === "claude" ? "原生Claude（实验）" : "原生Codex（实验）";
   const simpleModeDescription =
-    target?.provider === "codex"
+    effectiveTarget === "claude"
       ? "只保留真实用户消息和每轮最终答复，不依赖 Claude 的工具事件格式。"
       : "保留可见对话，工具调用和结果转为文本注记，不依赖 Codex 的工具事件格式。";
   const nativeModeDescription =
-    target?.provider === "codex"
+    effectiveTarget === "claude"
       ? "保留过程回复，配对完整的工具事件转为 Claude tool_use/tool_result。"
       : "保留过程回复和图片，配对完整的工具事件转为 Codex function_call/function_call_output。";
 
   useEffect(() => {
     if (!target) return;
     setConversionMode("simple");
+    setTargetProvider("claude");
     setErr(null);
   }, [target?.rollout_path]);
 
@@ -59,7 +75,9 @@ export function ConvertSessionDialog({ target, onOpenChange, onDone }: Props) {
       const report = await api.convertSessionProvider({
         codex_dir: settings.codex_dir,
         claude_dir: settings.claude_dir,
+        cursor_dir: settings.cursor_dir,
         source_provider: target.provider,
+        target_provider: effectiveTarget,
         rollout_path: target.rollout_path,
         conversion_mode: conversionMode,
       });
@@ -106,6 +124,30 @@ export function ConvertSessionDialog({ target, onOpenChange, onDone }: Props) {
             」转换为新的 {targetProviderLabel} 会话。
           </DialogDescription>
         </DialogHeader>
+
+        {isCursorSource && (
+          <div className="space-y-2">
+            <span className="text-sm font-medium text-foreground">转换目标</span>
+            <RadioGroup
+              value={targetProvider}
+              onValueChange={(value) => setTargetProvider(value as CoreSessionProvider)}
+              className="flex gap-2"
+            >
+              {(["claude", "codex"] as const).map((value) => (
+                <Label
+                  key={value}
+                  htmlFor={`convert-to-${value}`}
+                  className="flex flex-1 cursor-pointer items-center gap-2 rounded-md border bg-muted/30 p-3"
+                >
+                  <RadioGroupItem id={`convert-to-${value}`} value={value} />
+                  <span className="text-sm font-medium text-foreground">
+                    {providerLabels[value]}
+                  </span>
+                </Label>
+              ))}
+            </RadioGroup>
+          </div>
+        )}
 
         <RadioGroup
           value={conversionMode}

--- a/src/components/PreviewDialog.tsx
+++ b/src/components/PreviewDialog.tsx
@@ -591,7 +591,12 @@ export function PreviewDialog({
   const copyResume = async () => {
     if (!session) return;
     try {
-      const text = await api.copyResumeCommand(session.provider, session.id, session.cwd);
+      const text = await api.copyResumeCommand(
+        session.provider,
+        session.id,
+        session.cwd,
+        session.resume_command,
+      );
       toast.success(`已复制：${text}`);
     } catch (e: any) {
       toast.error("复制失败：" + String(e?.message ?? e));

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -371,10 +371,11 @@ export const SessionCard = memo(function SessionCard({
               {s.tokens_used > 0 && (
                 <span className="whitespace-nowrap">{humanTokens(s.tokens_used)} tok</span>
               )}
-              {s.tokens_used > 0 && <MetaDot />}
-              <span className="whitespace-nowrap">
-                {humanBytes(s.rollout_bytes)}
-              </span>
+              {s.tokens_used > 0 && s.rollout_bytes > 0 && <MetaDot />}
+              {/* 体积为 0 表示还没算出来（Cursor 的会话体积按需补算），显示"0 B"会让人误以为会话是空的。 */}
+              {s.rollout_bytes > 0 && (
+                <span className="whitespace-nowrap">{humanBytes(s.rollout_bytes)}</span>
+              )}
 
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>

--- a/src/components/SettingsSheet.tsx
+++ b/src/components/SettingsSheet.tsx
@@ -44,10 +44,12 @@ export function SettingsSheet({ trigger }: Props) {
   const [codex, setCodex] = useState("");
   const [claude, setClaude] = useState("");
   const [opencode, setOpenCode] = useState("");
+  const [cursor, setCursor] = useState("");
   const [backup, setBackup] = useState("");
   const [codexValidation, setCodexValidation] = useState<DirValidation | null>(null);
   const [claudeValidation, setClaudeValidation] = useState<DirValidation | null>(null);
   const [opencodeValidation, setOpenCodeValidation] = useState<DirValidation | null>(null);
+  const [cursorValidation, setCursorValidation] = useState<DirValidation | null>(null);
   const [updateState, setUpdateState] = useState<UpdateCheckResult>({ state: "idle" });
   const [currentVersion, setCurrentVersion] = useState("");
   const [currentVersionError, setCurrentVersionError] = useState("");
@@ -58,6 +60,7 @@ export function SettingsSheet({ trigger }: Props) {
     setCodex(settings.codex_dir);
     setClaude(settings.claude_dir);
     setOpenCode(settings.opencode_dir);
+    setCursor(settings.cursor_dir);
     setBackup(settings.backup_dir);
   }, [settings]);
 
@@ -111,6 +114,18 @@ export function SettingsSheet({ trigger }: Props) {
     return () => window.clearTimeout(id);
   }, [opencode]);
 
+  useEffect(() => {
+    if (!cursor) return;
+    const id = window.setTimeout(async () => {
+      try {
+        setCursorValidation(await api.validateCursorDir(cursor));
+      } catch {
+        setCursorValidation(null);
+      }
+    }, 200);
+    return () => window.clearTimeout(id);
+  }, [cursor]);
+
   const pick = async (setter: (s: string) => void, cur: string) => {
     const picked = await pickDirectoryPath({ defaultPath: cur });
     if (picked) setter(picked);
@@ -128,8 +143,18 @@ export function SettingsSheet({ trigger }: Props) {
     setOpenCode(await api.defaultOpenCodeDir());
   };
 
+  const restoreCursorDefault = async () => {
+    setCursor(await api.defaultCursorDir());
+  };
+
   const persistSettings = async () => {
-    await save({ codex_dir: codex, claude_dir: claude, opencode_dir: opencode, backup_dir: backup });
+    await save({
+      codex_dir: codex,
+      claude_dir: claude,
+      opencode_dir: opencode,
+      cursor_dir: cursor,
+      backup_dir: backup,
+    });
     toast.success("设置已保存");
     await load();
   };
@@ -235,6 +260,18 @@ export function SettingsSheet({ trigger }: Props) {
             <ValidationBadge v={opencodeValidation} provider="opencode" />
           </DirField>
 
+          <Separator />
+
+          <DirField
+            label="Cursor 用户数据目录"
+            value={cursor}
+            onChange={setCursor}
+            placeholder={"C:\\Users\\<me>\\AppData\\Roaming\\Cursor\\User"}
+            onPick={() => pick(setCursor, cursor)}
+            onRestoreDefault={restoreCursorDefault}
+          >
+            <ValidationBadge v={cursorValidation} provider="cursor" />
+          </DirField>
           <Separator />
 
           <DirField
@@ -463,7 +500,13 @@ function UpdateStatus({
   );
 }
 
-function ValidationBadge({ v, provider }: { v: DirValidation | null; provider: "codex" | "claude" | "opencode" }) {
+function ValidationBadge({
+  v,
+  provider,
+}: {
+  v: DirValidation | null;
+  provider: "codex" | "claude" | "opencode" | "cursor";
+}) {
   if (!v) return null;
   if (v.valid) {
     return (
@@ -476,6 +519,7 @@ function ValidationBadge({ v, provider }: { v: DirValidation | null; provider: "
   const reasons: string[] = [];
   if (provider === "codex" && !v.has_state_db) reasons.push("缺 state_5.sqlite");
   if (provider === "opencode" && !v.has_state_db) reasons.push("缺 opencode.db");
+  if (provider === "cursor" && !v.has_state_db) reasons.push("缺 state.vscdb");
   if (!v.has_sessions) {
     reasons.push(provider === "codex" ? "缺 sessions/" : provider === "claude" ? "缺 projects/" : "数据库不可用");
   }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Check,
   ChevronDown,
   MessageSquare,
+  MousePointer2,
   NotebookText,
   Package,
   Settings,
@@ -93,6 +94,17 @@ const providers: ProviderDefinition[] = [
       { to: "/opencode/sessions", icon: MessageSquare, label: "会话" },
       { to: "/opencode/backups", icon: Archive, label: "备份" },
       { to: "/opencode/transfer", icon: Package, label: "导出 / 导入" },
+    ],
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    icon: MousePointer2,
+    items: [
+      { to: "/cursor/sessions", icon: MessageSquare, label: "会话" },
+      { to: "/cursor/repair", icon: Wrench, label: "清理" },
+      { to: "/cursor/backups", icon: Archive, label: "备份" },
+      { to: "/cursor/transfer", icon: Package, label: "导出 / 导入" },
     ],
   },
 ];
@@ -297,7 +309,9 @@ function DirCard({ label, path, accent }: { label: string; path: string; accent:
 
 function providerFromPath(pathname: string): SessionProvider | null {
   const segment = pathname.split("/").filter(Boolean)[0];
-  if (segment === "codex" || segment === "claude" || segment === "opencode") return segment;
+  if (segment === "codex" || segment === "claude" || segment === "opencode" || segment === "cursor") {
+    return segment;
+  }
   return null;
 }
 
@@ -308,5 +322,6 @@ function providerDirectory(
   if (!settings) return "";
   if (provider === "claude") return settings.claude_dir;
   if (provider === "opencode") return settings.opencode_dir;
+  if (provider === "cursor") return settings.cursor_dir;
   return settings.codex_dir;
 }

--- a/src/components/StatsDashboard.tsx
+++ b/src/components/StatsDashboard.tsx
@@ -54,6 +54,7 @@ const providerOptions: { value: StatsProvider; label: string }[] = [
   { value: "codex", label: "Codex" },
   { value: "claude", label: "Claude" },
   { value: "opencode", label: "OpenCode" },
+  { value: "cursor", label: "Cursor" },
 ];
 
 const rangeOptions: { value: Range; label: string }[] = [
@@ -118,7 +119,9 @@ export function StatsDashboard() {
         ? settings.claude_dir
         : provider === "opencode"
           ? settings.opencode_dir
-          : settings.codex_dir;
+          : provider === "cursor"
+            ? settings.cursor_dir
+            : settings.codex_dir;
     if (!requiredDir) {
       setLoading(false);
       setError(
@@ -126,7 +129,9 @@ export function StatsDashboard() {
           ? "尚未配置 Claude 目录"
           : provider === "opencode"
             ? "尚未配置 OpenCode 数据目录"
-            : "尚未配置 Codex 目录",
+            : provider === "cursor"
+              ? "尚未配置 Cursor 用户数据目录"
+              : "尚未配置 Codex 目录",
       );
       return;
     }
@@ -137,6 +142,7 @@ export function StatsDashboard() {
       codex_dir: settings.codex_dir,
       claude_dir: settings.claude_dir,
       opencode_dir: settings.opencode_dir,
+      cursor_dir: settings.cursor_dir,
       from_ts: from,
       to_ts: to,
       cwd_filter: [] as string[],
@@ -170,6 +176,7 @@ export function StatsDashboard() {
     settings?.codex_dir,
     settings?.claude_dir,
     settings?.opencode_dir,
+    settings?.cursor_dir,
     provider,
     range,
     bucket,
@@ -831,7 +838,9 @@ function ProviderDot({ provider }: { provider: ProjectStat["provider"] }) {
       ? "hsl(var(--provider-claude))"
       : provider === "opencode"
         ? "hsl(var(--provider-opencode))"
-        : "hsl(var(--provider-codex))";
+        : provider === "cursor"
+          ? "hsl(var(--provider-cursor))"
+          : "hsl(var(--provider-codex))";
   return <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: color }} />;
 }
 

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -61,6 +61,7 @@ export function TopBar({
       loc.pathname.startsWith("/codex/sessions") ||
       loc.pathname.startsWith("/claude/sessions") ||
       loc.pathname.startsWith("/opencode/sessions") ||
+      loc.pathname.startsWith("/cursor/sessions") ||
       loc.pathname.startsWith("/backups/") ||
       loc.pathname.startsWith("/codex/backups/") ||
       loc.pathname.startsWith("/claude/backups/"));

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -8,7 +8,8 @@ export function useSessions(provider: SessionProvider, query: string) {
   const codexDir = settings?.codex_dir ?? "";
   const claudeDir = settings?.claude_dir ?? "";
   const opencodeDir = settings?.opencode_dir ?? "";
-  const scope = JSON.stringify([settingsReady, provider, codexDir, claudeDir, opencodeDir]);
+  const cursorDir = settings?.cursor_dir ?? "";
+  const scope = JSON.stringify([settingsReady, provider, codexDir, claudeDir, opencodeDir, cursorDir]);
   const [allSessions, setAllSessions] = useState<SessionSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -36,9 +37,14 @@ export function useSessions(provider: SessionProvider, query: string) {
           setError(null);
           return;
         }
-        const providerDir = provider === "claude" ? claudeDir : provider === "opencode" ? opencodeDir : codexDir;
+        const providerDir = providerDirectory(provider, {
+          codexDir,
+          claudeDir,
+          opencodeDir,
+          cursorDir,
+        });
         if (!providerDir) {
-          setError(provider === "claude" ? "尚未配置 Claude 目录" : provider === "opencode" ? "尚未配置 OpenCode 数据目录" : "尚未配置 Codex 目录");
+          setError(missingDirectoryMessage(provider));
           setLoading(false);
           return;
         }
@@ -46,7 +52,7 @@ export function useSessions(provider: SessionProvider, query: string) {
         setLoading(true);
         setError(null);
         try {
-          const list = await api.listSessions(provider, codexDir, claudeDir, opencodeDir);
+          const list = await api.listSessions(provider, codexDir, claudeDir, opencodeDir, cursorDir);
           if (!isCurrent()) return;
           setAllSessions(list);
         } catch (error) {
@@ -64,7 +70,7 @@ export function useSessions(provider: SessionProvider, query: string) {
     });
     inFlight.current = { scope, requestId, promise };
     return promise;
-  }, [claudeDir, codexDir, opencodeDir, provider, scope, settingsReady]);
+  }, [claudeDir, codexDir, cursorDir, opencodeDir, provider, scope, settingsReady]);
 
   useEffect(() => {
     requestSeq.current += 1;
@@ -141,7 +147,12 @@ export function useProjectGroups(provider: SessionProvider) {
       setError(null);
       return;
     }
-    const providerDir = provider === "claude" ? settings.claude_dir : provider === "opencode" ? settings.opencode_dir : settings.codex_dir;
+    const providerDir = providerDirectory(provider, {
+      codexDir: settings.codex_dir,
+      claudeDir: settings.claude_dir,
+      opencodeDir: settings.opencode_dir,
+      cursorDir: settings.cursor_dir,
+    });
     if (!providerDir) {
       setGroups([]);
       setLoading(false);
@@ -150,7 +161,13 @@ export function useProjectGroups(provider: SessionProvider) {
     setLoading(true);
     setError(null);
     try {
-      const next = await api.groupByProject(provider, settings.codex_dir, settings.claude_dir, settings.opencode_dir);
+      const next = await api.groupByProject(
+        provider,
+        settings.codex_dir,
+        settings.claude_dir,
+        settings.opencode_dir,
+        settings.cursor_dir,
+      );
       if (request === requestSeq.current) setGroups(next);
     } catch (error) {
       if (request === requestSeq.current) {
@@ -159,11 +176,41 @@ export function useProjectGroups(provider: SessionProvider) {
     } finally {
       if (request === requestSeq.current) setLoading(false);
     }
-  }, [settings?.codex_dir, settings?.claude_dir, settings?.opencode_dir, provider]);
+  }, [settings?.codex_dir, settings?.claude_dir, settings?.opencode_dir, settings?.cursor_dir, provider]);
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
 
   return { groups, loading, error, refresh };
+}
+
+/** 当前 provider 需要哪个目录才能列出会话。 */
+function providerDirectory(
+  provider: SessionProvider,
+  dirs: { codexDir: string; claudeDir: string; opencodeDir: string; cursorDir: string },
+): string {
+  switch (provider) {
+    case "claude":
+      return dirs.claudeDir;
+    case "opencode":
+      return dirs.opencodeDir;
+    case "cursor":
+      return dirs.cursorDir;
+    default:
+      return dirs.codexDir;
+  }
+}
+
+function missingDirectoryMessage(provider: SessionProvider): string {
+  switch (provider) {
+    case "claude":
+      return "尚未配置 Claude 目录";
+    case "opencode":
+      return "尚未配置 OpenCode 数据目录";
+    case "cursor":
+      return "尚未配置 Cursor 用户数据目录";
+    default:
+      return "尚未配置 Codex 目录";
+  }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -42,17 +42,22 @@ function resumeCommandText(provider: SessionProvider, sessionId: string, cwd?: s
     }
     case "opencode":
       return `opencode --session ${sessionId}`;
+    // Cursor 的 IDE 会话只能在 Cursor 里打开；cursor-agent 会话可以续聊，
+    // 但从 (provider, id) 分辨不出是哪一种，命令由后端逐会话给在 resume_command 上。
+    case "cursor":
+      return "";
   }
 }
 
 export type CoreSessionProvider = "codex" | "claude";
-export type SessionProvider = CoreSessionProvider | "opencode";
+export type SessionProvider = CoreSessionProvider | "opencode" | "cursor";
 export type StatsProvider = "all" | SessionProvider;
 
 export type Settings = {
   codex_dir: string;
   claude_dir: string;
   opencode_dir: string;
+  cursor_dir: string;
   backup_dir: string;
   open_command: string;
   refresh_interval_ms: number;
@@ -66,6 +71,50 @@ export type DirValidation = {
   has_state_db: boolean;
   has_sessions: boolean;
   threads_count: number;
+};
+
+export type CursorResidueSample = {
+  id: string;
+  title: string;
+  cwd: string;
+  bubbles: number;
+};
+
+export type CursorResidueGroup = {
+  kind: "empty_sessions" | "orphan_records" | "missing_project" | string;
+  label: string;
+  description: string;
+  sessions: number;
+  rows: number;
+  bytes: number;
+  /** 为 true 表示删除会丢失真实对话，界面上必须额外确认。 */
+  destructive: boolean;
+  samples: CursorResidueSample[];
+};
+
+export type CursorResidueReport = {
+  database_path: string;
+  database_bytes: number;
+  header_rows: number;
+  visible_sessions: number;
+  groups: CursorResidueGroup[];
+};
+
+export type CursorPruneReport = {
+  database_path: string;
+  dry_run: boolean;
+  removed_header_rows: number;
+  removed_kv_rows: number;
+  freed_bytes: number;
+  kinds: string[];
+  /** 内容块可达性扫描读不出来的行数；不为 0 时那一类被整体跳过。 */
+  blob_scan_errors: number;
+};
+
+export type CursorCompactReport = {
+  bytes_before: number;
+  bytes_after: number;
+  bytes_reclaimed: number;
 };
 
 export type AppUpdateInfo = {
@@ -909,21 +958,24 @@ export const api = {
   defaultCodexDir: () => invokeCommand<string>("default_codex_dir"),
   defaultClaudeDir: () => invokeCommand<string>("default_claude_dir"),
   defaultOpenCodeDir: () => invokeCommand<string>("default_opencode_dir"),
+  defaultCursorDir: () => invokeCommand<string>("default_cursor_dir"),
   validateCodexDir: (path: string) => invokeCommand<DirValidation>("validate_codex_dir", { path }),
   validateClaudeDir: (path: string) => invokeCommand<DirValidation>("validate_claude_dir", { path }),
   validateOpenCodeDir: (path: string) => invokeCommand<DirValidation>("validate_opencode_dir", { path }),
+  validateCursorDir: (path: string) => invokeCommand<DirValidation>("validate_cursor_dir", { path }),
 
-  listSessions: (provider: SessionProvider, codexDir: string, claudeDir?: string, opencodeDir?: string) =>
-    invokeCommand<SessionSummary[]>("list_sessions", { provider, codexDir, claudeDir, opencodeDir }),
-  groupByProject: (provider: SessionProvider, codexDir: string, claudeDir?: string, opencodeDir?: string) =>
-    invokeCommand<ProjectGroup[]>("group_sessions_by_project", { provider, codexDir, claudeDir, opencodeDir }),
-  searchSessions: (provider: SessionProvider, codexDir: string, claudeDir: string | undefined, opencodeDir: string | undefined, query: string) =>
-    invokeCommand<SessionSummary[]>("search_sessions", { provider, codexDir, claudeDir, opencodeDir, query }),
+  listSessions: (provider: SessionProvider, codexDir: string, claudeDir?: string, opencodeDir?: string, cursorDir?: string) =>
+    invokeCommand<SessionSummary[]>("list_sessions", { provider, codexDir, claudeDir, opencodeDir, cursorDir }),
+  groupByProject: (provider: SessionProvider, codexDir: string, claudeDir?: string, opencodeDir?: string, cursorDir?: string) =>
+    invokeCommand<ProjectGroup[]>("group_sessions_by_project", { provider, codexDir, claudeDir, opencodeDir, cursorDir }),
+  searchSessions: (provider: SessionProvider, codexDir: string, claudeDir: string | undefined, opencodeDir: string | undefined, cursorDir: string | undefined, query: string) =>
+    invokeCommand<SessionSummary[]>("search_sessions", { provider, codexDir, claudeDir, opencodeDir, cursorDir, query }),
   startContentSearch: (p: {
     provider: SessionProvider;
     codexDir: string;
     claudeDir: string;
     opencodeDir: string;
+    cursorDir: string;
     query: string;
     rolloutPaths: readonly string[];
   }) => invokeCommand<{ job_id: number }>("start_content_search", p),
@@ -933,13 +985,32 @@ export const api = {
     invokeCommand<{ job_id: number } | null>("active_content_search"),
   cancelContentSearch: (jobId: number) =>
     invokeCommand<void>("cancel_content_search", { jobId }),
-  setArchived: (provider: SessionProvider, codexDir: string, id: string, v: boolean, opencodeDir?: string) =>
-    invokeCommand<void>("set_archived", { provider, codexDir, id, v, opencodeDir }),
+  setArchived: (provider: SessionProvider, codexDir: string, id: string, v: boolean, opencodeDir?: string, cursorDir?: string) =>
+    invokeCommand<void>("set_archived", { provider, codexDir, id, v, opencodeDir, cursorDir }),
+  /** 扫描 Cursor 数据库里的空会话、孤儿记录与项目目录已消失的会话。 */
+  diagnoseCursorResidue: (codexDir: string, cursorDir?: string) =>
+    invokeCommand<CursorResidueReport>("diagnose_cursor_residue", { codexDir, cursorDir }),
+  pruneCursorResidue: (p: {
+    codex_dir: string;
+    cursor_dir?: string;
+    kinds: string[];
+    dry_run: boolean;
+  }) =>
+    invokeCommand<CursorPruneReport>("prune_cursor_residue", {
+      codexDir: p.codex_dir,
+      cursorDir: p.cursor_dir,
+      kinds: p.kinds,
+      dryRun: p.dry_run,
+    }),
+  /** 回收 Cursor 数据库中删除留下的空页；库可能有数 GB，耗时较长。 */
+  compactCursorDatabase: (codexDir: string, cursorDir?: string) =>
+    invokeCommand<CursorCompactReport>("compact_cursor_database", { codexDir, cursorDir }),
   renameSession: (p: {
     provider: SessionProvider;
     codex_dir: string;
     claude_dir?: string;
     opencode_dir?: string;
+    cursor_dir?: string;
     id: string;
     rollout_path?: string;
     title: string;
@@ -948,6 +1019,7 @@ export const api = {
     codexDir: p.codex_dir,
     claudeDir: p.claude_dir,
     opencodeDir: p.opencode_dir,
+    cursorDir: p.cursor_dir,
     id: p.id,
     rolloutPath: p.rollout_path,
     title: p.title,
@@ -978,7 +1050,8 @@ export const api = {
     claudeDir?: string,
     target?: DeleteTarget,
     opencodeDir?: string,
-  ) => invokeCommand<DeleteResult>("delete_session", { provider, codexDir, claudeDir, opencodeDir, id, target }),
+    cursorDir?: string,
+  ) => invokeCommand<DeleteResult>("delete_session", { provider, codexDir, claudeDir, opencodeDir, cursorDir, id, target }),
   deleteSessions: (
     provider: SessionProvider,
     codexDir: string,
@@ -986,12 +1059,14 @@ export const api = {
     claudeDir?: string,
     targets?: DeleteTarget[],
     opencodeDir?: string,
+    cursorDir?: string,
   ) =>
     invokeCommand<DeleteResult[]>("delete_sessions", {
       provider,
       codexDir,
       claudeDir,
       opencodeDir,
+      cursorDir,
       ids,
       targets,
     }),
@@ -1077,6 +1152,7 @@ export const api = {
     codex_dir: string;
     claude_dir?: string;
     opencode_dir?: string;
+    cursor_dir?: string;
     backup_dir: string;
     ids: string[];
     targets?: BundleExportTarget[];
@@ -1088,6 +1164,7 @@ export const api = {
       codexDir: p.codex_dir,
       claudeDir: p.claude_dir,
       opencodeDir: p.opencode_dir,
+      cursorDir: p.cursor_dir,
       backupDir: p.backup_dir,
       ids: p.ids,
       targets: p.targets,
@@ -1105,6 +1182,7 @@ export const api = {
     codex_dir: string;
     claude_dir?: string;
     opencode_dir?: string;
+    cursor_dir?: string;
     id: string;
     backup_rollout_relpath?: string;
     overwrite: boolean;
@@ -1116,6 +1194,7 @@ export const api = {
       codexDir: p.codex_dir,
       claudeDir: p.claude_dir,
       opencodeDir: p.opencode_dir,
+      cursorDir: p.cursor_dir,
       id: p.id,
       backupRolloutRelpath: p.backup_rollout_relpath,
       overwrite: p.overwrite,
@@ -1127,6 +1206,7 @@ export const api = {
     codex_dir: string;
     claude_dir?: string;
     opencode_dir?: string;
+    cursor_dir?: string;
     overwrite: boolean;
   }) =>
     invokeCommand<RestoreResult[]>("restore_all", {
@@ -1136,6 +1216,7 @@ export const api = {
       codexDir: p.codex_dir,
       claudeDir: p.claude_dir,
       opencodeDir: p.opencode_dir,
+      cursorDir: p.cursor_dir,
       overwrite: p.overwrite,
     }),
   deleteBackup: (backupDir: string, backupPath: string) =>
@@ -1148,6 +1229,7 @@ export const api = {
     codex_dir: string;
     claude_dir?: string;
     opencode_dir?: string;
+    cursor_dir?: string;
     from_ts: number | null;
     to_ts: number | null;
     bucket: "day" | "week";
@@ -1160,6 +1242,7 @@ export const api = {
       codexDir: p.codex_dir,
       claudeDir: p.claude_dir,
       opencodeDir: p.opencode_dir,
+      cursorDir: p.cursor_dir,
       fromTs: p.from_ts,
       toTs: p.to_ts,
       bucket: p.bucket,
@@ -1169,13 +1252,32 @@ export const api = {
     }),
 
   revealCwd: (cwd: string) => invokeCommand<void>("reveal_cwd", { cwd }),
-  copyResumeCommand: async (provider: SessionProvider, sessionId: string, cwd?: string) => {
+  /**
+   * 复制续聊命令。
+   *
+   * `precomputed` 是后端随会话给出的命令：Cursor 只有 cursor-agent 会话能续聊，
+   * 光靠 provider 推不出来，必须用会话自己带的那一条。
+   */
+  copyResumeCommand: async (
+    provider: SessionProvider,
+    sessionId: string,
+    cwd?: string,
+    precomputed?: string,
+  ) => {
+    const explicit = precomputed?.trim();
+    if (explicit) {
+      await copyText(explicit);
+      return explicit;
+    }
     if (isWebRuntime()) {
       const text = resumeCommandText(provider, sessionId, cwd);
+      if (!text) throw new Error("该会话没有可续聊的命令行入口");
       await copyText(text);
       return text;
     }
-    return invokeCommand<string>("copy_resume_command", { provider, sessionId, cwd });
+    const text = await invokeCommand<string>("copy_resume_command", { provider, sessionId, cwd });
+    if (!text) throw new Error("该会话没有可续聊的命令行入口");
+    return text;
   },
 
   // ========================= 修复 =========================
@@ -1234,14 +1336,19 @@ export const api = {
   convertSessionProvider: (p: {
     codex_dir: string;
     claude_dir: string;
+    cursor_dir?: string;
     source_provider: SessionProvider;
+    /** Cursor 两个方向都能去，必须显式指定；Codex 与 Claude 各自只有一个目标。 */
+    target_provider?: CoreSessionProvider;
     rollout_path: string;
     conversion_mode?: SessionConversionMode;
   }) =>
     invokeCommand<ConvertReport>("convert_session_provider", {
       codexDir: p.codex_dir,
       claudeDir: p.claude_dir,
+      cursorDir: p.cursor_dir,
       sourceProvider: p.source_provider,
+      targetProvider: p.target_provider ?? null,
       rolloutPath: p.rollout_path,
       conversionMode: p.conversion_mode ?? null,
     }),
@@ -1438,6 +1545,7 @@ export const api = {
     codex_dir: string;
     claude_dir?: string;
     opencode_dir?: string;
+    cursor_dir?: string;
     out_dir: string;
     ids: string[];
     targets?: BundleExportTarget[];
@@ -1449,6 +1557,7 @@ export const api = {
       codexDir: p.codex_dir,
       claudeDir: p.claude_dir,
       opencodeDir: p.opencode_dir,
+      cursorDir: p.cursor_dir,
       outDir: p.out_dir,
       ids: p.ids,
       targets: p.targets,
@@ -1460,6 +1569,7 @@ export const api = {
     codex_dir: string;
     claude_dir?: string;
     opencode_dir?: string;
+    cursor_dir?: string;
     out_dir: string;
     machine_label?: string;
     export_group?: string;
@@ -1470,6 +1580,7 @@ export const api = {
       codexDir: p.codex_dir,
       claudeDir: p.claude_dir,
       opencodeDir: p.opencode_dir,
+      cursorDir: p.cursor_dir,
       outDir: p.out_dir,
       machineLabel: p.machine_label,
       exportGroup: p.export_group,
@@ -1485,6 +1596,7 @@ export const api = {
     codex_dir: string;
     claude_dir?: string;
     opencode_dir?: string;
+    cursor_dir?: string;
     mode: ImportMode;
     make_visible: boolean;
     strict: boolean;
@@ -1496,6 +1608,7 @@ export const api = {
       codexDir: p.codex_dir,
       claudeDir: p.claude_dir,
       opencodeDir: p.opencode_dir,
+      cursorDir: p.cursor_dir,
       mode: p.mode,
       makeVisible: p.make_visible,
       strict: p.strict,

--- a/src/lib/providerTheme.ts
+++ b/src/lib/providerTheme.ts
@@ -13,6 +13,7 @@ const LABELS: Record<SessionProvider, string> = {
   codex: "Codex",
   claude: "Claude",
   opencode: "OpenCode",
+  cursor: "Cursor",
 };
 
 /** 把 provider 标识转成界面文案；未知取值原样返回，便于排查后端新增来源。 */
@@ -26,6 +27,7 @@ export const accentDot: Record<AccentKey, string> = {
   codex: "bg-provider-codex",
   claude: "bg-provider-claude",
   opencode: "bg-provider-opencode",
+  cursor: "bg-provider-cursor",
   global: "bg-foreground/60",
 };
 
@@ -34,6 +36,7 @@ export const accentBar: Record<AccentKey, string> = {
   codex: "bg-provider-codex/90",
   claude: "bg-provider-claude/90",
   opencode: "bg-provider-opencode/90",
+  cursor: "bg-provider-cursor/90",
   global: "bg-foreground/70",
 };
 
@@ -42,6 +45,7 @@ export const accentActiveBar: Record<AccentKey, string> = {
   codex: "bg-provider-codex shadow-[0_0_10px_-1px_hsl(var(--provider-codex)/0.55)]",
   claude: "bg-provider-claude shadow-[0_0_10px_-1px_hsl(var(--provider-claude)/0.55)]",
   opencode: "bg-provider-opencode shadow-[0_0_10px_-1px_hsl(var(--provider-opencode)/0.5)]",
+  cursor: "bg-provider-cursor shadow-[0_0_10px_-1px_hsl(var(--provider-cursor)/0.5)]",
   global: "bg-foreground/80",
 };
 
@@ -50,6 +54,7 @@ export const accentActiveIcon: Record<AccentKey, string> = {
   codex: "text-provider-codex-fg",
   claude: "text-provider-claude-fg",
   opencode: "text-provider-opencode-fg",
+  cursor: "text-provider-cursor-fg",
   global: "text-foreground",
 };
 
@@ -58,6 +63,7 @@ export const accentActiveTint: Record<AccentKey, string> = {
   codex: "bg-provider-codex/10 ring-1 ring-inset ring-provider-codex/20",
   claude: "bg-provider-claude/10 ring-1 ring-inset ring-provider-claude/20",
   opencode: "bg-provider-opencode/10 ring-1 ring-inset ring-provider-opencode/20",
+  cursor: "bg-provider-cursor/10 ring-1 ring-inset ring-provider-cursor/20",
   global: "bg-sidebar-accent ring-1 ring-inset ring-border/60",
 };
 
@@ -66,6 +72,7 @@ export const accentMark: Record<SessionProvider, string> = {
   codex: "bg-provider-codex/10 text-provider-codex-fg ring-1 ring-inset ring-provider-codex/25",
   claude: "bg-provider-claude/10 text-provider-claude-fg ring-1 ring-inset ring-provider-claude/25",
   opencode: "bg-provider-opencode/10 text-provider-opencode-fg ring-1 ring-inset ring-provider-opencode/25",
+  cursor: "bg-provider-cursor/10 text-provider-cursor-fg ring-1 ring-inset ring-provider-cursor/25",
 };
 
 /** 会话卡片上的 provider 徽章。 */
@@ -73,6 +80,7 @@ export const accentBadge: Record<SessionProvider, string> = {
   codex: "border-provider-codex/35 bg-provider-codex/10 text-provider-codex-fg",
   claude: "border-provider-claude/40 bg-provider-claude/10 text-provider-claude-fg",
   opencode: "border-provider-opencode/35 bg-provider-opencode/10 text-provider-opencode-fg",
+  cursor: "border-provider-cursor/35 bg-provider-cursor/10 text-provider-cursor-fg",
 };
 
 /** 列表项选中态：与会话卡片一致的"左侧色条 + 淡底"写法。 */
@@ -80,6 +88,7 @@ export const accentRow: Record<SessionProvider, string> = {
   codex: "border-provider-codex/30 bg-provider-codex/[0.07] before:bg-provider-codex",
   claude: "border-provider-claude/30 bg-provider-claude/[0.07] before:bg-provider-claude",
   opencode: "border-provider-opencode/30 bg-provider-opencode/[0.07] before:bg-provider-opencode",
+  cursor: "border-provider-cursor/30 bg-provider-cursor/[0.07] before:bg-provider-cursor",
 };
 
 export function accentBadgeFor(provider: string): { label: string; className: string } {

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -3,7 +3,7 @@ declare global {
     __TAURI_INTERNALS__?: unknown;
     __CC_SESSIONS_WEBUI__?: {
       apiToken?: string;
-      defaultProvider?: "codex" | "claude" | "opencode";
+      defaultProvider?: "codex" | "claude" | "opencode" | "cursor";
     };
   }
 }
@@ -20,7 +20,9 @@ export function webuiApiToken() {
   return window.__CC_SESSIONS_WEBUI__?.apiToken;
 }
 
-export function webuiDefaultProvider(): "codex" | "claude" | "opencode" {
+export function webuiDefaultProvider(): "codex" | "claude" | "opencode" | "cursor" {
   const provider = window.__CC_SESSIONS_WEBUI__?.defaultProvider;
-  return provider === "claude" || provider === "opencode" ? provider : "codex";
+  return provider === "claude" || provider === "opencode" || provider === "cursor"
+    ? provider
+    : "codex";
 }

--- a/src/lib/sessionVisibility.ts
+++ b/src/lib/sessionVisibility.ts
@@ -55,7 +55,8 @@ export function selectSessionsForView(
   options: SessionVisibilityOptions,
 ): SessionSummary[] {
   const isCodex = options.provider === "codex";
-  const supportsArchive = isCodex || options.provider === "opencode";
+  const supportsArchive =
+    isCodex || options.provider === "opencode" || options.provider === "cursor";
   const includeHiddenRecords = options.includeHiddenRecords ?? false;
   const candidates: SessionSummary[] = [];
 

--- a/src/routes/backup-detail.tsx
+++ b/src/routes/backup-detail.tsx
@@ -323,6 +323,7 @@ export default function BackupDetailRoute({ provider = "codex" }: { provider?: S
             codex_dir: settings.codex_dir,
             claude_dir: settings.claude_dir,
             opencode_dir: settings.opencode_dir,
+            cursor_dir: settings.cursor_dir,
             id: restoreTarget.id,
             backup_rollout_relpath: restoreTarget.rollout_relpath,
             overwrite: overwrite === "overwrite",

--- a/src/routes/backups.tsx
+++ b/src/routes/backups.tsx
@@ -160,6 +160,7 @@ export default function BackupsRoute({ provider = "codex" }: { provider?: Sessio
             codex_dir: settings.codex_dir,
             claude_dir: settings.claude_dir,
             opencode_dir: settings.opencode_dir,
+            cursor_dir: settings.cursor_dir,
             overwrite: false,
           });
           const ok = r.filter((x) => x.ok).length;

--- a/src/routes/repair.tsx
+++ b/src/routes/repair.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { DESKTOP_DELETE_RESTART_NOTICE } from "@/lib/desktopRestart";
+import { humanBytes } from "@/lib/format";
 
 import { TopBar } from "@/components/TopBar";
 import { EmptyState } from "@/components/EmptyState";
@@ -61,6 +62,7 @@ import {
 import { useSettings } from "@/stores/settings";
 import {
   api,
+  type CursorResidueReport,
   type ArchiveOriginBackfillReport,
   type DiagnosticReport,
   type FamilyIntegrityReport,
@@ -76,7 +78,9 @@ import {
 import { copyText } from "@/lib/clipboard";
 
 export default function RepairRoute({ provider = "codex" }: { provider?: SessionProvider }) {
-  return provider === "claude" ? <ClaudeRepairRoute /> : <CodexRepairRoute />;
+  if (provider === "claude") return <ClaudeRepairRoute />;
+  if (provider === "cursor") return <CursorRepairRoute />;
+  return <CodexRepairRoute />;
 }
 
 function CodexRepairRoute() {
@@ -1581,6 +1585,324 @@ function ClaudeRepairRoute() {
       </AlertDialog>
     </>
   );
+}
+
+// Cursor 的清理页：Cursor 自己不提供任何维护入口，空会话、孤儿记录会一直留在
+// 那个几 GB 的库里。诊断要整段扫气泡表（实测 9 秒），所以不自动跑，由用户点。
+function CursorRepairRoute() {
+  const settings = useSettings((s) => s.settings);
+  const codexDir = settings?.codex_dir ?? "";
+  const cursorDir = settings?.cursor_dir ?? "";
+  const [report, setReport] = useState<CursorResidueReport | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [running, setRunning] = useState(false);
+  const [compacting, setCompacting] = useState(false);
+  const [selected, setSelected] = useState<Record<string, boolean>>({});
+  /** null = 关闭；"prune" = 只清理；"prune_compact" = 清理后接着压缩。 */
+  const [confirmPrune, setConfirmPrune] = useState<null | "prune" | "prune_compact">(null);
+
+  const diagnose = useCallback(async () => {
+    if (!codexDir) return;
+    setLoading(true);
+    try {
+      const next = await api.diagnoseCursorResidue(codexDir, cursorDir);
+      setReport(next);
+      // 默认只勾非破坏性的那几类，删除有内容的会话必须用户自己点。
+      setSelected(
+        Object.fromEntries(
+          next.groups.map((group) => [group.kind, !group.destructive && hasWork(group)]),
+        ),
+      );
+    } catch (e) {
+      toast.error(`Cursor 残留诊断失败：${String((e as Error)?.message ?? e)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, [codexDir, cursorDir]);
+
+  const busy = running || compacting || loading;
+  const chosen = (report?.groups ?? []).filter((group) => selected[group.kind] && hasWork(group));
+  const chosenDestructive = chosen.some((group) => group.destructive);
+  const chosenSessions = chosen.reduce((sum, group) => sum + group.sessions, 0);
+  const chosenBytes = chosen.reduce((sum, group) => sum + group.bytes, 0);
+
+  // 删除只把页面标成空闲，文件不会变小；VACUUM 才会真正把磁盘还回去。
+  const compact = async () => {
+    setCompacting(true);
+    try {
+      const report = await api.compactCursorDatabase(codexDir, cursorDir);
+      toast.success(
+        report.bytes_reclaimed > 0
+          ? `已回收 ${humanBytes(report.bytes_reclaimed)}（${humanBytes(report.bytes_before)} → ${humanBytes(report.bytes_after)}）`
+          : "数据库已经是紧凑的，没有可回收的空间",
+      );
+      await diagnose();
+    } catch (e) {
+      toast.error(String((e as Error)?.message ?? e));
+    } finally {
+      setCompacting(false);
+    }
+  };
+
+  const prune = async (dryRun: boolean, thenCompact = false) => {
+    setRunning(true);
+    try {
+      const result = await api.pruneCursorResidue({
+        codex_dir: codexDir,
+        cursor_dir: cursorDir,
+        kinds: chosen.map((group) => group.kind),
+        dry_run: dryRun,
+      });
+      const summary = `${result.removed_header_rows} 个会话、${result.removed_kv_rows} 行记录，约 ${humanBytes(result.freed_bytes)}`;
+      if (result.blob_scan_errors > 0) {
+        toast.warning(`「无引用的内容块」已跳过`, {
+          description: `有 ${result.blob_scan_errors} 行读不出来，无法确认剩下的内容块是否还被引用，为避免误删这一类整体没动。`,
+        });
+      }
+      if (dryRun) {
+        toast.success(`预览：将清理 ${summary}`);
+        return;
+      }
+      if (thenCompact) {
+        toast.success(`已清理 ${summary}，正在压缩数据库…`);
+      } else {
+        toast.success(`已清理 ${summary}`, {
+          description: "磁盘占用需要点下方「压缩数据库」才会真正回落。",
+        });
+      }
+      // 压缩自己会重新诊断，不必重复跑一次几秒的扫描。
+      if (thenCompact) {
+        await compact();
+      } else {
+        await diagnose();
+      }
+    } catch (e) {
+      toast.error(String((e as Error)?.message ?? e));
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <>
+      <TopBar title="Cursor 清理" />
+      <ScrollArea className="flex-1">
+        <div className="mx-auto min-w-0 max-w-5xl space-y-4 p-4">
+          <Card className="min-w-0 overflow-hidden">
+            <CardHeader className="pb-3">
+              <CardTitle className="flex min-w-0 flex-wrap items-center gap-2 text-base">
+                <Database className="h-4 w-4 shrink-0" />
+                Cursor 数据库残留
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="min-w-0 space-y-3">
+              <div className="text-xs text-muted-foreground">
+                Cursor 删除会话时留下的检查点、代码差异、文件快照都还在库里，从不回收。
+                这里可以把它们真正清掉。诊断要做一次全库可达性扫描，6 GB 的库上约半分钟。
+              </div>
+              {report && (
+                <div className="grid min-w-0 gap-2 sm:grid-cols-3">
+                  <Stat label="会话头总数" value={report.header_rows} />
+                  <Stat label="列表可见会话" value={report.visible_sessions} />
+                  <Stat label="数据库大小" value={humanBytes(report.database_bytes)} />
+                </div>
+              )}
+              <div className="flex flex-wrap items-center gap-2">
+                <Button size="sm" onClick={() => void diagnose()} disabled={busy}>
+                  {loading ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Wrench className="mr-1.5 h-3.5 w-3.5" />
+                  )}
+                  {report ? "重新诊断" : "开始诊断"}
+                </Button>
+                {report && (
+                  <span className="text-xs text-muted-foreground [overflow-wrap:anywhere]">
+                    <code>{report.database_path}</code>
+                  </span>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {!report && !loading && (
+            <EmptyState
+              title="尚未诊断"
+              description="点击「开始诊断」扫描 Cursor 数据库中的残留数据"
+            />
+          )}
+
+          {report?.groups.map((group) => (
+            <Card key={group.kind} className="min-w-0 overflow-hidden">
+              <CardHeader className="pb-3">
+                <CardTitle className="flex min-w-0 flex-wrap items-center gap-2 text-base">
+                  {group.destructive ? (
+                    <ShieldAlert className="h-4 w-4 shrink-0 text-amber-600" />
+                  ) : (
+                    <Eraser className="h-4 w-4 shrink-0" />
+                  )}
+                  {group.label}
+                  <Badge variant={hasWork(group) ? "outline" : "secondary"} className="text-[10px]">
+                    {group.sessions > 0 ? `${group.sessions} 个会话` : `${group.rows} 行记录`}
+                  </Badge>
+                  {group.destructive && (
+                    <Badge variant="outline" className="border-amber-500/40 text-[10px] text-amber-600">
+                      会丢失对话
+                    </Badge>
+                  )}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="min-w-0 space-y-3">
+                <div className="text-xs text-muted-foreground">{group.description}</div>
+                <div className="grid min-w-0 gap-2 sm:grid-cols-3">
+                  <Stat label="会话数" value={group.sessions} warn={group.sessions > 0} />
+                  <Stat label="记录行数" value={group.rows} warn={group.rows > 0} />
+                  <Stat
+                    label="占用"
+                    value={group.bytes > 0 ? humanBytes(group.bytes) : "—"}
+                    hint={group.bytes > 0 ? undefined : "这一类只删会话头，占用会在清理时统计"}
+                  />
+                </div>
+                {group.samples.length > 0 && (
+                  <div className="min-w-0 space-y-1 rounded-md bg-muted/30 p-3 text-xs">
+                    <div className="text-muted-foreground">样例：</div>
+                    {group.samples.map((sample) => (
+                      <div key={sample.id} className="min-w-0 [overflow-wrap:anywhere]">
+                        <code className="text-[11px]">{sample.id.slice(0, 8)}</code>{" "}
+                        <span className="text-foreground">{sample.title}</span>
+                        {sample.bubbles > 0 && (
+                          <span className="text-muted-foreground"> · {sample.bubbles} 条消息</span>
+                        )}
+                        {sample.cwd && <span className="text-muted-foreground"> · {sample.cwd}</span>}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div className="flex items-center gap-2 rounded-md border bg-muted/20 px-2.5 py-1">
+                  <Switch
+                    id={`cursor-residue-${group.kind}`}
+                    checked={!!selected[group.kind]}
+                    disabled={busy || !hasWork(group)}
+                    onCheckedChange={(v) =>
+                      setSelected((prev) => ({ ...prev, [group.kind]: v }))
+                    }
+                  />
+                  <Label htmlFor={`cursor-residue-${group.kind}`} className="text-xs">
+                    纳入清理
+                  </Label>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+
+          {report && (
+            <Card className="min-w-0 overflow-hidden">
+              <CardContent className="min-w-0 space-y-3 pt-6">
+                <div className="text-xs text-muted-foreground">
+                  清理和压缩都需要先完全退出 Cursor，否则会被拒绝。清理只把库内页面标成空闲，
+                  文件不会变小；<b>压缩数据库</b>才会把磁盘还回去，几 GB 的库可能要几分钟。
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void prune(true)}
+                    disabled={busy || chosen.length === 0}
+                  >
+                    效果预览
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => setConfirmPrune("prune")}
+                    disabled={busy || chosen.length === 0}
+                    className="gap-1.5"
+                  >
+                    {running ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-3.5 w-3.5" />
+                    )}
+                    清理已选（约 {humanBytes(chosenBytes)}）
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => setConfirmPrune("prune_compact")}
+                    disabled={busy || chosen.length === 0}
+                    className="gap-1.5"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                    清理并压缩数据库
+                  </Button>
+                  <Separator orientation="vertical" className="h-6" />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => void compact()}
+                    disabled={busy}
+                    className="gap-1.5"
+                  >
+                    {compacting ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <Database className="h-3.5 w-3.5" />
+                    )}
+                    {compacting ? "压缩中…" : "压缩数据库"}
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </ScrollArea>
+
+      <AlertDialog
+        open={confirmPrune !== null}
+        onOpenChange={(open) => !open && setConfirmPrune(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {confirmPrune === "prune_compact" ? "清理并压缩数据库" : "清理 Cursor 残留"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              即将清理 <b>{chosen.map((group) => group.label).join("、")}</b>，
+              涉及 {chosenSessions} 个会话、{chosen.reduce((sum, group) => sum + group.rows, 0)} 行记录，
+              约 <b>{humanBytes(chosenBytes)}</b>。此操作不可撤销。
+              {chosenDestructive && (
+                <>
+                  {" "}
+                  其中<b>「项目目录已不存在」包含完整对话内容</b>，删除后这些对话将永久丢失。
+                </>
+              )}
+              {confirmPrune === "prune_compact" && (
+                <> 清理完成后会立刻压缩数据库，期间请不要打开 Cursor。</>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => {
+                const thenCompact = confirmPrune === "prune_compact";
+                setConfirmPrune(null);
+                void prune(false, thenCompact);
+              }}
+            >
+              确认清理
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+/// 有些残留按会话计（空会话、孤儿记录），有些只按行计（内容块没有会话归属）。
+function hasWork(group: { sessions: number; rows: number }) {
+  return group.sessions > 0 || group.rows > 0;
 }
 
 function Stat({

--- a/src/routes/sessions.tsx
+++ b/src/routes/sessions.tsx
@@ -86,7 +86,10 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
   const { sessions, allSessions, loading, error, refresh } = useSessions(provider, query);
   const isCodex = provider === "codex";
   const isOpenCode = provider === "opencode";
-  const supportsArchive = isCodex || isOpenCode;
+  const isCursor = provider === "cursor";
+  const supportsArchive = isCodex || isOpenCode || isCursor;
+  // Cursor 的子会话只随父会话管理，没有独立视图。
+  const supportsSubagentView = !isCursor;
   const { index: backupIndex, error: backupIndexError } = useBackupIndex(provider);
   const selected = useSelection((s) => s.selected);
   const setSelection = useSelection((s) => s.set);
@@ -160,11 +163,18 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
     settings?.codex_dir ?? "",
     settings?.claude_dir ?? "",
     settings?.opencode_dir ?? "",
+    settings?.cursor_dir ?? "",
     query,
   ]);
   const overlayScopeRef = useRef(overlayScope);
   const refreshScopeRef = useRef(refreshScope);
   const overlayRequestSeq = useRef(0);
+
+  useEffect(() => {
+    if (!supportsSubagentView && showSubagentSessions) {
+      setSubagentView(false);
+    }
+  }, [setSubagentView, showSubagentSessions, supportsSubagentView]);
 
   // 两种视图互斥；同时为 true 只可能来自热更新前的旧状态。
   useEffect(() => {
@@ -530,7 +540,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
 
   const onCopyResume = useCallback(async (s: SessionSummary) => {
     try {
-      const text = await api.copyResumeCommand(s.provider, s.id, s.cwd);
+      const text = await api.copyResumeCommand(s.provider, s.id, s.cwd, s.resume_command);
       toast.success("已复制：" + text);
     } catch (e: any) {
       toast.error("复制失败：" + String(e?.message ?? e));
@@ -554,6 +564,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
         s.id,
         !s.archived,
         settings.opencode_dir,
+        settings.cursor_dir,
       );
       toast.success(s.archived ? "已取消归档" : "已归档");
       await refreshAll();
@@ -657,25 +668,28 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
                 <DropdownMenuSeparator />
               </>
             )}
-            <DropdownMenuCheckboxItem
-              checked={showSubagentSessions}
-              onCheckedChange={(checked) => setSubagentView(checked === true)}
-              className="gap-1.5 px-2 [&>span:first-child]:hidden"
-            >
-              <Network className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="whitespace-nowrap">{isOpenCode ? "子会话" : "子代理"}</span>
-              <span
-                aria-hidden="true"
-                data-state={showSubagentSessions ? "checked" : "unchecked"}
-                className="ml-auto inline-flex h-3.5 w-6 shrink-0 items-center rounded-full bg-input p-0.5 transition-colors data-[state=checked]:bg-primary"
+            {/* Cursor 的子会话记在父会话上，只随父会话一起管理，不提供单独视图。 */}
+            {supportsSubagentView && (
+              <DropdownMenuCheckboxItem
+                checked={showSubagentSessions}
+                onCheckedChange={(checked) => setSubagentView(checked === true)}
+                className="gap-1.5 px-2 [&>span:first-child]:hidden"
               >
+                <Network className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="whitespace-nowrap">{isOpenCode ? "子会话" : "子代理"}</span>
                 <span
-                  className={`block h-2.5 w-2.5 rounded-full bg-background shadow-sm transition-transform ${
-                    showSubagentSessions ? "translate-x-2.5" : "translate-x-0"
-                  }`}
-                />
-              </span>
-            </DropdownMenuCheckboxItem>
+                  aria-hidden="true"
+                  data-state={showSubagentSessions ? "checked" : "unchecked"}
+                  className="ml-auto inline-flex h-3.5 w-6 shrink-0 items-center rounded-full bg-input p-0.5 transition-colors data-[state=checked]:bg-primary"
+                >
+                  <span
+                    className={`block h-2.5 w-2.5 rounded-full bg-background shadow-sm transition-transform ${
+                      showSubagentSessions ? "translate-x-2.5" : "translate-x-0"
+                    }`}
+                  />
+                </span>
+              </DropdownMenuCheckboxItem>
+            )}
             {supportsArchive && (
               <DropdownMenuCheckboxItem
                 checked={showArchivedSessions}
@@ -818,7 +832,9 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
                   ? "打开 Codex 后会自动出现在此"
                   : provider === "claude"
                     ? "打开 Claude Code 后会自动出现在此"
-                    : "在 OpenCode 中创建会话后会自动出现在此"
+                    : provider === "cursor"
+                      ? "在 Cursor 中创建会话后会自动出现在此"
+                      : "在 OpenCode 中创建会话后会自动出现在此"
             }
             icon={<MessageSquare className="h-10 w-10" />}
           />
@@ -847,7 +863,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
             onExportMarkdown={setExportTarget}
             onConvert={isOpenCode ? undefined : setConvertTarget}
             onRename={setRenameTarget}
-            onMoveCwd={setMoveTarget}
+            onMoveCwd={isCursor ? undefined : setMoveTarget}
             onSetArchiveOrigin={isCodex ? onSetArchiveOrigin : undefined}
           />
         )}
@@ -860,6 +876,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
         codexDir={settings.codex_dir}
         claudeDir={settings.claude_dir}
         opencodeDir={settings.opencode_dir}
+        cursorDir={settings.cursor_dir}
         showSubagentSessions={showSubagentSessions}
         showArchivedSessions={showArchivedSessions}
         rolloutPaths={contentSearchRolloutPaths}
@@ -916,6 +933,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
               codex_dir: settings.codex_dir,
               claude_dir: settings.claude_dir,
               opencode_dir: settings.opencode_dir,
+              cursor_dir: settings.cursor_dir,
               id: renameTarget.id,
               rollout_path: renameTarget.rollout_path,
               title,
@@ -1031,6 +1049,7 @@ export default function SessionsRoute({ provider = "codex" }: { provider?: Sessi
               rollout_path: session.rollout_path,
             })),
             settings.opencode_dir,
+            settings.cursor_dir,
           );
           const okCount = r.filter((x) => x.ok).length;
           const desktopRestartRequired = r.some(
@@ -1158,6 +1177,13 @@ function DeleteSummary({
             history.jsonl 匹配行、tasks/&lt;id&gt; 与 file-history/&lt;id&gt;；仍有同 ID 副本时这些共享数据会保留。
             项目 memory、.claude.json、session-env 和 shell-snapshots 不会被删除。
           </>
+        ) : provider === "cursor" ? (
+          <>
+            将从 Cursor 的 <code>state.vscdb</code> 删除 <b>{targets.length}</b> 个会话的会话头、
+            气泡索引与全部气泡，<b>并连同它们的子会话一起删除</b>，不会触碰项目工作区文件。
+            被其它会话共用的子会话会保留。
+            删除只释放库内页面，磁盘占用需要到「清理」页执行「压缩数据库」才会回收。
+          </>
         ) : (
           <>
             将从 <code>opencode.db</code> 删除 <b>{targets.length}</b> 个会话及其消息、片段和关联记录。
@@ -1169,6 +1195,11 @@ function DeleteSummary({
       {provider === "codex" && (
         <div className="text-amber-600 dark:text-amber-400">
           Codex/ChatGPT Desktop 正在运行时仍会执行删除；{DESKTOP_DELETE_RESTART_NOTICE}
+        </div>
+      )}
+      {provider === "cursor" && (
+        <div className="text-amber-600 dark:text-amber-400">
+          需要先完全退出 Cursor，否则删除会被拒绝——Cursor 运行时会用内存里的旧会话状态覆盖改动。
         </div>
       )}
       {targets.length > 1 && (

--- a/src/routes/transfer.tsx
+++ b/src/routes/transfer.tsx
@@ -74,8 +74,16 @@ export default function TransferRoute({ provider = "codex" }: { provider?: Sessi
   const codexDir = settings?.codex_dir ?? "";
   const claudeDir = settings?.claude_dir ?? "";
   const opencodeDir = settings?.opencode_dir ?? "";
+  const cursorDir = settings?.cursor_dir ?? "";
   const providerName = providerLabel(provider);
-  const providerDir = provider === "codex" ? codexDir : provider === "claude" ? claudeDir : opencodeDir;
+  const providerDir =
+    provider === "codex"
+      ? codexDir
+      : provider === "claude"
+        ? claudeDir
+        : provider === "cursor"
+          ? cursorDir
+          : opencodeDir;
 
   return (
     <>
@@ -103,6 +111,7 @@ export default function TransferRoute({ provider = "codex" }: { provider?: Sessi
                   codexDir={codexDir}
                   claudeDir={claudeDir}
                   opencodeDir={opencodeDir}
+                  cursorDir={cursorDir}
                 />
               </TabsContent>
               <TabsContent value="import">
@@ -111,6 +120,7 @@ export default function TransferRoute({ provider = "codex" }: { provider?: Sessi
                   codexDir={codexDir}
                   claudeDir={claudeDir}
                   opencodeDir={opencodeDir}
+                  cursorDir={cursorDir}
                 />
               </TabsContent>
             </Tabs>
@@ -128,11 +138,13 @@ function ExportPanel({
   codexDir,
   claudeDir,
   opencodeDir,
+  cursorDir,
 }: {
   provider: SessionProvider;
   codexDir: string;
   claudeDir: string;
   opencodeDir: string;
+  cursorDir: string;
 }) {
   const { sessions, loading: loadingSessions } = useSessions(provider, "");
   const [outDir, setOutDir] = useState("");
@@ -276,6 +288,7 @@ function ExportPanel({
       codex_dir: codexDir,
       claude_dir: claudeDir,
       opencode_dir: opencodeDir,
+      cursor_dir: cursorDir,
       out_dir: outDir,
       ids: selected.map((session) => session.id),
       targets: selected.map((session) => ({
@@ -313,6 +326,7 @@ function ExportPanel({
         codex_dir: codexDir,
         claude_dir: claudeDir,
         opencode_dir: opencodeDir,
+        cursor_dir: cursorDir,
         out_dir: outDir,
         machine_label: machineLabel || undefined,
         export_group: exportGroup || undefined,
@@ -674,11 +688,13 @@ function ImportPanel({
   codexDir,
   claudeDir,
   opencodeDir,
+  cursorDir,
 }: {
   provider: SessionProvider;
   codexDir: string;
   claudeDir: string;
   opencodeDir: string;
+  cursorDir: string;
 }) {
   const [srcDir, setSrcDir] = useState("");
   const [items, setItems] = useState<BundleListItem[]>([]);
@@ -846,6 +862,7 @@ function ImportPanel({
         codex_dir: codexDir,
         claude_dir: claudeDir,
         opencode_dir: opencodeDir,
+        cursor_dir: cursorDir,
         mode,
         make_visible: providerAtStart === "codex" ? makeVisible : false,
         strict,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -45,6 +45,8 @@
     --provider-claude-fg: 14 50% 47%;
     --provider-opencode: 217 91% 60%;
     --provider-opencode-fg: 221 83% 53%;
+    --provider-cursor: 265 70% 55%;
+    --provider-cursor-fg: 264 72% 47%;
   }
 
   .dark {
@@ -86,6 +88,8 @@
     --provider-claude-fg: 16 81% 74%;
     --provider-opencode: 217 91% 64%;
     --provider-opencode-fg: 212 96% 78%;
+    --provider-cursor: 265 82% 70%;
+    --provider-cursor-fg: 262 88% 80%;
   }
 }
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -55,6 +55,8 @@ const config: Config = {
           "claude-fg": "hsl(var(--provider-claude-fg) / <alpha-value>)",
           opencode: "hsl(var(--provider-opencode) / <alpha-value>)",
           "opencode-fg": "hsl(var(--provider-opencode-fg) / <alpha-value>)",
+          cursor: "hsl(var(--provider-cursor) / <alpha-value>)",
+          "cursor-fg": "hsl(var(--provider-cursor-fg) / <alpha-value>)",
         },
         sidebar: {
           DEFAULT: "hsl(var(--sidebar-background))",


### PR DESCRIPTION
把 Cursor 接成第四个 provider，并支持 Cursor → Claude / Codex 的会话迁移。

## 数据源

| 来源 | 位置 | 说明 |
|---|---|---|
| IDE Composer | `<globalStorage>/state.vscdb` | `composerHeaders`（权威会话列表）+ `cursorDiskKV` |
| cursor-agent | `~/.cursor/chats/<md5(cwd)>/<agentId>/store.db` | root blob 是 protobuf，只用一个最小 varint 扫描器取 field 1 的有序子 blob 列表 |

没有接 `~/.cursor/projects/*/agent-transcripts`：实测 200 个会话里**独有 0 个**，且格式严格更差（只有 `text` 和 `tool_use` 两种 block，没有 tool_result、没有 tool_use id、没有时间戳），接进来只会让同一会话在列表里出现两次。

## 架构

照 OpenCode 的样子铺，**不引入新抽象**——共享 `SessionSummary` / `PreviewEvent` 输出类型，各入口显式 `match provider` 分发。`rollout_path` 沿用 locator 语义：

```
cursor:<base64url(json)>
  {"store":"composer","db":"<state.vscdb 路径>","id":"<composerId>"}
  {"store":"agent","dir":"<chats/<hash>/<agentId>>","id":"<agentId>"}
```

列举只读 `composerHeaders`（837 条实测 12ms），气泡在预览 / 搜索 / 迁移时按需点查。多 MB 的 `composerData` 加了按 `(lastUpdatedAt, length)` 失效的索引缓存，8799 条消息的会话首页从 7.3s 降到 105ms。

## 能力

- 列举 / 项目分组 / 搜索 / 预览 / Markdown 导出 / 统计
- 归档、重命名、删除、备份、bundle 导出导入
- Cursor → Claude / Codex 迁移，复用现有 builder 与四方可补偿事务，不新写 builder

单向：**不往 Cursor 写入会话**。IDE Composer 侧没有 CLI resume，迁过去能续聊，反向不可行。

## 写入安全

- 复用 `desktop_guard` 的三平台进程探测，Cursor 在跑一律拒写——它会把会话状态缓存在内存里，运行期间改库大概率被按旧状态覆盖回去
- 读一次 `composer.composerHeaders.tableGateEnabled`，为 `false` 时拒绝写入并提示版本不兼容
- 不碰 `ItemTable` 里的遗留数组 `composer.composerHeaders`（实测本机它只有 622 条而表里 837 条，新版 Cursor 已不再维护）
- bundle **只导出该会话拥有的行**，绝不整库拷贝——`state.vscdb` 含凭据与全部工作区状态

## 数据库残留清理

Cursor 自己的 `deleteComposer` 只清一部分键空间，内容块则从不回收。实测一个 6.28 GB 的库里 **3.22 GB 属于已删会话**。

**会话级**：照 Cursor 自身删除实现覆盖 8 个键空间（`checkpointId` / `codeBlockDiff` / `bubbleId` / `codeBlockPartialInlineDiffFates` / `composerData` / `ofsContent`，外加它漏掉的 `messageRequestContext` 和 `composerVirtualRowHeights`），删会话时级联；子会话链同时跟 `subagentComposerIds` 和 `subComposerIds`。

**内容寻址**：`agentKv:blob` 与 `composer.content` 做可达性回收。引用藏在 `composerData` / `bubbleId` 的 `conversationState` 字段里——base64 编码的二进制，blob id 以**原始 32 字节**出现，按十六进制搜不到；blob 之间还互相引用（实测 376 万条边），要一路做闭包。

判定策略是**宽松超集**：在字节流里找任何一段等于已知 blob id 的 32 字节窗口，不做协议解析。这是"按 protobuf 字段解析"的严格超集，字段号、嵌套层数、编码方式怎么变都不影响，代价只是可能多留几个块。与 Cursor 一致，遍历中只要出现一次解码失败就整体放弃删除；但只跳过内容块这一类，不会把已经算准的会话级清理一起回滚。

## 验证

在一个 6.28 GB 的真实库上做了清理前后的 **key 全集比对**：

```
removed  = 191543
expected = 191543
误删（删了但不在预测集合里）: 0
漏删（预测该删却还在）      : 0
```

- 重新走一遍引用闭包：剩余内容块 111564 个**全部可达**，悬空引用 0
- 141 个存活会话的气泡数**逐个比对无变化**（总计 131551 条）
- `PRAGMA integrity_check` = ok，库 6.28 GB → 2.95 GB

另外用两套**完全不同的算法**（宽松窗口扫描 vs 严格 protobuf 解析）独立实现同一判定，在真实库上结果完全一致。

## 测试

- 361 → 420，新增 59 个
- 失败集与改动前**完全相同的 30 个**（`bundle` / `claude_transfer` / `app_update`，macOS `/var` 软链导致，与本次改动无关；已在干净 `main` 上跑过确认）
- `cargo fmt --check` / `npm run build` / `npm run test:frontend`(57/0) / `cargo check --all-targets` 均通过

## 未改动

版本号保持 `0.5.11` —— 看历史发版是单独提交，没在功能 PR 里动。
