### PR TITLE
fix(repair): 批量同步跳过分页会话的可见性修复

### DIFF
--- a/src-tauri/src/repair.rs
+++ b/src-tauri/src/repair.rs
@@ -707,6 +707,54 @@ fn scan_active_rollout_identities(codex: &Path) -> AppResult<Vec<(PathBuf, Rollo
     Ok(rollouts)
 }
 
+/// 判断 rollout 文件名是否为分页(paginated)会话的延续文件。
+///
+/// Codex 分页会话在触发分页/续写时会生成形如
+/// `rollout-<ts>-<session_id>_<continuation_id>.jsonl` 的延续文件，它与存根
+/// 文件 `rollout-<ts>-<session_id>.jsonl` 携带**同一个 session id**。
+/// 两者同时存在时，索引类重建必须指向延续文件，否则会话只剩存根内容。
+fn rollout_filename_is_paginated_continuation(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let Some(stem) = name.strip_suffix(".jsonl") else {
+        return false;
+    };
+    // 存根: rollout-<ts>-<session_id>.jsonl；延续: rollout-<ts>-<session_id>_<continuation_id>.jsonl
+    // 时间戳与 uuid 均不含下划线，stem 中出现 '_' 即为延续文件。
+    stem.strip_prefix("rollout-")
+        .is_some_and(|rest| rest.contains('_'))
+}
+
+/// 同 id 的存根/延续文件二选一：延续文件优先；同为延续或同为存根时 updated_at 新者胜。
+///
+/// chosen 的 value 为 (payload, updated_at_ms, is_continuation)，payload 携带
+/// 额外的分类标记（如是否来自有效 session_meta），延续文件优先时一并带过去。
+fn prefer_continuation_entry<K, V>(
+    chosen: &mut std::collections::BTreeMap<K, ((V, bool), i64, bool)>,
+    id: K,
+    payload: (V, bool),
+    updated_at_ms: i64,
+    path: &Path,
+) where
+    K: Ord,
+{
+    let is_continuation = rollout_filename_is_paginated_continuation(path);
+    let replace = match chosen.get(&id) {
+        Some((_, existing_updated, existing_is_continuation)) => {
+            match (is_continuation, *existing_is_continuation) {
+                (true, false) => true,
+                (false, true) => false,
+                _ => updated_at_ms >= *existing_updated,
+            }
+        }
+        None => true,
+    };
+    if replace {
+        chosen.insert(id, (payload, updated_at_ms, is_continuation));
+    }
+}
+
 pub(crate) fn read_rollout_brief(codex_dir: &Path, path: &Path) -> AppResult<Option<RolloutBrief>> {
     read_rollout_brief_impl(codex_dir, path, None)
 }
@@ -1178,11 +1226,14 @@ pub fn diagnose_codex_state(codex_dir: String) -> AppResult<DiagnosticReport> {
 pub fn repair_session_index(codex_dir: String, dry_run: bool) -> AppResult<IndexRepairReport> {
     let codex = PathBuf::from(&codex_dir);
     let rollouts = family::scan_rollouts(&codex)?;
+    // 分页会话的存根与延续文件共用同一 id；索引必须指向延续文件且不得重复。
+    // chosen 的 value 为 ((entry, has_meta), updated_at_ms, is_continuation)。
+    let mut chosen: std::collections::BTreeMap<String, ((Value, bool), i64, bool)> =
+        std::collections::BTreeMap::new();
     let mut written = 0u32;
     let mut salvaged = 0u32;
     let mut errors: Vec<String> = Vec::new();
 
-    let mut entries: Vec<Value> = Vec::with_capacity(rollouts.len());
     for p in &rollouts {
         match read_rollout_brief(&codex, p) {
             Ok(Some(b)) => {
@@ -1194,13 +1245,19 @@ pub fn repair_session_index(codex_dir: String, dry_run: bool) -> AppResult<Index
                     0
                 };
                 let abs = b.path.to_string_lossy().into_owned();
-                entries.push(serde_json::json!({
+                let entry = serde_json::json!({
                     "id": b.id,
                     "thread_name": b.first_user_message.clone(),
                     "rollout_path": abs,
                     "updated_at": updated,
-                }));
-                written += 1;
+                });
+                prefer_continuation_entry(
+                    &mut chosen,
+                    b.id.clone(),
+                    (entry, true),
+                    updated,
+                    &b.path,
+                );
             }
             Ok(None) => {
                 // 没有 session_meta → 尝试从文件名救援
@@ -1211,13 +1268,13 @@ pub fn repair_session_index(codex_dir: String, dry_run: bool) -> AppResult<Index
                         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
                         .map(|d| d.as_millis() as i64)
                         .unwrap_or(0);
-                    entries.push(serde_json::json!({
+                    let entry = serde_json::json!({
                         "id": id,
                         "thread_name": "",
                         "rollout_path": p.to_string_lossy(),
                         "updated_at": mtime_ms,
-                    }));
-                    salvaged += 1;
+                    });
+                    prefer_continuation_entry(&mut chosen, id, (entry, false), mtime_ms, p);
                 }
             }
             Err(e) => {
@@ -1225,6 +1282,16 @@ pub fn repair_session_index(codex_dir: String, dry_run: bool) -> AppResult<Index
             }
         }
     }
+    let mut entries: Vec<Value> = Vec::with_capacity(chosen.len());
+    for (_, ((entry, has_meta), _, _)) in chosen {
+        if has_meta {
+            written += 1;
+        } else {
+            salvaged += 1;
+        }
+        entries.push(entry);
+    }
+    entries.sort_by(|a, b| a["id"].as_str().unwrap_or("").cmp(b["id"].as_str().unwrap_or("")));
 
     if !dry_run {
         let out_path = paths::session_index_path(&codex);
@@ -2525,6 +2592,9 @@ pub fn rebuild_threads_table(codex_dir: String, dry_run: bool) -> AppResult<Thre
     let state = state_db::open(&codex)?;
     let effective_cols = effective_threads_cols(&state)?;
     let mut planned_upserts = Vec::new();
+    // 分页会话的存根与延续文件共用同一 id；threads 行必须指向延续文件。
+    let mut planned_by_id: std::collections::BTreeMap<String, ((Vec<Value>, bool), i64, bool)> =
+        std::collections::BTreeMap::new();
 
     for (p, archived) in active_rollouts
         .iter()
@@ -2534,10 +2604,21 @@ pub fn rebuild_threads_table(codex_dir: String, dry_run: bool) -> AppResult<Thre
         scanned += 1;
         match thread_values_from_rollout(&codex, p, archived, &effective_cols) {
             Ok(Some(values)) => {
-                upserted += 1;
-                if !dry_run {
-                    planned_upserts.push(values);
-                }
+                let id = values
+                    .first()
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string();
+                let updated_at_ms = read_rollout_brief(&codex, p)?
+                    .map(|b| if b.updated_at_ms > 0 { b.updated_at_ms } else { b.created_at_ms })
+                    .unwrap_or(0);
+                prefer_continuation_entry(
+                    &mut planned_by_id,
+                    id,
+                    (values, true),
+                    updated_at_ms,
+                    p,
+                );
             }
             Ok(None) => skipped += 1,
             Err(e) => {
@@ -2548,12 +2629,19 @@ pub fn rebuild_threads_table(codex_dir: String, dry_run: bool) -> AppResult<Thre
     }
 
     if !dry_run {
+        planned_upserts = planned_by_id
+            .into_values()
+            .map(|((values, _), _, _)| values)
+            .collect();
+        upserted = planned_upserts.len() as u32;
         let transaction =
             rusqlite::Transaction::new_unchecked(&state, rusqlite::TransactionBehavior::Immediate)?;
         for values in &planned_upserts {
             upsert_thread_values(&transaction, &effective_cols, values)?;
         }
         transaction.commit()?;
+    } else {
+        upserted = planned_by_id.len() as u32;
     }
 
     Ok(ThreadsRebuildReport {
@@ -4816,6 +4904,12 @@ fn clone_session_for_provider_locked_with_hint(
     if src_brief.history_mode == "paginated" && matches!(&strategy, SwitchStrategy::Continuous) {
         return Err(AppError::Other(
             "分页会话不支持连续模式；请选择散点模式（scatter），通过 Codex 官方派生保留完整历史，可在 Codex App 运行时执行"
+                .into(),
+        ));
+    }
+    if src_brief.history_mode == "paginated" && matches!(&strategy, SwitchStrategy::Follow) {
+        return Err(AppError::Other(
+            "分页会话不支持跟随（follow）模式：就地改写只会命中存根或延续文件之一，且会按单文件回写 threads 索引；请选择散点模式（scatter），通过 Codex 官方派生保留完整历史"
                 .into(),
         ));
     }
@@ -8862,6 +8956,93 @@ mod tests {
         assert_eq!(report.written, 1);
         assert_ne!(fs::read(&index_path)?, b"sentinel-index-bytes\n");
         assert_eq!(fs::read(&global_path)?, global_before);
+        fs::remove_dir_all(&codex).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn repair_index_prefers_paginated_continuation_over_stub() -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-index-paginated-dedup-test");
+        let rollout_dir = codex.join("sessions").join("2026").join("09").join("09");
+        fs::create_dir_all(&rollout_dir)?;
+        let id = "paginated-dedup-source";
+        let continuation_id = "paginated-dedup-cont";
+        let stub = rollout_dir.join(format!("rollout-2026-09-09T10-42-10-{id}.jsonl"));
+        let cont = rollout_dir.join(format!(
+            "rollout-2026-09-09T10-43-17-{id}_{continuation_id}.jsonl"
+        ));
+        let meta_line = |ts: &str| {
+            serde_json::json!({
+                "timestamp": ts,
+                "type": "session_meta",
+                "payload": {
+                    "id": id,
+                    "model_provider": DEFAULT_PROVIDER,
+                    "history_mode": "paginated",
+                    "cwd": r"F:\project\example"
+                }
+            })
+        };
+        let stub_body = serde_json::to_string(&meta_line("2026-09-09T02:42:10Z"))?;
+        let cont_body = serde_json::to_string(&meta_line("2026-09-09T02:43:17Z"))?;
+        fs::write(&stub, format!("{stub_body}\n"))?;
+        fs::write(&cont, format!("{cont_body}\n"))?;
+
+        let report = repair_session_index(codex.to_string_lossy().into_owned(), false)?;
+
+        assert_eq!(report.scanned, 2);
+        assert_eq!(report.written + report.salvaged, 1, "同 id 必须去重");
+        let index_path = paths::session_index_path(&codex);
+        let content = fs::read_to_string(&index_path)?;
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1, "索引只能有一行: {content}");
+        let entry: Value = serde_json::from_str(lines[0])?;
+        assert_eq!(entry["rollout_path"].as_str(), Some(cont.to_str().unwrap()));
+        fs::remove_dir_all(&codex).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn rebuild_threads_prefers_paginated_continuation_over_stub() -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-threads-paginated-dedup-test");
+        let rollout_dir = codex.join("sessions").join("2026").join("09").join("09");
+        fs::create_dir_all(&rollout_dir)?;
+        let id = "threads-paginated-dedup";
+        let continuation_id = "threads-paginated-cont";
+        let stub = rollout_dir.join(format!("rollout-2026-09-09T10-42-10-{id}.jsonl"));
+        let cont = rollout_dir.join(format!(
+            "rollout-2026-09-09T10-43-17-{id}_{continuation_id}.jsonl"
+        ));
+        let meta_line = |ts: &str| {
+            serde_json::json!({
+                "timestamp": ts,
+                "type": "session_meta",
+                "payload": {
+                    "id": id,
+                    "model_provider": DEFAULT_PROVIDER,
+                    "history_mode": "paginated",
+                    "cwd": r"F:\project\example"
+                }
+            })
+        };
+        let stub_body = serde_json::to_string(&meta_line("2026-09-09T02:42:10Z"))?;
+        let cont_body = serde_json::to_string(&meta_line("2026-09-09T02:43:17Z"))?;
+        fs::write(&stub, format!("{stub_body}\n"))?;
+        fs::write(&cont, format!("{cont_body}\n"))?;
+        let state = create_full_state(&codex)?;
+        drop(state);
+
+        let report = rebuild_threads_table(codex.to_string_lossy().into_owned(), false)?;
+
+        assert_eq!(report.scanned, 2);
+        assert_eq!(report.upserted, 1, "同 id 只 upsert 一条");
+        let state = state_db::open_ro(&codex)?;
+        let rollout_path: String = state.query_row(
+            "SELECT rollout_path FROM threads WHERE id = ?1",
+            [id],
+            |row| row.get(0),
+        )?;
+        assert_eq!(rollout_path, cont.to_string_lossy());
         fs::remove_dir_all(&codex).ok();
         Ok(())
     }

--- a/src-tauri/src/repair.rs
+++ b/src-tauri/src/repair.rs
@@ -4645,6 +4645,16 @@ fn clone_session_for_provider_locked_with_hint(
     }
     if let Some(b) = active_branch.as_ref() {
         if b.provider == provider {
+            // 分页会话的 rollout 只是 history_base 链上的存根，完整历史在同目录的
+            // 延续文件（文件名带 _<子会话ID> 后缀）里；threads 表由 Codex App 自己
+            // 维护并指向延续文件。此处按存根 upsert 会把 rollout_path 改回存根、
+            // 回退 updated_at，导致 Codex App 中该会话只剩中断的存根内容。
+            if src_brief.history_mode == "paginated" {
+                report.skipped_reason =
+                    Some("分页会话（paginated）已属于当前 provider，跳过本地索引可见性修复以保留 Codex App 指向延续文件的记录".into());
+                report.ok = true;
+                return Ok(report);
+            }
             if dry_run {
                 report.skipped_reason = Some("dry_run: 将复核并修复本地索引可见性".into());
             } else {
@@ -8012,6 +8022,61 @@ mod tests {
         assert_eq!(thread_after.source, thread_before.source);
         assert_eq!(thread_after.archived, thread_before.archived);
 
+        fs::remove_dir_all(codex).ok();
+        Ok(())
+    }
+
+    #[test]
+    fn provider_visibility_repair_preserves_paginated_thread_rollout_path() -> AppResult<()> {
+        let codex = temp_codex_dir("cc-session-manager-paginated-visibility-test");
+        let session_id = "paginated-visibility";
+        // paginated 会话的 rollout 是 history_base 链上的存根；threads 表由 Codex App
+        // 维护并指向带完整历史的延续文件。构造 threads 表指向延续文件、磁盘扫描
+        // 只能看到存根的 state_drift 场景。
+        let source = prepare_paginated_provider_switch_fixture(&codex, session_id)?;
+        let continuation_rel = format!("sessions/2026/04/24/rollout-{session_id}_continuation.jsonl");
+        let continuation_path = codex.join(&continuation_rel);
+        write_sync_rollout(&continuation_path, session_id, DEFAULT_PROVIDER, &[])?;
+        {
+            let state = state_db::open(&codex)?;
+            state.execute(
+                "UPDATE threads SET rollout_path = ? WHERE id = ?",
+                rusqlite::params![continuation_rel, session_id],
+            )?;
+        }
+        let index_before = fs::read(paths::session_index_path(&codex))?;
+        let source_before = fs::read(&source)?;
+        let continuation_before = fs::read(&continuation_path)?;
+        let mut forker = FakeProviderThreadForker::new(codex.clone());
+
+        for dry_run in [true, false] {
+            let report = clone_session_for_provider_locked_with_hint(
+                codex.to_string_lossy().into_owned(),
+                session_id.to_string(),
+                Some("custom".to_string()),
+                SwitchStrategy::Continuous,
+                dry_run,
+                Some(&source),
+                &mut forker,
+            )?;
+
+            assert!(report.ok);
+            assert!(report.skipped_reason.is_some_and(|reason| reason.contains("paginated")));
+            assert_eq!(forker.fork_count, 0);
+            assert_eq!(forker.delete_count, 0);
+            let thread_after = read_thread_state_map(&codex)?
+                .remove(session_id)
+                .expect("paginated fixture thread state");
+            assert_eq!(
+                thread_after.rollout_path.as_deref(),
+                Some(continuation_rel.as_str()),
+                "visibility repair must not rewrite paginated rollout_path back to the stub"
+            );
+        }
+
+        assert_eq!(fs::read(&source)?, source_before);
+        assert_eq!(fs::read(&continuation_path)?, continuation_before);
+        assert_eq!(fs::read(paths::session_index_path(&codex))?, index_before);
         fs::remove_dir_all(codex).ok();
         Ok(())
     }


### PR DESCRIPTION
## 问题

批量同步到当前服务商时，分页(paginated)会话在 Codex App 中只剩中断的存根内容（1 条 turn，实际历史上千行）。

### 根因（可见性修复分支）

分页会话的 rollout 只是 history_base 链上的存根，完整历史在同目录的延续文件（文件名带 `_<子会话ID>` 后缀）里，threads 表由 Codex App 维护并指向延续文件。

批量同步到当前 provider 时，state_drift 判定会让已属于当前 provider 的会话进入可见性修复分支，`sync_thread_from_rollout` 按扫描到的存根 upsert threads 表，把 rollout_path 改回存根并回退 updated_at。

### 根因（索引/threads 重建，issue #38 症状 2）

存根与延续文件携带**同一个 session id**。`repair_session_index` 和 `rebuild_threads_table` 按扫描顺序逐个 upsert，同 id 时最后写入者赢（walkdir 顺序不确定）——threads 表/索引可能指向存根，导致"修复索引后仍无法查看"。批量同步入口 `list_mismatched_sessions_from_rollouts` 的 BTreeMap 按 id 收路径同样存在最后者赢问题。

## 修复

1. **可见性修复分支**：paginated 会话已属于当前 provider 时跳过本地索引修复，保留 Codex App 指向延续文件的记录
2. **`repair_session_index`**：同 id 去重，延续文件优先，session_index.jsonl 同 id 只保留一行
3. **`rebuild_threads_table`**：同 id 去重，延续文件优先，threads 行指向延续文件
4. **Follow 策略**：对 paginated 补上与 Continuous 一致的友好预检拦截（就地改写会命中存根/延续文件之一且按单文件回写索引，不安全）

延续文件判定：文件名 `rollout-<ts>-<id>_<子ID>.jsonl` 中出现下划线（存根的 ts+uuid 均不含下划线）；同为延续/存根时按 updated_at 新者胜。

## 测试

新增回归测试：
- `provider_visibility_repair_preserves_paginated_thread_rollout_path`
- `repair_index_prefers_paginated_continuation_over_stub`
- `rebuild_threads_prefers_paginated_continuation_over_stub`

`cargo test --lib`：paginated 组 14/14、provider 组 17/17、repair 组 94/95（唯一失败为 macOS `/var` symlink 环境问题，基线同样失败）。